### PR TITLE
Remove dependency on react-known-props

### DIFF
--- a/packages/reakit/package.json
+++ b/packages/reakit/package.json
@@ -39,7 +39,6 @@
     "hoist-non-react-statics": "^3.0.1",
     "popper.js": "^1.14.4",
     "prop-types": "^15.6.2",
-    "react-known-props": "^2.3.1",
     "styled-components": "^3.4.2",
     "styled-tools": "^1.1.0"
   },

--- a/packages/reakit/src/_utils/__tests__/pickHTMLProps-test.js
+++ b/packages/reakit/src/_utils/__tests__/pickHTMLProps-test.js
@@ -2,7 +2,7 @@ import pickHTMLProps from "../pickHTMLProps";
 
 test("pickHTMLProps", () => {
   expect(
-    pickHTMLProps("div", { "data-foo": true, foo: true, id: "foo" })
+    pickHTMLProps({ "data-foo": true, foo: true, id: "foo" })
   ).toEqual({
     "data-foo": true,
     id: "foo"

--- a/packages/reakit/src/_utils/pickHTMLProps.ts
+++ b/packages/reakit/src/_utils/pickHTMLProps.ts
@@ -1,21 +1,14 @@
-import { getElementProps, getEventProps } from "react-known-props";
+import validAttr from "styled-components/lib/utils/validAttr";
 
-const pickHTMLProps = (tagName: string, props: { [key: string]: any }) => {
-  const allowedProps = [
-    ...getElementProps(tagName, { legacy: true }),
-    ...getEventProps()
-  ];
-
-  const testProp = (prop: string) =>
-    allowedProps.indexOf(prop) >= 0 || /^data-.+/.test(prop);
-
-  return Object.keys(props).reduce(
-    (finalProps, key) => ({
-      ...finalProps,
-      ...(testProp(key) ? { [key]: props[key] } : {})
-    }),
-    {}
-  );
-};
+function pickHTMLProps<P extends object>(props: P): Partial<P> {
+  const filteredProps = {};
+  const keys = Object.keys(props);
+  for (let key of keys) {
+    if (validAttr(key)) {
+      filteredProps[key] = props[key];
+    }
+  }
+  return filteredProps;
+}
 
 export default pickHTMLProps;

--- a/packages/reakit/src/as.tsx
+++ b/packages/reakit/src/as.tsx
@@ -59,7 +59,7 @@ function render({ as: t, ...props }: AllProps): ReactElement<any> | null {
       ...(style ? { style } : {})
     };
     const allProps = {
-      ...pickHTMLProps(T, propsWithStyle),
+      ...pickHTMLProps(propsWithStyle),
       className
     };
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,13 +1,3 @@
-declare module "react-known-props" {
-  export interface Options {
-    legacy: boolean;
-  }
-
-  export function getElementProps(tagName: string, options: Options): string[];
-
-  export function getEventProps(): string[];
-}
-
 declare module "styled-tools";
 
 declare module "constate";

--- a/types/validAttr.d.ts
+++ b/types/validAttr.d.ts
@@ -1,0 +1,3 @@
+declare module "styled-components/lib/utils/validAttr" {
+  export default function(prop: string): boolean;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7707,10 +7707,6 @@ react-is@^16.3.1, react-is@^16.3.2, react-is@^16.4.2:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
 
-react-known-props@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/react-known-props/-/react-known-props-2.3.1.tgz#9daf9a9133590d2e2bb349fd6a20a94622215ff5"
-
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"


### PR DESCRIPTION
Closes #173

This is reusing `validAttr` from `styled-components` as an attempt to reduce bundle size. It can be a little dangerous because it's not public API, but I think we can deal with that.

Possible issue I can think about is `validAttr`'s API being modified or even removed from `styled-components` in a patch or minor release. Actually, [they're planning to get rid of it](https://github.com/styled-components/styled-components/pull/1682) in a future major release, but [it's unlikely to happen so soon](https://github.com/styled-components/styled-components/pull/1682#issuecomment-382915902).

My opinion is that [JSX namespaces](https://github.com/facebook/jsx/issues/81) are the best way to handle it. Until that happens, I think this is a good solution.

cc/ @Andarist @Thomazella