### PR TITLE
fix: Dedupe classNames with identical styles

### DIFF
--- a/packages/reakit/src/__tests__/__snapshots__/as-test.js.snap
+++ b/packages/reakit/src/__tests__/__snapshots__/as-test.js.snap
@@ -44,7 +44,6 @@ exports[`creates component 3`] = `
 
 exports[`creates component by extending another one with styled 1`] = `
 Array [
-  "Styled(Derivative.as(div))",
   "Derivative.as(div)",
   "Derivative",
   "Base.as(span)",
@@ -55,61 +54,56 @@ Array [
 `;
 
 exports[`creates component by extending another one with styled 2`] = `
-<Styled(Derivative.as(div))>
-  <Derivative.as(div)
-    className="as-test__Derivative-cQWxNw gcSFEM"
+<Derivative.as(div)>
+  <Derivative
+    as={[Function]}
+    nextAs={
+      Array [
+        "div",
+      ]
+    }
   >
-    <Derivative
+    <Base.as(span)
       as={[Function]}
-      className="as-test__Derivative-cQWxNw gcSFEM"
+      className="as-test__Derivative-cQWxNw gxwxdP"
       nextAs={
         Array [
           "div",
         ]
       }
     >
-      <Base.as(span)
+      <Base
         as={[Function]}
-        className="as-test__Derivative-cQWxNw gcSFEM as-test__Derivative-cQWxNw gxwxdP"
+        className="as-test__Derivative-cQWxNw gxwxdP"
         nextAs={
           Array [
             "div",
           ]
         }
       >
-        <Base
-          as={[Function]}
-          className="as-test__Derivative-cQWxNw gcSFEM as-test__Derivative-cQWxNw gxwxdP"
+        <As
+          className="as-test__Derivative-cQWxNw gxwxdP"
+          id="Base"
           nextAs={
             Array [
               "div",
             ]
           }
         >
-          <As
-            className="as-test__Derivative-cQWxNw gcSFEM as-test__Derivative-cQWxNw gxwxdP"
+          <div
+            className="as-test__Derivative-cQWxNw gxwxdP"
             id="Base"
-            nextAs={
-              Array [
-                "div",
-              ]
-            }
-          >
-            <div
-              className="as-test__Derivative-cQWxNw gcSFEM gxwxdP"
-              id="Base"
-            />
-          </As>
-        </Base>
-      </Base.as(span)>
-    </Derivative>
-  </Derivative.as(div)>
-</Styled(Derivative.as(div))>
+          />
+        </As>
+      </Base>
+    </Base.as(span)>
+  </Derivative>
+</Derivative.as(div)>
 `;
 
 exports[`creates component by extending another one with styled 3`] = `
 
-<div class="as-test__Derivative-cQWxNw gcSFEM gxwxdP"
+<div class="as-test__Derivative-cQWxNw gxwxdP"
      id="Base"
 >
 </div>

--- a/packages/reakit/src/as.tsx
+++ b/packages/reakit/src/as.tsx
@@ -121,9 +121,9 @@ function as(asComponents: AsProp) {
     EnhancedComponent.displayName = displayName;
 
     if (isStyledComponent(WrappedComponent)) {
-      const StyledComponent = WrappedComponent.withComponent(EnhancedComponent);
+      const StyledComponent = EnhancedComponent as typeof WrappedComponent;
       StyledComponent.styledComponentId = WrappedComponent.styledComponentId;
-      StyledComponent.displayName = `Styled(${displayName})`;
+      StyledComponent.target = EnhancedComponent;
       return defineProperties(StyledComponent);
     }
 


### PR DESCRIPTION
Closes #208

This PR not only removes duplicated styles, but also decreases the number of components generated by not creating another wrapper around the enhanced component.

### Base styles after

![image](https://user-images.githubusercontent.com/3068563/44564467-6ab4ac00-a739-11e8-80f3-ba015e833b02.png)

The whole problem was that `Styled(Base.as(div))` was injecting duplicated (and unnecessary) class names into the enhanced component:

### React tree before

![image](https://user-images.githubusercontent.com/3068563/44564511-b23b3800-a739-11e8-81fb-8f8c76f8f966.png)

### React tree after

![image](https://user-images.githubusercontent.com/3068563/44564522-bff0bd80-a739-11e8-9ee3-a2537a3c3bd7.png)

cc @lomocc
