### PR TITLE
fix: Remove buggy `flexWrap` props on `Flex` component

### DIFF
--- a/packages/reakit/src/Flex/Flex.ts
+++ b/packages/reakit/src/Flex/Flex.ts
@@ -10,19 +10,14 @@ export interface FlexProps extends BoxProps {
   column?: boolean;
   rowReverse?: boolean;
   columnReverse?: boolean;
-  nowrap?: boolean;
-  wrap?: boolean;
-  wrapReverse?: boolean;
 }
 
 const directions = ["row", "column", "rowReverse", "columnReverse"];
-const wraps = ["nowrap", "wrap", "wrapReverse"];
 
 const Flex = styled(Box)<FlexProps>`
   display: flex;
   &&& {
     ${bool("flex-direction", directions)};
-    ${bool("flex-wrap", wraps)};
   }
 
   ${theme("Flex")};
@@ -33,10 +28,7 @@ Flex.propTypes = {
   row: PropTypes.bool,
   column: PropTypes.bool,
   rowReverse: PropTypes.bool,
-  columnReverse: PropTypes.bool,
-  nowrap: PropTypes.bool,
-  wrap: PropTypes.bool,
-  wrapReverse: PropTypes.bool
+  columnReverse: PropTypes.bool
 };
 
 export default as("div")(Flex);


### PR DESCRIPTION
Reported by @jpdesigndev on https://github.com/reakit/reakit/issues/229#issuecomment-427239512

It turns out that `wrap` is an actual HTML prop. We can't have conflicting props like this, so I'm removing it (which is a breaking change, so I'm targeting `next` branch).

The css prop should be used instead:
```jsx
<Flex flexWrap="wrap" />
```