### PR TITLE
Fixed refs for Box

### DIFF
--- a/packages/reakit/src/Box/Box.tsx
+++ b/packages/reakit/src/Box/Box.tsx
@@ -46,8 +46,9 @@ const BoxComponent = React.forwardRef<HTMLElement, BoxProps>(
       );
       return <T {...allProps} ref={applyAllRefs(ref, props.elementRef)} />;
     }
-
-    return <T {...props} style={style} />;
+    return (
+      <T {...props} ref={applyAllRefs(ref, props.elementRef)} style={style} />
+    );
   }
 );
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

This fixes a bug where refs weren't being applied to `Box` that had its `use` prop set to a component.

More specifically, this was the issue I personally was having:

```jsx
<Button use={Overlay.Hide} elementRef={this.initialFocusRef}>Close</Button>
```

It seemed that the ref wasn't being properly attached in this case, however, if I removed the `use` prop altogether, it worked.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
