### PR TITLE
feat: Add `shift` and `flip` props to `Popover`

### DIFF
--- a/packages/reakit/src/Popover/Popover.js
+++ b/packages/reakit/src/Popover/Popover.js
@@ -52,16 +52,18 @@ class Component extends React.Component {
   };
 
   getOptions = () => {
-    const { placement } = this.props;
+    const { placement, flip, shift } = this.props;
     const popover = this.getPopover();
     const arrowClassName = `.${PopoverArrow.styledComponentId}`;
     const arrow = popover.querySelector(arrowClassName);
     return {
       placement,
       modifiers: {
+        hide: { enabled: false },
         applyStyle: { enabled: false },
         arrow: { enabled: !!arrow, element: arrow },
-        flip: { padding: 16 },
+        flip: { enabled: flip, padding: 16 },
+        shift: { enabled: shift },
         offset: { offset: `0, ${this.props.gutter}` },
         setState: {
           enabled: true,
@@ -157,6 +159,8 @@ Popover.propTypes = {
     "bottom-end",
     "left-end"
   ]),
+  flip: PropTypes.bool,
+  shift: PropTypes.bool,
   gutter: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   popoverId: PropTypes.string
 };
@@ -165,6 +169,8 @@ Popover.defaultProps = {
   role: "group",
   placement: "bottom",
   hideOnEsc: true,
+  flip: true,
+  shift: true,
   gutter: 12
 };
 

--- a/packages/website/src/components/HeroGitHubButton.js
+++ b/packages/website/src/components/HeroGitHubButton.js
@@ -47,6 +47,7 @@ const HeroGitHubButton = props => (
             <StarsPopover
               visible={stars > 0}
               placement={getPopoverPlacement(width)}
+              flip={false}
             >
               <Popover.Arrow />
               <StarIcon /> {stars}


### PR DESCRIPTION
Added props to enable/disable the shift and flip modifiers of popper.js.