### PR TITLE
fix(typescript): Use `getSelector` when interpolating styled components

### DIFF
--- a/packages/reakit/src/Card/Card.ts
+++ b/packages/reakit/src/Card/Card.ts
@@ -1,6 +1,7 @@
 import * as PropTypes from "prop-types";
 import { theme, withProp } from "styled-tools";
 import numberToPx from "../_utils/numberToPx";
+import getSelector from "../_utils/getSelector";
 import styled from "../styled";
 import as from "../as";
 import Box from "../Box";
@@ -13,8 +14,7 @@ export interface CardProps {
 const Card = styled(Box)<CardProps>`
   display: inline-block;
 
-  // @ts-ignore
-  && > *:not(${CardFit}) {
+  && > *:not(${getSelector(CardFit)}) {
     margin: ${withProp("gutter", numberToPx)};
   }
 

--- a/packages/reakit/src/Group/Group.js
+++ b/packages/reakit/src/Group/Group.js
@@ -1,9 +1,12 @@
 import PropTypes from "prop-types";
 import { ifProp, prop, theme, withProp } from "styled-tools";
 import styled, { css } from "../styled";
+import getSelector from "../_utils/getSelector";
 import as from "../as";
 import Box from "../Box";
 import GroupItem from "./GroupItem";
+
+const groupItemSelector = getSelector(GroupItem);
 
 const verticalAt = (pass, fail) =>
   ifProp(
@@ -25,7 +28,7 @@ const Group = styled(Box)`
   ${verticalAt("flex-direction: column")};
 
   > *:not(:first-child):not(:last-child),
-  > *:not(:first-child):not(:last-child) ${GroupItem} {
+  > *:not(:first-child):not(:last-child) ${groupItemSelector} {
     border-radius: 0;
     ${verticalAt(
       css`
@@ -38,7 +41,7 @@ const Group = styled(Box)`
   }
 
   > *:first-child,
-  > *:first-child ${GroupItem} {
+  > *:first-child ${groupItemSelector} {
     border-bottom-right-radius: 0;
     ${verticalAt(
       css`
@@ -49,7 +52,7 @@ const Group = styled(Box)`
   }
 
   > *:last-child,
-  > *:last-child ${GroupItem} {
+  > *:last-child ${groupItemSelector} {
     border-top-left-radius: 0;
     ${verticalAt(
       css`

--- a/packages/reakit/src/Popover/Popover.js
+++ b/packages/reakit/src/Popover/Popover.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import { theme } from "styled-tools";
 import Popper from "popper.js";
 import styled from "../styled";
+import getSelector from "../_utils/getSelector";
 import as from "../as";
 import Hidden from "../Hidden";
 import PopoverArrow from "./PopoverArrow";
@@ -51,8 +52,8 @@ class Component extends React.Component {
   getOptions = () => {
     const { placement, flip, shift } = this.props;
     const popover = this.getPopover();
-    const arrowClassName = `.${PopoverArrow.styledComponentId}`;
-    const arrow = popover.querySelector(arrowClassName);
+    const arrowSelector = getSelector(PopoverArrow);
+    const arrow = popover.querySelector(arrowSelector);
     return {
       placement,
       modifiers: {

--- a/packages/reakit/src/Popover/Popover.js
+++ b/packages/reakit/src/Popover/Popover.js
@@ -52,8 +52,7 @@ class Component extends React.Component {
   getOptions = () => {
     const { placement, flip, shift } = this.props;
     const popover = this.getPopover();
-    const arrowSelector = getSelector(PopoverArrow);
-    const arrow = popover.querySelector(arrowSelector);
+    const arrow = popover.querySelector(getSelector(PopoverArrow));
     return {
       placement,
       modifiers: {

--- a/packages/reakit/src/Toolbar/ToolbarFocusable.js
+++ b/packages/reakit/src/Toolbar/ToolbarFocusable.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import { theme } from "styled-tools";
 import hoistNonReactStatics from "hoist-non-react-statics";
 import callAll from "../_utils/callAll";
+import getSelector from "../_utils/getSelector";
 import styled from "../styled";
 import as from "../as";
 import Box from "../Box";
@@ -63,16 +64,14 @@ class Component extends React.Component {
 
   getToolbar = () => {
     if (typeof this.toolbar === "undefined") {
-      this.toolbar = this.getElement().closest(`.${Toolbar.styledComponentId}`);
+      this.toolbar = this.getElement().closest(getSelector(Toolbar));
     }
     return this.toolbar;
   };
 
   getFocusables = () => {
     if (!this.getToolbar()) return [];
-    return this.getToolbar().querySelectorAll(
-      `.${ToolbarFocusable.styledComponentId}`
-    );
+    return this.getToolbar().querySelectorAll(getSelector(ToolbarFocusable));
   };
 
   getCurrentIndex = focusables => {

--- a/packages/reakit/src/_utils/__tests__/getSelector-test.ts
+++ b/packages/reakit/src/_utils/__tests__/getSelector-test.ts
@@ -1,0 +1,6 @@
+import getSelector from "../getSelector";
+
+test("getClassName", () => {
+  expect(getSelector({})).toBe("");
+  expect(getSelector({ styledComponentId: "foo" })).toBe(".foo");
+});

--- a/packages/reakit/src/_utils/getSelector.ts
+++ b/packages/reakit/src/_utils/getSelector.ts
@@ -1,0 +1,8 @@
+function getSelector(object: any): string {
+  if (object != null && object.styledComponentId) {
+    return `.${object.styledComponentId}`;
+  }
+  return "";
+}
+
+export default getSelector;

--- a/packages/reakit/test.tsx
+++ b/packages/reakit/test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import * as React from "react";
-import { styled, Box, Code } from "./src";
+import { styled, Box, Code, Card } from "./src";
 
 interface Props {
   foo: string;
@@ -16,4 +16,5 @@ interface Props {
   <Test as="div" foo="" absolute />;
   <Code />;
   <Code block />;
+  <Card gutter={8} />;
 }


### PR DESCRIPTION
TypeScript wasn't recognizing this prop because of the `// @ts-ignore` on component selector:
```jsx
<Card gutter={8} />
```