### PR TITLE
fix: add missing imports to examples

### DIFF
--- a/packages/reakit/src/Avatar/Avatar.md
+++ b/packages/reakit/src/Avatar/Avatar.md
@@ -1,8 +1,12 @@
 ```jsx
+import {Avatar} from 'reakit';
+
 <Avatar src="https://placekitten.com/100/100" alt="Kitten" />
 ```
 
 ```jsx
+import {Avatar} from 'reakit';
+
 <Avatar
   src="https://placekitten.com/150/200"
   alt="Kitten"

--- a/packages/reakit/src/Avatar/Avatar.md
+++ b/packages/reakit/src/Avatar/Avatar.md
@@ -1,11 +1,11 @@
 ```jsx
-import {Avatar} from 'reakit';
+import { Avatar } from "reakit";
 
 <Avatar src="https://placekitten.com/100/100" alt="Kitten" />
 ```
 
 ```jsx
-import {Avatar} from 'reakit';
+import { Avatar } from "reakit";
 
 <Avatar
   src="https://placekitten.com/150/200"

--- a/packages/reakit/src/Backdrop/Backdrop.md
+++ b/packages/reakit/src/Backdrop/Backdrop.md
@@ -1,7 +1,7 @@
 `Backdrop` is a [Hidden](../Hidden/Hidden.md) component that sits behind some other component and handles clicks (like a `button`). It can be used to implement a *click outside to close* functionality.
 
 ```jsx
-import { Backdrop, Overlay } from "reakit";
+import { Backdrop, Button, Overlay } from "reakit";
 
 <Overlay.Container>
   {overlay => (

--- a/packages/reakit/src/Block/Block.md
+++ b/packages/reakit/src/Block/Block.md
@@ -1,6 +1,8 @@
 `Block` is [Box](../Box/Box.md) with `display: block`. By default it renders as a `<div>`.
 
 ```jsx
+import {Block} from 'reakit';
+
 <React.Fragment>
   <Block
     width="100px"

--- a/packages/reakit/src/Block/Block.md
+++ b/packages/reakit/src/Block/Block.md
@@ -1,7 +1,7 @@
 `Block` is [Box](../Box/Box.md) with `display: block`. By default it renders as a `<div>`.
 
 ```jsx
-import {Block} from 'reakit';
+import { Block } from "reakit";
 
 <React.Fragment>
   <Block

--- a/packages/reakit/src/Blockquote/Blockquote.md
+++ b/packages/reakit/src/Blockquote/Blockquote.md
@@ -1,7 +1,7 @@
 By default it renders as a `<blockquote>`.
 
 ```jsx
-import { Blackquote } from 'reakit';
+import { Blackquote } from "reakit";
 <div>
   <Blockquote>
     Freedom means the opportunity to be what we never thought we would be.

--- a/packages/reakit/src/Blockquote/Blockquote.md
+++ b/packages/reakit/src/Blockquote/Blockquote.md
@@ -1,6 +1,7 @@
 By default it renders as a `<blockquote>`.
 
 ```jsx
+import { Blackquote } from 'reakit';
 <div>
   <Blockquote>
     Freedom means the opportunity to be what we never thought we would be.

--- a/packages/reakit/src/Box/Box.md
+++ b/packages/reakit/src/Box/Box.md
@@ -1,7 +1,7 @@
 This is the abstract layout component that all other Reakit components are built on top of. By default it renders a `div` tag with basic reset styles.
 
 ```jsx
-import { Box } from 'reakit';
+import { Box } from "reakit";
 
 <Box>Box</Box>
 ```
@@ -9,7 +9,7 @@ import { Box } from 'reakit';
 Any additional css rules can be added as props:
 
 ```jsx
-import { Box } from 'reakit';
+import { Box } from "reakit";
 
 <Box backgroundColor="palevioletred" color="white">Box</Box>
 ```
@@ -17,7 +17,7 @@ import { Box } from 'reakit';
 You can use the `palette` prop to change its colors based on your [theme](../../docs/theming.md) (it has no effect if you're not using a theme):
 
 ```jsx
-import { Box } from 'reakit';
+import { Box } from "reakit";
 
 <React.Fragment>
   <Box palette="primary">Box</Box>
@@ -29,7 +29,7 @@ import { Box } from 'reakit';
 It offers convenience props to control the `position` css property:
 
 ```jsx
-import { Box } from 'reakit';
+import { Box } from "reakit";
 
 <Box relative width={100} height={40}>
   <Box
@@ -46,7 +46,7 @@ import { Box } from 'reakit';
 You can render it [as](../../docs/as.md) any other HTML element or React component:
 
 ```jsx
-import { Box } from 'reakit';
+import { Box } from "reakit";
 
 <Box
   as="a"

--- a/packages/reakit/src/Box/Box.md
+++ b/packages/reakit/src/Box/Box.md
@@ -1,18 +1,24 @@
 This is the abstract layout component that all other Reakit components are built on top of. By default it renders a `div` tag with basic reset styles.
 
 ```jsx
+import { Box } from 'reakit';
+
 <Box>Box</Box>
 ```
 
 Any additional css rules can be added as props:
 
 ```jsx
+import { Box } from 'reakit';
+
 <Box backgroundColor="palevioletred" color="white">Box</Box>
 ```
 
 You can use the `palette` prop to change its colors based on your [theme](../../docs/theming.md) (it has no effect if you're not using a theme):
 
 ```jsx
+import { Box } from 'reakit';
+
 <React.Fragment>
   <Box palette="primary">Box</Box>
   <Box palette="primary" opaque>Box</Box>
@@ -23,6 +29,8 @@ You can use the `palette` prop to change its colors based on your [theme](../../
 It offers convenience props to control the `position` css property:
 
 ```jsx
+import { Box } from 'reakit';
+
 <Box relative width={100} height={40}>
   <Box
     absolute
@@ -38,6 +46,8 @@ It offers convenience props to control the `position` css property:
 You can render it [as](../../docs/as.md) any other HTML element or React component:
 
 ```jsx
+import { Box } from 'reakit';
+
 <Box
   as="a"
   href="https://github.com/reakit/reakit"

--- a/packages/reakit/src/Button/Button.md
+++ b/packages/reakit/src/Button/Button.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Button } from 'reakit';
+import { Button } from "reakit";
 
 <Button>Button</Button>
 ```

--- a/packages/reakit/src/Button/Button.md
+++ b/packages/reakit/src/Button/Button.md
@@ -1,3 +1,5 @@
 ```jsx
+import { Button } from 'reakit';
+
 <Button>Button</Button>
 ```

--- a/packages/reakit/src/Card/Card.md
+++ b/packages/reakit/src/Card/Card.md
@@ -1,7 +1,7 @@
 A Card can be used to serve related information together such as actions, image, text etc.
 
 ```jsx
-import { Heading, Image, Paragraph } from "reakit";
+import { Heading, Image, Paragraph, Card } from "reakit";
 
 <Card>
   <Heading as="h3">Card Heading</Heading>
@@ -17,7 +17,7 @@ import { Heading, Image, Paragraph } from "reakit";
 ```
 
 ```jsx
-const { Grid, Image, Heading, Paragraph } = require("reakit");
+const { Grid, Image, Heading, Paragraph, Card } = require("reakit");
 
 <Grid column autoColumns="minmax(min-content, max-content)" gap={20} alignItems="start">
   <Card>

--- a/packages/reakit/src/Card/CardFit.md
+++ b/packages/reakit/src/Card/CardFit.md
@@ -1,6 +1,8 @@
 You can use `CardFit` to bypass the `gutter` prop on [Card](../Card/Card.md):
 
 ```jsx
+import { Card } from 'reakit';
+
 <Card>
   <div>This has some spacing around</div>
   <Card.Fit>This doesn't</Card.Fit>

--- a/packages/reakit/src/Card/CardFit.md
+++ b/packages/reakit/src/Card/CardFit.md
@@ -1,7 +1,7 @@
 You can use `CardFit` to bypass the `gutter` prop on [Card](../Card/Card.md):
 
 ```jsx
-import { Card } from 'reakit';
+import { Card } from "reakit";
 
 <Card>
   <div>This has some spacing around</div>

--- a/packages/reakit/src/Code/Code.md
+++ b/packages/reakit/src/Code/Code.md
@@ -1,12 +1,16 @@
 Code works in two modes, for inline code and pre-formatted code blocks. Use the `block` prop to change between modes.
 
 ```jsx
+import { Code } from 'reakit';
+
 <Code>Code by itself will be inline</Code>
 ```
 
 Code in block mode.
 
 ```jsx
+import { Code } from 'reakit';
+
 <Code block>
   {`//for example:
 let foo = 99

--- a/packages/reakit/src/Code/Code.md
+++ b/packages/reakit/src/Code/Code.md
@@ -1,7 +1,7 @@
 Code works in two modes, for inline code and pre-formatted code blocks. Use the `block` prop to change between modes.
 
 ```jsx
-import { Code } from 'reakit';
+import { Code } from "reakit";
 
 <Code>Code by itself will be inline</Code>
 ```
@@ -9,7 +9,7 @@ import { Code } from 'reakit';
 Code in block mode.
 
 ```jsx
-import { Code } from 'reakit';
+import { Code } from "reakit";
 
 <Code block>
   {`//for example:

--- a/packages/reakit/src/Divider/Divider.md
+++ b/packages/reakit/src/Divider/Divider.md
@@ -1,7 +1,7 @@
 It serves the same function as HTML's `<hr>`, to separate content. Use prop `vertical` or `horizontal` to toggle Divider's orientation. It defaults to a 1px wide horizontal line.
 
 ```jsx
-import { Divider } from 'reakit';
+import { Divider } from "reakit";
 
 <Divider />
 ```

--- a/packages/reakit/src/Divider/Divider.md
+++ b/packages/reakit/src/Divider/Divider.md
@@ -1,13 +1,15 @@
 It serves the same function as HTML's `<hr>`, to separate content. Use prop `vertical` or `horizontal` to toggle Divider's orientation. It defaults to a 1px wide horizontal line.
 
 ```jsx
+import { Divider } from 'reakit';
+
 <Divider />
 ```
 
 Basic styling via props, with `vertical`.
 
 ```jsx
-import { Flex, Block } from "reakit";
+import { Flex, Block, Divider } from "reakit";
 
 <Flex
   backgroundColor="rgb(85.9%, 54.3%, 30.3%)"

--- a/packages/reakit/src/Field/Field.md
+++ b/packages/reakit/src/Field/Field.md
@@ -1,7 +1,7 @@
 Field is a wrapper optimized for form elements. Specially things that come in pairs, like `<label>` and `<input>`.
 
 ```jsx
-import { Label, Input } from "reakit";
+import { Label, Input, Field } from "reakit";
 
 <Field>
   <Label htmlFor="input1">Username</Label>
@@ -12,7 +12,7 @@ import { Label, Input } from "reakit";
 Field wrapping a Group:
 
 ```jsx
-import { Label, Group, Button, Input } from "reakit";
+import { Label, Group, Button, Input, Field } from "reakit";
 
 <Field>
   <Label htmlFor="input2">Organize</Label>
@@ -27,7 +27,7 @@ import { Label, Group, Button, Input } from "reakit";
 Styled via props:
 
 ```jsx
-import { Label, Input } from "reakit";
+import { Label, Input, Field } from "reakit";
 
 <Field padding={8} backgroundColor="rgb(49.9%, 72.5%, 44.9%)">
   <Label htmlFor="input3">How do you feel looking at green?</Label>

--- a/packages/reakit/src/Flex/Flex.md
+++ b/packages/reakit/src/Flex/Flex.md
@@ -1,7 +1,7 @@
 This component consists of [Box](../Box/Box.md) with `display: flex`. Several flex properties can be passed directly as props for convenience.
 
 ```jsx
-import { Paragraph } from "reakit";
+import { Paragraph, Flex } from "reakit";
 
 <Flex>
   <Paragraph marginRight="1em">

--- a/packages/reakit/src/Grid/Grid.md
+++ b/packages/reakit/src/Grid/Grid.md
@@ -1,7 +1,7 @@
 Grid is [Box](../Box/Box.md) with `display: grid`. It pairs with the Grid.Item component. Both take props to set several `grid-*` related properties.
 
 ```jsx
-import { Grid } from 'reakit';
+import { Grid } from "reakit";
 
 <Grid columns="repeat(2, 1fr)" autoRows="auto" gap="3vw">
   <Grid.Item>

--- a/packages/reakit/src/Grid/Grid.md
+++ b/packages/reakit/src/Grid/Grid.md
@@ -1,6 +1,8 @@
 Grid is [Box](../Box/Box.md) with `display: grid`. It pairs with the Grid.Item component. Both take props to set several `grid-*` related properties.
 
 ```jsx
+import { Grid } from 'reakit';
+
 <Grid columns="repeat(2, 1fr)" autoRows="auto" gap="3vw">
   <Grid.Item>
     Non proident duis cupidatat veniam ea. Lorem esse ullamco do velit voluptate

--- a/packages/reakit/src/Group/Group.md
+++ b/packages/reakit/src/Group/Group.md
@@ -1,7 +1,7 @@
 Group gives visual unity to elements that work together. It **doesn't** add borders, only adjusts `border-radius` of its children.
 
 ```jsx
-import { Button } from "reakit";
+import { Button, Group } from "reakit";
 
 <Group>
   <Button>Ok</Button>
@@ -12,7 +12,7 @@ import { Button } from "reakit";
 Use handy prop `vertical` to group components vertically:
 
 ```jsx
-import { Button } from "reakit";
+import { Button, Group } from "reakit";
 
 <Group vertical>
   <Button maxWidth="20vmin">Up</Button>

--- a/packages/reakit/src/Group/GroupItem.md
+++ b/packages/reakit/src/Group/GroupItem.md
@@ -1,7 +1,7 @@
 Group applies styling to its direct children, but in case the component isn't a direct child, you can use `GroupItem`:
 
 ```jsx
-import { Box, Field, Label, Input, Button } from "reakit";
+import { Box, Field, Label, Input, Button, Group } from "reakit";
 
 <Box relative border={0}>
   <Group vertical>

--- a/packages/reakit/src/Heading/Heading.md
+++ b/packages/reakit/src/Heading/Heading.md
@@ -1,6 +1,8 @@
 A component to be used for all heading weights. By default renders as an `<h1>` element. Use, for example, `as="h2"` to render as another heading element.
 
 ```jsx
+import { Heading } from 'reakit';
+
 <React.Fragment>
   <Heading>Heading level 1</Heading>
   <Heading as="h2">Heading level 2</Heading>

--- a/packages/reakit/src/Heading/Heading.md
+++ b/packages/reakit/src/Heading/Heading.md
@@ -1,7 +1,7 @@
 A component to be used for all heading weights. By default renders as an `<h1>` element. Use, for example, `as="h2"` to render as another heading element.
 
 ```jsx
-import { Heading } from 'reakit';
+import { Heading } from "reakit";
 
 <React.Fragment>
   <Heading>Heading level 1</Heading>

--- a/packages/reakit/src/Hidden/Hidden.md
+++ b/packages/reakit/src/Hidden/Hidden.md
@@ -1,7 +1,7 @@
 `Hidden` is a highly generic yet powerful Reakit component. It simply hides itself away and waits for a `visible` prop to show up.
 
 ```jsx
-import { Hidden } from 'reakit';
+import { Hidden } from "reakit";
 
 <Hidden visible>Hidden</Hidden>
 ```

--- a/packages/reakit/src/Hidden/Hidden.md
+++ b/packages/reakit/src/Hidden/Hidden.md
@@ -1,6 +1,8 @@
 `Hidden` is a highly generic yet powerful Reakit component. It simply hides itself away and waits for a `visible` prop to show up.
 
 ```jsx
+import { Hidden } from 'reakit';
+
 <Hidden visible>Hidden</Hidden>
 ```
 
@@ -11,7 +13,7 @@ You can use [HiddenContainer](HiddenContainer.md) to control its state with ease
 > Unless you're doing something different with state, it's highly recommended to pass the whole state down to components (`{...hidden}` in the example below). If something changes in the library in the future, even breaking changes, you most likely will not need to change your code, since the state details will be encapsulated.
 
 ```jsx
-import { Block, Group, Button } from "reakit";
+import { Block, Group, Button, Hidden } from "reakit";
 
 <Hidden.Container>
   {hidden => (

--- a/packages/reakit/src/Hidden/HiddenContainer.md
+++ b/packages/reakit/src/Hidden/HiddenContainer.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block, Group, Button } from "reakit";
+import { Block, Group, Button, Hidden } from "reakit";
 
 <Hidden.Container>
   {({ visible, show, hide, toggle }) => (

--- a/packages/reakit/src/Hidden/HiddenHide.md
+++ b/packages/reakit/src/Hidden/HiddenHide.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Hidden } from "reakit";
 
 <Hidden.Container initialState={{ visible: true }}>
   {({ visible, hide }) => (

--- a/packages/reakit/src/Hidden/HiddenShow.md
+++ b/packages/reakit/src/Hidden/HiddenShow.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Hidden } from "reakit";
 
 <Hidden.Container>
   {({ visible, show }) => (

--- a/packages/reakit/src/Hidden/HiddenToggle.md
+++ b/packages/reakit/src/Hidden/HiddenToggle.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Hidden } from "reakit";
 
 <Hidden.Container>
   {({ visible, toggle }) => (

--- a/packages/reakit/src/Image/Image.md
+++ b/packages/reakit/src/Image/Image.md
@@ -1,7 +1,7 @@
 The only css applied is `max-width: 100%`, so the component will fit to parent width and will not stretch beyond its own width.
 
 ```jsx
-import { Image } from 'reakit';
+import { Image } from "reakit";
 
 <Image src="https://placekitten.com/350/350" width={350} height={350} />
 ```

--- a/packages/reakit/src/Image/Image.md
+++ b/packages/reakit/src/Image/Image.md
@@ -1,5 +1,7 @@
 The only css applied is `max-width: 100%`, so the component will fit to parent width and will not stretch beyond its own width.
 
 ```jsx
+import { Image } from 'reakit';
+
 <Image src="https://placekitten.com/350/350" width={350} height={350} />
 ```

--- a/packages/reakit/src/Inline/Inline.md
+++ b/packages/reakit/src/Inline/Inline.md
@@ -1,7 +1,7 @@
 `Inline` is [Box](../Box/Box.md) with `display: inline`.
 
 ```jsx
-import { Inline } from 'reakit';
+import { Inline } from "reakit";
 
 <div>
   <Inline>We are </Inline>

--- a/packages/reakit/src/Inline/Inline.md
+++ b/packages/reakit/src/Inline/Inline.md
@@ -1,6 +1,8 @@
 `Inline` is [Box](../Box/Box.md) with `display: inline`.
 
 ```jsx
+import { Inline } from 'reakit';
+
 <div>
   <Inline>We are </Inline>
   <Inline>inline </Inline>

--- a/packages/reakit/src/InlineBlock/InlineBlock.md
+++ b/packages/reakit/src/InlineBlock/InlineBlock.md
@@ -1,6 +1,8 @@
 `InlineBlock` is [Box](../Box/Box.md) with `display: inline-block`.
 
 ```jsx
+import { InlineBlock } from 'reakit';
+
 <div>
   <InlineBlock
     width="100px"

--- a/packages/reakit/src/InlineBlock/InlineBlock.md
+++ b/packages/reakit/src/InlineBlock/InlineBlock.md
@@ -1,7 +1,7 @@
 `InlineBlock` is [Box](../Box/Box.md) with `display: inline-block`.
 
 ```jsx
-import { InlineBlock } from 'reakit';
+import { InlineBlock } from "reakit";
 
 <div>
   <InlineBlock

--- a/packages/reakit/src/InlineFlex/InlineFlex.md
+++ b/packages/reakit/src/InlineFlex/InlineFlex.md
@@ -1,7 +1,7 @@
 `InlineFlex` is [Box](../Box/Box.md) with `display: inline-flex`.
 
 ```jsx
-import { InlineFlex, Block } from 'reakit';
+import { InlineFlex, Block } from "reakit";
 
 <InlineFlex justifyContent="space-evenly" width="100%">
   <Block width="100px" height="100px" backgroundColor="rgb(219, 112, 147)" />

--- a/packages/reakit/src/InlineFlex/InlineFlex.md
+++ b/packages/reakit/src/InlineFlex/InlineFlex.md
@@ -1,6 +1,8 @@
 `InlineFlex` is [Box](../Box/Box.md) with `display: inline-flex`.
 
 ```jsx
+import { InlineFlex, Block } from 'reakit';
+
 <InlineFlex justifyContent="space-evenly" width="100%">
   <Block width="100px" height="100px" backgroundColor="rgb(219, 112, 147)" />
   <Block width="100px" height="100px" backgroundColor="rgb(219, 112, 198)" />

--- a/packages/reakit/src/Input/Input.md
+++ b/packages/reakit/src/Input/Input.md
@@ -1,12 +1,16 @@
 By default renders as an `<input>` of `type="text"`.
 
 ```jsx
+import { Input } from 'reakit';
+
 <Input />
 ```
 
 A `select`:
 
 ```jsx
+import { Input } from 'reakit';
+
 <Input as="select">
   <option>Hi</option>
   <option>Hello</option>
@@ -16,6 +20,8 @@ A `select`:
 `type="checkbox"`:
 
 ```jsx
+import { Input } from 'reakit';
+
 <label>
   <Input type="checkbox" /> Choose any
 </label>
@@ -23,6 +29,8 @@ A `select`:
 
 `type="radio"`:
 ```jsx
+import { Input } from 'reakit';
+
 <label>
   <Input type="radio" /> Choose one
 </label>
@@ -30,5 +38,7 @@ A `select`:
 
 `as="textarea"`:
 ```jsx
+import { Input } from 'reakit';
+
 <Input as="textarea" />
 ```

--- a/packages/reakit/src/Input/Input.md
+++ b/packages/reakit/src/Input/Input.md
@@ -1,7 +1,7 @@
 By default renders as an `<input>` of `type="text"`.
 
 ```jsx
-import { Input } from 'reakit';
+import { Input } from "reakit";
 
 <Input />
 ```
@@ -9,7 +9,7 @@ import { Input } from 'reakit';
 A `select`:
 
 ```jsx
-import { Input } from 'reakit';
+import { Input } from "reakit";
 
 <Input as="select">
   <option>Hi</option>
@@ -20,7 +20,7 @@ import { Input } from 'reakit';
 `type="checkbox"`:
 
 ```jsx
-import { Input } from 'reakit';
+import { Input } from "reakit";
 
 <label>
   <Input type="checkbox" /> Choose any
@@ -29,7 +29,7 @@ import { Input } from 'reakit';
 
 `type="radio"`:
 ```jsx
-import { Input } from 'reakit';
+import { Input } from "reakit";
 
 <label>
   <Input type="radio" /> Choose one
@@ -38,7 +38,7 @@ import { Input } from 'reakit';
 
 `as="textarea"`:
 ```jsx
-import { Input } from 'reakit';
+import { Input } from "reakit";
 
 <Input as="textarea" />
 ```

--- a/packages/reakit/src/Label/Label.md
+++ b/packages/reakit/src/Label/Label.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Input } from "reakit";
+import { Input, Label } from "reakit";
 
 <Label>
   Try it <Input />

--- a/packages/reakit/src/Link/Link.md
+++ b/packages/reakit/src/Link/Link.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Link } from 'reakit';
+import { Link } from "reakit";
 
 <Link href="https://github.com/reakit/reakit">GitHub</Link>
 ```

--- a/packages/reakit/src/Link/Link.md
+++ b/packages/reakit/src/Link/Link.md
@@ -1,3 +1,5 @@
 ```jsx
+import { Link } from 'reakit';
+
 <Link href="https://github.com/reakit/reakit">GitHub</Link>
 ```

--- a/packages/reakit/src/List/List.md
+++ b/packages/reakit/src/List/List.md
@@ -1,7 +1,7 @@
 `List` renders by default as an `<ul>` tag with `list-style` unset.
 
 ```jsx
-import { List } from 'reakit';
+import { List } from "reakit";
 
 <List>
   <li>Item 1</li>

--- a/packages/reakit/src/List/List.md
+++ b/packages/reakit/src/List/List.md
@@ -1,6 +1,8 @@
 `List` renders by default as an `<ul>` tag with `list-style` unset.
 
 ```jsx
+import { List } from 'reakit';
+
 <List>
   <li>Item 1</li>
   <li>Item 2</li>

--- a/packages/reakit/src/Navigation/Navigation.md
+++ b/packages/reakit/src/Navigation/Navigation.md
@@ -1,7 +1,7 @@
 `Navigation` renders a `<nav>` by default.
 
 ```jsx
-import { List } from "reakit";
+import { List, Navigation, Link } from "reakit";
 
 <Navigation>
   <List>

--- a/packages/reakit/src/Overlay/Overlay.md
+++ b/packages/reakit/src/Overlay/Overlay.md
@@ -1,7 +1,7 @@
 `Overlay` is by default fixed on the middle of the screen.
 
 ```jsx
-const { Block, Button, Backdrop } = require('reakit');
+const { Block, Button, Backdrop, Overlay } = require('reakit');
 
 <Overlay.Container>
   {overlay => (
@@ -17,7 +17,7 @@ const { Block, Button, Backdrop } = require('reakit');
 This is usually combined with [Portal](../Portal/Portal.md) so it can be dettached from the DOM hierarchy:
 
 ```jsx
-const { Block, Button, Backdrop, Portal } = require('reakit');
+const { Block, Button, Backdrop, Portal, Overlay } = require('reakit');
 
 <Overlay.Container>
   {overlay => (

--- a/packages/reakit/src/Overlay/Overlay.md
+++ b/packages/reakit/src/Overlay/Overlay.md
@@ -1,7 +1,7 @@
 `Overlay` is by default fixed on the middle of the screen.
 
 ```jsx
-const { Block, Button, Backdrop, Overlay } = require('reakit');
+const { Block, Button, Backdrop, Overlay } = require("reakit");
 
 <Overlay.Container>
   {overlay => (
@@ -17,7 +17,7 @@ const { Block, Button, Backdrop, Overlay } = require('reakit');
 This is usually combined with [Portal](../Portal/Portal.md) so it can be dettached from the DOM hierarchy:
 
 ```jsx
-const { Block, Button, Backdrop, Portal, Overlay } = require('reakit');
+const { Block, Button, Backdrop, Portal, Overlay } = require("reakit");
 
 <Overlay.Container>
   {overlay => (

--- a/packages/reakit/src/Overlay/OverlayContainer.md
+++ b/packages/reakit/src/Overlay/OverlayContainer.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block, Button } from "reakit";
+import { Block, Button, Overlay } from "reakit";
 
 <Overlay.Container>
   {({ visible, show, hide, toggle }) => (

--- a/packages/reakit/src/Overlay/OverlayHide.md
+++ b/packages/reakit/src/Overlay/OverlayHide.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Overlay } from "reakit";
 
 <Overlay.Container initialState={{ visible: true }}>
   {({ visible, hide }) => (

--- a/packages/reakit/src/Overlay/OverlayShow.md
+++ b/packages/reakit/src/Overlay/OverlayShow.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Overlay } from "reakit";
 
 <Overlay.Container>
   {({ visible, show }) => (

--- a/packages/reakit/src/Overlay/OverlayToggle.md
+++ b/packages/reakit/src/Overlay/OverlayToggle.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Overlay } from "reakit";
 
 <Overlay.Container>
   {({ visible, toggle }) => (

--- a/packages/reakit/src/Paragraph/Paragraph.md
+++ b/packages/reakit/src/Paragraph/Paragraph.md
@@ -1,6 +1,8 @@
 Paragraph renders by default as a `<p>` tag with `margin-bottom`.
 
 ```jsx
+import { Paragraph } from 'reakit';
+
 <Paragraph>
   Popovers are typically dismissable, whether by click on other parts of the
   page or second clicking the popover target (depending on implementation), for

--- a/packages/reakit/src/Paragraph/Paragraph.md
+++ b/packages/reakit/src/Paragraph/Paragraph.md
@@ -1,7 +1,7 @@
 Paragraph renders by default as a `<p>` tag with `margin-bottom`.
 
 ```jsx
-import { Paragraph } from 'reakit';
+import { Paragraph } from "reakit";
 
 <Paragraph>
   Popovers are typically dismissable, whether by click on other parts of the

--- a/packages/reakit/src/Popover/Popover.md
+++ b/packages/reakit/src/Popover/Popover.md
@@ -3,7 +3,7 @@
 You can change the visiblity of the popover in the example below by removing `visible`.
 
 ```jsx
-import { InlineBlock, Button } from "reakit";
+import { InlineBlock, Button, Popover } from "reakit";
 
 <InlineBlock relative>
   <Button>Button</Button>
@@ -16,7 +16,7 @@ import { InlineBlock, Button } from "reakit";
 You can use [PopoverContainer](PopoverContainer.md) in combination with [PopoverHide](PopoverHide.md) and [PopoverToggle](PopoverToggle.md) to easily create an animated popover:
 
 ```jsx
-import { InlineBlock, Popover } from "reakit";
+import { InlineBlock, Button, Popover } from "reakit";
 
 <Popover.Container>
   {popover => (

--- a/packages/reakit/src/Popover/PopoverArrow.md
+++ b/packages/reakit/src/Popover/PopoverArrow.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Popover } from 'reakit';
+import { Popover } from "reakit";
 
 <Popover.Arrow />
 ```

--- a/packages/reakit/src/Popover/PopoverArrow.md
+++ b/packages/reakit/src/Popover/PopoverArrow.md
@@ -1,3 +1,5 @@
 ```jsx
+import { Popover } from 'reakit';
+
 <Popover.Arrow />
 ```

--- a/packages/reakit/src/Popover/PopoverContainer.md
+++ b/packages/reakit/src/Popover/PopoverContainer.md
@@ -1,5 +1,5 @@
 ```jsx
-import { InlineBlock, Button } from "reakit";
+import { InlineBlock, Button, Popover } from "reakit";
 
 <Popover.Container>
   {({ visible, show, hide, toggle }) => (

--- a/packages/reakit/src/Popover/PopoverHide.md
+++ b/packages/reakit/src/Popover/PopoverHide.md
@@ -1,5 +1,5 @@
 ```jsx
-import { InlineBlock } from "reakit";
+import { InlineBlock, Popover } from "reakit";
 
 <Popover.Container initialState={{ visible: true }}>
   {({ visible, hide }) => (

--- a/packages/reakit/src/Popover/PopoverShow.md
+++ b/packages/reakit/src/Popover/PopoverShow.md
@@ -1,5 +1,5 @@
 ```jsx
-import { InlineBlock } from "reakit";
+import { InlineBlock, Popover } from "reakit";
 
 <Popover.Container>
   {({ visible, show }) => (

--- a/packages/reakit/src/Popover/PopoverToggle.md
+++ b/packages/reakit/src/Popover/PopoverToggle.md
@@ -1,5 +1,5 @@
 ```jsx
-import { InlineBlock } from "reakit";
+import { InlineBlock, Popover } from "reakit";
 
 <Popover.Container>
   {({ visible, toggle }) => (

--- a/packages/reakit/src/Portal/Portal.md
+++ b/packages/reakit/src/Portal/Portal.md
@@ -1,6 +1,8 @@
 `Portal` is built upon [React Portals](https://reactjs.org/docs/portals.html) and can be used alone or in combination with other components to dettach the element from the current DOM hierarchy and put it in a new `<div>`, which will be appended to `<body>`.
 
 ```jsx
+import { Portal } from 'reakit';
+
 <Portal textAlign="center">
   I'm on the bottom of the page
 </Portal>

--- a/packages/reakit/src/Portal/Portal.md
+++ b/packages/reakit/src/Portal/Portal.md
@@ -1,7 +1,7 @@
 `Portal` is built upon [React Portals](https://reactjs.org/docs/portals.html) and can be used alone or in combination with other components to dettach the element from the current DOM hierarchy and put it in a new `<div>`, which will be appended to `<body>`.
 
 ```jsx
-import { Portal } from 'reakit';
+import { Portal } from "reakit";
 
 <Portal textAlign="center">
   I'm on the bottom of the page

--- a/packages/reakit/src/Provider/Provider.md
+++ b/packages/reakit/src/Provider/Provider.md
@@ -4,7 +4,7 @@ You can pass it a `theme` prop to style your components.
 Use the component name in uppercase as a key.
 
 ```jsx
-import { Provider, Button } from 'reakit';
+import { Provider, Button } from "reakit";
 
 const theme = {
   Button: {

--- a/packages/reakit/src/Provider/Provider.md
+++ b/packages/reakit/src/Provider/Provider.md
@@ -4,6 +4,8 @@ You can pass it a `theme` prop to style your components.
 Use the component name in uppercase as a key.
 
 ```jsx
+import { Provider, Button } from 'reakit';
+
 const theme = {
   Button: {
     backgroundColor: "palevioletred",
@@ -19,7 +21,7 @@ const theme = {
 `Provider` supports the [Constate API](https://github.com/diegohaz/constate#provider) which makes [React Context](https://reactjs.org/docs/context.html) easier to use.
 
 ```jsx
-import { Container } from "reakit";
+import { Container, Provider, Container } from "reakit";
 
 const initial = {
   Button: {

--- a/packages/reakit/src/Sidebar/Sidebar.md
+++ b/packages/reakit/src/Sidebar/Sidebar.md
@@ -1,7 +1,7 @@
 By default, `Sidebar` is a fixed [Overlay](../Overlay/Overlay.md) that appears on the left side of the screen.
 
 ```jsx
-import { Block, Button, Backdrop } from "reakit";
+import { Block, Button, Backdrop, Sidebar } from "reakit";
 
 <Sidebar.Container>
   {sidebar => (
@@ -19,7 +19,7 @@ import { Block, Button, Backdrop } from "reakit";
 You can change its position with the `align` prop:
 
 ```jsx
-import { Block, Button, Backdrop } from "reakit";
+import { Block, Button, Backdrop, Sidebar } from "reakit";
 
 <Sidebar.Container>
   {sidebar => (
@@ -37,7 +37,7 @@ import { Block, Button, Backdrop } from "reakit";
 This is usually combined with [Portal](../Portal/Portal.md):
 
 ```jsx
-import { Block, Button, Backdrop, Portal } from "reakit";
+import { Block, Button, Backdrop, Portal, Sidebar } from "reakit";
 
 <Sidebar.Container>
   {sidebar => (
@@ -55,7 +55,7 @@ import { Block, Button, Backdrop, Portal } from "reakit";
 You can also put it inside another wrapper component tweaking its `position` and `height` css properties:
 
 ```jsx
-import { Block, Button, Backdrop } from "reakit";
+import { Block, Button, Backdrop, Sidebar } from "reakit";
 
 <Sidebar.Container>
   {sidebar => (

--- a/packages/reakit/src/Sidebar/SidebarContainer.md
+++ b/packages/reakit/src/Sidebar/SidebarContainer.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block, Button } from "reakit";
+import { Block, Button, Sidebar } from "reakit";
 
 <Sidebar.Container>
   {({ visible, show, hide, toggle }) => (

--- a/packages/reakit/src/Sidebar/SidebarHide.md
+++ b/packages/reakit/src/Sidebar/SidebarHide.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Sidebar } from "reakit";
 
 <Sidebar.Container initialState={{ visible: true }}>
   {({ visible, hide }) => (

--- a/packages/reakit/src/Sidebar/SidebarShow.md
+++ b/packages/reakit/src/Sidebar/SidebarShow.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Sidebar } from "reakit";
 
 <Sidebar.Container>
   {({ visible, show }) => (

--- a/packages/reakit/src/Sidebar/SidebarToggle.md
+++ b/packages/reakit/src/Sidebar/SidebarToggle.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Sidebar } from "reakit";
 
 <Sidebar.Container>
   {({ visible, toggle }) => (

--- a/packages/reakit/src/Step/StepContainer.md
+++ b/packages/reakit/src/Step/StepContainer.md
@@ -1,7 +1,7 @@
 Here's a destructured version of the example you saw on [Step](Step.md):
 
 ```jsx
-import { Block, Group, Button } from "reakit";
+import { Block, Group, Button, Step } from "reakit";
 
 <Step.Container initialState={{ current: 0 }}>
   {({

--- a/packages/reakit/src/Step/StepHide.md
+++ b/packages/reakit/src/Step/StepHide.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Step } from "reakit";
 
 <Step.Container initialState={{ current: 0 }}>
   {({ hide, ...step }) => (

--- a/packages/reakit/src/Step/StepNext.md
+++ b/packages/reakit/src/Step/StepNext.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Step } from "reakit";
 
 <Step.Container>
   {({ next, hasNext, ...step }) => (

--- a/packages/reakit/src/Step/StepPrevious.md
+++ b/packages/reakit/src/Step/StepPrevious.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Step } from "reakit";
 
 <Step.Container initialState={{ current: 2 }}>
   {({ previous, hasPrevious, ...step }) => (

--- a/packages/reakit/src/Step/StepShow.md
+++ b/packages/reakit/src/Step/StepShow.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Step } from "reakit";
 
 <Step.Container>
   {({ show, ...step }) => (

--- a/packages/reakit/src/Step/StepToggle.md
+++ b/packages/reakit/src/Step/StepToggle.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Step } from "reakit";
 
 <Step.Container>
   {({ toggle, ...step }) => (

--- a/packages/reakit/src/Table/Table.md
+++ b/packages/reakit/src/Table/Table.md
@@ -3,7 +3,7 @@ It applies a basic styling to its children to improve differentiation between he
 Table renders by default as a `<table>`.
 
 ```jsx
-import { Block } from "reakit";
+import { Block, Table } from "reakit";
 
 <Block overflowX="auto">
   <Table>
@@ -34,7 +34,7 @@ import { Block } from "reakit";
 A more throughout example:
 
 ```jsx
-import { Block } from "reakit";
+import { Block, Table } from "reakit";
 
 <Block overflowX="auto">
   <Table>

--- a/packages/reakit/src/Table/TableWrapper.md
+++ b/packages/reakit/src/Table/TableWrapper.md
@@ -2,7 +2,7 @@
 It renders by default as a `<div>`.
 
 ```jsx
-import { Table } from 'reakit';
+import { Table } from "reakit";
 
 <Table.Wrapper maxWidth={300}>
   <Table>

--- a/packages/reakit/src/Table/TableWrapper.md
+++ b/packages/reakit/src/Table/TableWrapper.md
@@ -2,6 +2,8 @@
 It renders by default as a `<div>`.
 
 ```jsx
+import { Table } from 'reakit';
+
 <Table.Wrapper maxWidth={300}>
   <Table>
     <tr>

--- a/packages/reakit/src/Tabs/Tabs.md
+++ b/packages/reakit/src/Tabs/Tabs.md
@@ -1,7 +1,7 @@
 `Tabs` renders as a `<ul>` for one or more [TabsTab](TabsTab.md)s inside, which render as `<li>`s. To be accessible, once focused, the arrow keys can be used to change tabs.
 
 ```jsx
-import { Block } from "reakit";
+import { Block, Tabs } from "reakit";
 
 <Tabs.Container>
   {tabs => (

--- a/packages/reakit/src/Tabs/TabsContainer.md
+++ b/packages/reakit/src/Tabs/TabsContainer.md
@@ -1,7 +1,7 @@
 Here's a destructured version of the example you saw on [Tabs](Tabs.md):
 
 ```jsx
-import { Block, Group, Button } from "reakit";
+import { Block, Group, Button, Tabs } from "reakit";
 
 <Tabs.Container>
   {({

--- a/packages/reakit/src/Tabs/TabsNext.md
+++ b/packages/reakit/src/Tabs/TabsNext.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Tabs } from "reakit";
 
 <Tabs.Container>
   {({ next, hasNext, ...tabs }) => (

--- a/packages/reakit/src/Tabs/TabsPanel.md
+++ b/packages/reakit/src/Tabs/TabsPanel.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Tabs } from "reakit";
 
 <Tabs.Container>
   {tabs => (

--- a/packages/reakit/src/Tabs/TabsPrevious.md
+++ b/packages/reakit/src/Tabs/TabsPrevious.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Tabs } from "reakit";
 
 <Tabs.Container>
   {({ previous, hasPrevious, ...tabs }) => (

--- a/packages/reakit/src/Tabs/TabsTab.md
+++ b/packages/reakit/src/Tabs/TabsTab.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Block } from "reakit";
+import { Block, Tabs } from "reakit";
 
 <Tabs.Container>
   {tabs => (

--- a/packages/reakit/src/Toolbar/Toolbar.md
+++ b/packages/reakit/src/Toolbar/Toolbar.md
@@ -1,7 +1,7 @@
 `Toolbar` is a generic bar that works as a wrapper for titles and actions. It's usually positioned on the top of a page, but can be used in several ways, including vertically.
 
 ```jsx
-import { Heading, Avatar } from "reakit";
+import { Heading, Avatar, Toolbar } from "reakit";
 import MenuIcon from "react-icons/lib/md/menu";
 
 <Toolbar background="white" gutter="8px 16px">
@@ -23,7 +23,7 @@ import MenuIcon from "react-icons/lib/md/menu";
 If you pass in a `vertical` prop, the toolbar content will be vertically aligned:
 
 ```jsx
-import { Button, Heading, Link } from "reakit";
+import { Button, Heading, Link, Toolbar } from "reakit";
 import MenuIcon from "react-icons/lib/md/menu";
 import CreateIcon from "react-icons/lib/md/create";
 

--- a/packages/reakit/src/Toolbar/ToolbarContent.md
+++ b/packages/reakit/src/Toolbar/ToolbarContent.md
@@ -1,6 +1,8 @@
 `ToolbarContent` is a wrapper for your [Toolbar](Toolbar.md) items. It helps you to align and space your elements correctly within the toolbar.
 
 ```jsx
+import { Toolbar } from 'reakit';
+
 <Toolbar>
   <Toolbar.Content>Start</Toolbar.Content>
   <Toolbar.Content align="center">Center</Toolbar.Content>
@@ -11,6 +13,8 @@
 When using `align="center"`, the elements inside it will be centralized no matter the size of the end elements. That's true until it touches one of them:
 
 ```jsx
+import { Toolbar } from 'reakit';
+
 <Toolbar overflow="auto">
   <Toolbar.Content background="white" width={500}>
     Start

--- a/packages/reakit/src/Toolbar/ToolbarContent.md
+++ b/packages/reakit/src/Toolbar/ToolbarContent.md
@@ -1,7 +1,7 @@
 `ToolbarContent` is a wrapper for your [Toolbar](Toolbar.md) items. It helps you to align and space your elements correctly within the toolbar.
 
 ```jsx
-import { Toolbar } from 'reakit';
+import { Toolbar } from "reakit";
 
 <Toolbar>
   <Toolbar.Content>Start</Toolbar.Content>
@@ -13,7 +13,7 @@ import { Toolbar } from 'reakit';
 When using `align="center"`, the elements inside it will be centralized no matter the size of the end elements. That's true until it touches one of them:
 
 ```jsx
-import { Toolbar } from 'reakit';
+import { Toolbar } from "reakit";
 
 <Toolbar overflow="auto">
   <Toolbar.Content background="white" width={500}>

--- a/packages/reakit/src/Toolbar/ToolbarFocusable.md
+++ b/packages/reakit/src/Toolbar/ToolbarFocusable.md
@@ -1,6 +1,8 @@
 You should use `ToolbarFocusable` on elements within your [Toolbar](Toolbar.md) that you want to add to the focus sequence.
 
 ```jsx
+import { Toolbar } from 'reakit';
+
 <Toolbar>
   <Toolbar.Content whiteSpace="nowrap">
     <Toolbar.Focusable>I'm focusable</Toolbar.Focusable>

--- a/packages/reakit/src/Toolbar/ToolbarFocusable.md
+++ b/packages/reakit/src/Toolbar/ToolbarFocusable.md
@@ -1,7 +1,7 @@
 You should use `ToolbarFocusable` on elements within your [Toolbar](Toolbar.md) that you want to add to the focus sequence.
 
 ```jsx
-import { Toolbar } from 'reakit';
+import { Toolbar } from "reakit";
 
 <Toolbar>
   <Toolbar.Content whiteSpace="nowrap">

--- a/packages/reakit/src/Tooltip/Tooltip.md
+++ b/packages/reakit/src/Tooltip/Tooltip.md
@@ -1,7 +1,7 @@
 It displays a tooltip when the parent element is hovered or receives focus. By default it renders as a `<div>`.
 
 ```jsx
-import { Button } from "reakit";
+import { Button, Tooltip } from "reakit";
 
 <Button>
   Hover me
@@ -12,7 +12,7 @@ import { Button } from "reakit";
 Multiple Tooltips are possible:
 
 ```jsx
-import { Button } from "reakit";
+import { Button, Tooltip } from "reakit";
 
 <Button margin="50px 80px">
   Hover me

--- a/packages/reakit/src/Tooltip/TooltipArrow.md
+++ b/packages/reakit/src/Tooltip/TooltipArrow.md
@@ -1,4 +1,4 @@
 ```jsx
-import { Tooltip } from 'reakit';
+import { Tooltip } from "reakit";
 <Tooltip.Arrow />
 ```

--- a/packages/reakit/src/Tooltip/TooltipArrow.md
+++ b/packages/reakit/src/Tooltip/TooltipArrow.md
@@ -1,3 +1,4 @@
 ```jsx
+import { Tooltip } from 'reakit';
 <Tooltip.Arrow />
 ```


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Refactoring (??)

**Does this PR introduce a breaking change?**
No

As we have discussed on slack, adding those missing imports helps user to copy and paste the code, if one wants to use the whole example.