### PR TITLE
feat: Attach `initialState`, `selectors` and `actions` to containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ node_js:
 script:
   - yarn lint
   - yarn type-check
-  - yarn build
   - yarn test --coverage
+  - yarn build
 cache:
   - yarn
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ node_js:
 script:
   - yarn lint
   - yarn type-check
-  - yarn test --coverage
   - yarn build
+  - yarn test --coverage
 cache:
   - yarn
 before_install:

--- a/packages/reakit/src/Hidden/HiddenContainer.tsx
+++ b/packages/reakit/src/Hidden/HiddenContainer.tsx
@@ -35,8 +35,7 @@ const HiddenContainer: ComposableContainer<
 
 // @ts-ignore
 HiddenContainer.propTypes = {
-  initialState: PropTypes.object,
-  actions: PropTypes.objectOf(PropTypes.func)
+  initialState: PropTypes.object
 };
 
 export default Object.assign(HiddenContainer, {

--- a/packages/reakit/src/Hidden/HiddenContainer.tsx
+++ b/packages/reakit/src/Hidden/HiddenContainer.tsx
@@ -12,21 +12,14 @@ export interface HiddenContainerActions {
   toggle: () => void;
 }
 
-export const initialState: HiddenContainerState = { visible: false };
+const initialState: HiddenContainerState = { visible: false };
 
-export const show = () => () => ({ visible: true });
-export const hide = () => () => ({ visible: false });
-export const toggle = () => (state: HiddenContainerState) => ({
-  visible: !state.visible
-});
-
-export const actions: ActionMap<
-  HiddenContainerState,
-  HiddenContainerActions
-> = {
-  show,
-  hide,
-  toggle
+const actions: ActionMap<HiddenContainerState, HiddenContainerActions> = {
+  show: () => ({ visible: true }),
+  hide: () => ({ visible: false }),
+  toggle: () => state => ({
+    visible: !state.visible
+  })
 };
 
 const HiddenContainer: ComposableContainer<
@@ -46,4 +39,7 @@ HiddenContainer.propTypes = {
   actions: PropTypes.objectOf(PropTypes.func)
 };
 
-export default HiddenContainer;
+export default Object.assign(HiddenContainer, {
+  initialState,
+  actions
+});

--- a/packages/reakit/src/Hidden/__tests__/HiddenContainer-test.ts
+++ b/packages/reakit/src/Hidden/__tests__/HiddenContainer-test.ts
@@ -1,18 +1,29 @@
-import { initialState, toggle, show, hide } from "../HiddenContainer";
+import HiddenContainer from "../HiddenContainer";
+import callMeMaybe from "../../_utils/callMeMaybe";
+
+const { initialState, actions: a } = HiddenContainer;
 
 test("initialState", () => {
   expect(initialState).toEqual({ visible: false });
 });
 
 test("toggle", () => {
-  expect(toggle()({ visible: false })).toEqual({ visible: true });
-  expect(toggle()({ visible: true })).toEqual({ visible: false });
+  expect(callMeMaybe(a.toggle(), { visible: false })).toEqual({
+    visible: true
+  });
+  expect(callMeMaybe(a.toggle(), { visible: true })).toEqual({
+    visible: false
+  });
 });
 
 test("show", () => {
-  expect(show()()).toEqual({ visible: true });
+  expect(callMeMaybe(a.show(), initialState)).toEqual({
+    visible: true
+  });
 });
 
 test("hide", () => {
-  expect(hide()()).toEqual({ visible: false });
+  expect(callMeMaybe(a.hide(), initialState)).toEqual({
+    visible: false
+  });
 });

--- a/packages/reakit/src/Step/StepContainer.tsx
+++ b/packages/reakit/src/Step/StepContainer.tsx
@@ -181,8 +181,8 @@ StepContainer.propTypes = {
   initialState: PropTypes.object
 };
 
-export const stepContainerState = initialState;
-export const stepContainerActions = actions;
-export const stepContainerSelectors = selectors;
-
-export default StepContainer;
+export default Object.assign(StepContainer, {
+  initialState,
+  actions,
+  selectors
+});

--- a/packages/reakit/src/Step/__tests__/StepContainer-test.tsx
+++ b/packages/reakit/src/Step/__tests__/StepContainer-test.tsx
@@ -1,9 +1,7 @@
-import {
-  stepContainerState as initialState,
-  stepContainerSelectors as s,
-  stepContainerActions as a
-} from "../StepContainer";
+import StepContainer from "../StepContainer";
 import c from "../../_utils/callMeMaybe";
+
+const { initialState, selectors: s, actions: a } = StepContainer;
 
 const state = (obj?: object) => ({ ...initialState, ...obj });
 


### PR DESCRIPTION
Instead of exporting them separately as `hiddenContainerState`, `hiddenContainerActions` etc., they will be attached to `HiddenContainer`:

```jsx
import { Hidden } from "reakit";

const { show } = Hidde.Container.actions;
```

Besides fixing a bug on the final bundle (for some reason, `rollup`'s `experimentalCodeSplitting` isn't working properly with the current master's approach), it makes the exports more concise.