### PR TITLE
Portal component

### DIFF
--- a/src/components/Overlay/Overlay.js
+++ b/src/components/Overlay/Overlay.js
@@ -1,33 +1,9 @@
-import React from "react";
-import ReactDOM from "react-dom";
 import styled from "styled-components";
 import { prop } from "styled-tools";
 import as from "../../enhancers/as";
 import Hidden from "../Hidden";
 
-class Component extends React.Component {
-  state = {};
-
-  componentDidMount() {
-    const wrapper = document.createElement("div");
-    document.body.appendChild(wrapper);
-    this.setState({ wrapper });
-  }
-
-  componentWillUnmount() {
-    document.body.removeChild(this.state.wrapper);
-  }
-
-  render() {
-    const { wrapper } = this.state;
-    if (wrapper) {
-      return ReactDOM.createPortal(<Hidden {...this.props} />, wrapper);
-    }
-    return null;
-  }
-}
-
-const Overlay = styled(Component)`
+const Overlay = styled(Hidden)`
   position: fixed;
   background-color: white;
   left: 50%;

--- a/src/components/Overlay/Overlay.md
+++ b/src/components/Overlay/Overlay.md
@@ -1,17 +1,31 @@
+`Overlay` is by default fixed on the middle of the screen.
+
 ```jsx
 const { Block, Button, Backdrop } = require('reakit');
 
-const Example = () => (
-  <Overlay.Container>
-    {overlay => (
-      <Block>
-        <Button as={Overlay.Show} {...overlay}>Click me</Button>
-        <Backdrop fade as={Overlay.Hide} {...overlay} />
-        <Overlay fade slide {...overlay}>Overlay</Overlay>
-      </Block>
-    )}
-  </Overlay.Container>
-);
+<Overlay.Container>
+  {overlay => (
+    <Block>
+      <Button as={Overlay.Show} {...overlay}>Click me</Button>
+      <Backdrop fade as={Overlay.Hide} {...overlay} />
+      <Overlay fade slide {...overlay}>Overlay</Overlay>
+    </Block>
+  )}
+</Overlay.Container>
+```
 
-<Example />
+This is usually combined with [Portal](/components/portal) so it can be dettached from the DOM hierarchy:
+
+```jsx
+const { Block, Button, Backdrop, Portal } = require('reakit');
+
+<Overlay.Container>
+  {overlay => (
+    <Block>
+      <Button as={Overlay.Show} {...overlay}>Click me</Button>
+      <Backdrop as={[Portal, Overlay.Hide]} {...overlay} />
+      <Overlay as={Portal} {...overlay}>Overlay</Overlay>
+    </Block>
+  )}
+</Overlay.Container>
 ```

--- a/src/components/Portal/Portal.js
+++ b/src/components/Portal/Portal.js
@@ -1,0 +1,34 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import styled from "styled-components";
+import { prop } from "styled-tools";
+import as from "../../enhancers/as";
+import Base from "../Base";
+
+class Component extends React.Component {
+  state = {};
+
+  componentDidMount() {
+    const wrapper = document.createElement("div");
+    document.body.appendChild(wrapper);
+    this.setState({ wrapper });
+  }
+
+  componentWillUnmount() {
+    document.body.removeChild(this.state.wrapper);
+  }
+
+  render() {
+    const { wrapper } = this.state;
+    if (wrapper) {
+      return ReactDOM.createPortal(<Base {...this.props} />, wrapper);
+    }
+    return null;
+  }
+}
+
+const Portal = styled(Component)`
+  ${prop("theme.Portal")};
+`;
+
+export default as("div")(Portal);

--- a/src/components/Portal/Portal.md
+++ b/src/components/Portal/Portal.md
@@ -1,0 +1,25 @@
+`Portal` is built upon [React Portals](https://reactjs.org/docs/portals.html) and can be used alone or in combination with other components to dettach the element from the current DOM hierarchy and put it in a new `<div>`, which will be appended to `<body>`.
+
+```jsx
+<Portal textAlign="center">
+  I'm on the bottom of the page
+</Portal>
+```
+
+[Overlays](/components/overlay) and [Backdrops](/components/backdrop) are good candidates to using portals. 
+
+In the example below, while **not** a good example of usage, you can understand most of what you should expect when using portals alone or combined with other components. If you click on `Backdrop` or `Overlay`, you can see that, even though they aren't children of `Button` in the DOM (because of `Portal`), they keep bubbling up events, such as `onClick`, which triggers `Overlay.Toggle`.
+
+```jsx
+import { Button, Overlay } from "reakit";
+
+<Overlay.Container>
+  {overlay => (
+    <Button as={Overlay.Toggle} {...overlay}>
+      Open overlay
+      <Backdrop as={Portal} {...overlay} />
+      <Overlay as={Portal} {...overlay}>Overlay</Overlay>
+    </Button>
+  )}
+</Overlay.Container>
+```

--- a/src/components/Portal/index.js
+++ b/src/components/Portal/index.js
@@ -1,0 +1,1 @@
+export default from "./Portal";

--- a/src/components/Sidebar/Sidebar.md
+++ b/src/components/Sidebar/Sidebar.md
@@ -1,10 +1,14 @@
+By default, `Sidebar` is a fixed [Overlay](/components/overlay) that appears on the left side of the screen.
+
 ```jsx
 import { Block, Button, Backdrop } from "reakit";
 
 <Sidebar.Container>
   {sidebar => (
     <Block>
-      <Button as={Sidebar.Show} {...sidebar}>Open left sidebar</Button>
+      <Button as={Sidebar.Show} {...sidebar}>
+        Open sidebar
+      </Button>
       <Backdrop fade as={Sidebar.Hide} {...sidebar} />
       <Sidebar slide {...sidebar}>Sidebar</Sidebar>
     </Block>
@@ -12,15 +16,57 @@ import { Block, Button, Backdrop } from "reakit";
 </Sidebar.Container>
 ```
 
+You can change its position with the `align` prop:
+
 ```jsx
 import { Block, Button, Backdrop } from "reakit";
 
 <Sidebar.Container>
   {sidebar => (
     <Block>
-      <Button as={Sidebar.Show} {...sidebar}>Open right sidebar</Button>
+      <Button as={Sidebar.Show} {...sidebar}>
+        Open right sidebar
+      </Button>
       <Backdrop fade as={Sidebar.Hide} {...sidebar} />
       <Sidebar slide align="right" {...sidebar}>Sidebar</Sidebar>
+    </Block>
+  )}
+</Sidebar.Container>
+```
+
+This is usually combined with [Portal](/components/portal):
+
+```jsx
+import { Block, Button, Backdrop, Portal } from "reakit";
+
+<Sidebar.Container>
+  {sidebar => (
+    <Block>
+      <Button as={Sidebar.Show} {...sidebar}>
+        Open sidebar
+      </Button>
+      <Backdrop as={[Portal, Sidebar.Hide]} {...sidebar} />
+      <Sidebar as={Portal} {...sidebar}>Sidebar</Sidebar>
+    </Block>
+  )}
+</Sidebar.Container>
+```
+
+You can also put it inside another wrapper component tweaking its `position` and `height` css properties:
+
+```jsx
+import { Block, Button, Backdrop } from "reakit";
+
+<Sidebar.Container>
+  {sidebar => (
+    <Block relative overflow="hidden">
+      <Button as={Sidebar.Show} {...sidebar}>
+        Open sidebar
+      </Button>
+      <Backdrop absolute fade as={Sidebar.Hide} {...sidebar} />
+      <Sidebar absolute height="100%" slide {...sidebar}>
+        Sidebar
+      </Sidebar>
     </Block>
   )}
 </Sidebar.Container>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -27,6 +27,7 @@ export Navigation from "./Navigation";
 export Overlay from "./Overlay";
 export Paragraph from "./Paragraph";
 export Popover from "./Popover";
+export Portal from "./Portal";
 export Shadow from "./Shadow";
 export Sidebar from "./Sidebar";
 export Step from "./Step";


### PR DESCRIPTION
This PR introduces a `Portal` component (abstracted from `Overlay`) so it will be easier to create other components with this feature.

It also makes it possible to use `Overlay` and `Sidebar` without being portals (actually, they won't be portals by default), so we can use them within another wrappers.

### BREAKING CHANGES

* `Overlay` and `Sidebar` no longer use React portals by default. Now it should be combined with `Portal` component in order to achieve the same behavior.

  Before:

  ```jsx
  <Overlay />
  <Sidebar />
  ```

  After:

  ```jsx
  <Overlay as={Portal} />
  <Sidebar as={Portal} />
  ```