### PR TITLE
fix(typescript): Stop using csstype for CSS properties

### DIFF
--- a/packages/reakit/src/_utils/getComponentName.ts
+++ b/packages/reakit/src/_utils/getComponentName.ts
@@ -1,7 +1,7 @@
 import { ComponentType } from "react";
 
-function getComponentName<P>(
-  component: ComponentType<P> | keyof JSX.IntrinsicElements
+function getComponentName(
+  component: ComponentType<any> | keyof JSX.IntrinsicElements
 ) {
   if (typeof component === "string") {
     return component;

--- a/packages/reakit/src/_utils/types.ts
+++ b/packages/reakit/src/_utils/types.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { StandardProperties } from "csstype";
+import CSSProps from "./CSSProps";
 
 export type Dictionary<T = any> = { [key: string]: T };
 
@@ -58,6 +58,8 @@ export type InheritedAsProps<T> = WithoutAsProp<
   UnionToIntersection<ComponentToProps<T>>
 >;
 
+export type CSSProperties = { [K in keyof typeof CSSProps]?: string | number };
+
 /**
  * Props of a component enhanced with `as()`
  * @template T The type of the `as` prop
@@ -67,7 +69,7 @@ export type AsProps<T extends AsElement> = {
   nextAs?: T | T[];
   elementRef?: React.Ref<any>;
 } & InheritedAsProps<T> &
-  StandardProperties<string | number> &
+  CSSProperties &
   Omit<React.HTMLProps<any>, "as">;
 
 /**


### PR DESCRIPTION
Closes #245

It was breaking some components. Since those properties weren't picked by `pickCSSProps` they wouldn't be rendered anyway.