### PR TITLE
Remove outline for mouse users but preserves it for keyboard users

### DIFF
--- a/packages/reakit/src/Box/Box.ts
+++ b/packages/reakit/src/Box/Box.ts
@@ -36,6 +36,11 @@ const Box = styled(BoxComponent)<BoxProps>`
   box-sizing: border-box;
   background-color: ${bgColorWithProps};
   color: ${textColorWithProps};
+
+  &:focus:not(:focus-visible) {
+    outline: none;
+  }
+
   ${theme("Box")};
   &&& {
     ${bool("position", positions)};


### PR DESCRIPTION
> Gets rid of the annoying outline for mouse users but preserves it for keyboard users, and is ignored by browsers that don’t support `:focus-visible`.

Closes https://github.com/reakit/reakit/issues/259