### PR TITLE
fix: TypeScript definition errors

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 dist
 es
 lib
+ts
 coverage
 node_modules

--- a/packages/reakit/package.json
+++ b/packages/reakit/package.json
@@ -20,7 +20,7 @@
     "postcoverage": "opn coverage/lcov-report/index.html",
     "lint": "eslint src scripts --ext js,ts,tsx",
     "build:clean": "rimraf dist es lib ts && node scripts/cleanProxies",
-    "build:ts": "tsc --emitDeclarationOnly --allowJs false",
+    "build:ts": "tsc --emitDeclarationOnly --allowJs false && node scripts/createDefinitions",
     "prebuild": "npm run build:clean && npm run build:ts",
     "build": "rollup -c && node scripts/makeProxies",
     "dev": "styleguidist server",

--- a/packages/reakit/scripts/createDefinitions.js
+++ b/packages/reakit/scripts/createDefinitions.js
@@ -1,0 +1,13 @@
+const { writeFileSync } = require("fs");
+const publicFiles = require("./publicFiles");
+
+const content = `
+declare const _default: any;
+export default _default;
+`.trimLeft();
+
+Object.entries(publicFiles)
+  .filter(([, file]) => /\.js$/.test(file))
+  .forEach(([module]) => {
+    writeFileSync(`ts/${module}.d.ts`, content);
+  });

--- a/packages/reakit/src/Arrow/Arrow.ts
+++ b/packages/reakit/src/Arrow/Arrow.ts
@@ -1,4 +1,4 @@
-import PropTypes from "prop-types";
+import * as PropTypes from "prop-types";
 import { prop } from "styled-tools";
 import styled from "../styled";
 import as from "../as";

--- a/packages/reakit/src/Base/Base.ts
+++ b/packages/reakit/src/Base/Base.ts
@@ -1,5 +1,5 @@
-import React, { ComponentType } from "react";
-import PropTypes from "prop-types";
+import * as React from "react";
+import * as PropTypes from "prop-types";
 import { prop } from "styled-tools";
 import { bool } from "../_utils/styledProps";
 import styled from "../styled";
@@ -14,7 +14,7 @@ const positions = {
 };
 
 type ComponentProps = {
-  as: keyof JSX.IntrinsicElements | ComponentType;
+  as: keyof JSX.IntrinsicElements | React.ComponentType;
 };
 
 const Component = ({ as: T, ...props }: ComponentProps) =>

--- a/packages/reakit/src/as.tsx
+++ b/packages/reakit/src/as.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-import React, { ReactElement, ComponentType, HTMLProps, Ref } from "react";
+import * as React from "react";
 import pickCSSProps from "./_utils/pickCSSProps";
 import parseTag from "./_utils/parseTag";
 import parseClassName from "./_utils/parseClassName";
@@ -14,23 +14,25 @@ export type CSSProperties = {
   [key in keyof typeof CSSProps]?: string | number
 };
 
-export type AllProps<T = any> = Omit<HTMLProps<T>, "as"> &
+export type AllProps<T = any> = Omit<React.HTMLProps<T>, "as"> &
   ReaKitProps<T> &
   CSSProperties;
 
 export type SingleAsProp =
   | keyof JSX.IntrinsicElements
-  | ComponentType<AllProps>;
+  | React.ComponentType<AllProps>;
 
 export type AsProp = SingleAsProp | SingleAsProp[];
 
 export interface ReaKitProps<T = any> {
   as?: AsProp | null;
   nextAs?: SingleAsProp | null;
-  elementRef?: Ref<T>;
+  elementRef?: React.Ref<T>;
 }
 
-export type ReaKitComponent<P extends AllProps = object> = ComponentType<P> & {
+export type ReaKitComponent<P extends AllProps = object> = React.ComponentType<
+  P
+> & {
   asComponents: AsProp;
   as: (asComponents: AsProp) => ReaKitComponent<P>;
 };
@@ -39,7 +41,7 @@ function As({ nextAs, ...props }: AllProps) {
   return render({ ...props, as: nextAs });
 }
 
-function render({ as: t, ...props }: AllProps): ReactElement<any> | null {
+function render({ as: t, ...props }: AllProps): JSX.Element {
   const T = parseTag(t);
 
   if (Array.isArray(T)) {
@@ -83,7 +85,7 @@ function isWrappedWithAs(target: any): target is ReaKitComponent {
 type AllPropsReplaceAs<P extends AllProps> = Omit<P, "as"> & AllProps;
 
 function as(asComponents: AsProp) {
-  return <P extends AllProps>(WrappedComponent: ComponentType<P>) => {
+  return <P extends AllProps>(WrappedComponent: React.ComponentType<P>) => {
     const target = isStyledComponent(WrappedComponent)
       ? WrappedComponent.target
       : WrappedComponent;

--- a/packages/reakit/src/index.ts
+++ b/packages/reakit/src/index.ts
@@ -7,40 +7,73 @@ export * from "./styled";
 
 export { default as Arrow } from "./Arrow";
 export { default as Avatar } from "./Avatar";
+// @ts-ignore
 export { default as Backdrop } from "./Backdrop";
 export { default as Base } from "./Base";
 export { default as Block } from "./Block";
 export { default as Blockquote } from "./Blockquote";
 export { default as Box } from "./Box";
+// @ts-ignore
 export { default as Button } from "./Button";
+// @ts-ignore
 export { default as Card } from "./Card";
+// @ts-ignore
 export { default as Code } from "./Code";
+// @ts-ignore
 export { default as Divider } from "./Divider";
+// @ts-ignore
 export { default as Field } from "./Field";
+// @ts-ignore
 export { default as Fit } from "./Fit";
+// @ts-ignore
 export { default as Flex } from "./Flex";
+// @ts-ignore
 export { default as Grid } from "./Grid";
+// @ts-ignore
 export { default as Group } from "./Group";
+// @ts-ignore
 export { default as Heading } from "./Heading";
+// @ts-ignore
 export { default as Hidden } from "./Hidden";
+// @ts-ignore
 export { default as Image } from "./Image";
+// @ts-ignore
 export { default as Inline } from "./Inline";
+// @ts-ignore
 export { default as InlineBlock } from "./InlineBlock";
+// @ts-ignore
 export { default as InlineFlex } from "./InlineFlex";
+// @ts-ignore
 export { default as Input } from "./Input";
+// @ts-ignore
 export { default as Label } from "./Label";
+// @ts-ignore
 export { default as Link } from "./Link";
+// @ts-ignore
 export { default as List } from "./List";
+// @ts-ignore
 export { default as Navigation } from "./Navigation";
+// @ts-ignore
 export { default as Overlay } from "./Overlay";
+// @ts-ignore
 export { default as Paragraph } from "./Paragraph";
+// @ts-ignore
 export { default as Popover } from "./Popover";
+// @ts-ignore
 export { default as Portal } from "./Portal";
+// @ts-ignore
 export { default as Provider } from "./Provider";
+// @ts-ignore
 export { default as Shadow } from "./Shadow";
+// @ts-ignore
 export { default as Sidebar } from "./Sidebar";
+// @ts-ignore
 export { default as Step } from "./Step";
+// @ts-ignore
 export { default as Table } from "./Table";
+// @ts-ignore
 export { default as Tabs } from "./Tabs";
+// @ts-ignore
 export { default as Toolbar } from "./Toolbar";
+// @ts-ignore
 export { default as Tooltip } from "./Tooltip";

--- a/packages/reakit/test.tsx
+++ b/packages/reakit/test.tsx
@@ -1,10 +1,14 @@
 /* eslint-disable no-unused-expressions */
-import React from "react";
+import * as React from "react";
 import { styled, Base, Arrow } from "./src";
 
+interface Props {
+  foo: string;
+}
+
 {
-  const Test = styled(Base)<{ foo: string }>`
-    color: ${props => props.foo};
+  const Test = styled(Base)<Props>`
+    color: ${(props: Props) => props.foo};
   `;
 
   <Base />;
@@ -13,8 +17,8 @@ import { styled, Base, Arrow } from "./src";
 }
 
 {
-  const Test = styled(Arrow)<{ foo: string }>`
-    color: ${props => props.foo};
+  const Test = styled(Arrow)<Props>`
+    color: ${(props: Props) => props.foo};
   `;
 
   <Arrow />;

--- a/packages/website/src/components/NewsletterForm.tsx
+++ b/packages/website/src/components/NewsletterForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Input, Block, Link, styled } from "reakit";
 import ButtonPrimary from "../elements/ButtonPrimary";
 import ContentWrapper from "../elements/ContentWrapper";
@@ -33,7 +33,7 @@ const Wrapper = styled(ContentWrapper)`
   }
 `;
 
-const NewsletterForm = props => (
+const NewsletterForm = (props: any) => (
   <Wrapper as="form" action={action} method="post" {...props}>
     <Block gridArea="text" fontSize={20} lineHeight={1.5} textAlign="center">
       ReaKit is evolving and big announcements are coming.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,28 +1,16 @@
 {
   "compilerOptions": {
-    "allowJs": true,
-    "checkJs": false,
-    "allowSyntheticDefaultImports": true,
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
     "jsx": "react",
-    "declaration": true,
-    "pretty": true,
     "strict": true,
+    "allowJs": true,
+    "declaration": true,
     "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": false,
     "noImplicitReturns": true,
-    "noImplicitThis": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "esModuleInterop": true,
-    "importHelpers": true,
-    "sourceMap": true,
-    "emitDecoratorMetadata": false,
-    "experimentalDecorators": false,
-    "removeComments": true,
-    "strictNullChecks": true,
     "stripInternal": true
   }
 }


### PR DESCRIPTION
Closes #198

Cleaned up `tsconfig.json` removing redundant properties (`strict` already enables some of them) and most of `false` options were already `false` by default. I tried to leave it as strict as possible so it'll not show errors on users' projects. But since I'm new to this, I may have left something out.

I've added some `// @ts-ignore` on `index.ts` for components that we didn't converted into TS yet. We can gradually remove them as we do it.

And, finally, to fix the `Module not found` issue, there's a `createDefinitions` script that generates empty (`any`) definition files for JS files.