### PR TITLE
Fix "types" key for proxy packages

### DIFF
--- a/packages/reakit/scripts/makeProxies.js
+++ b/packages/reakit/scripts/makeProxies.js
@@ -1,18 +1,14 @@
 // https://developers.livechatinc.com/blog/how-to-create-javascript-libraries-in-2018-part-2/
 const { mkdirSync, writeFileSync } = require("fs");
-const { dirname } = require("path");
 const { name } = require("../package.json");
 const publicFiles = require("./publicFiles");
 
-const getTSPath = (module, file) =>
-  dirname(file.replace(/^src\//, "")).replace(/^\.$/, module);
-
-const createProxyPackage = (module, file) => `{
+const createProxyPackage = module => `{
   "name": "${name}/${module}",
   "private": true,
   "main": "../lib/${module}",
   "module": "../es/${module}",
-  "types": "../ts/${getTSPath(module, file)}"
+  "types": "../ts/${module}/index.d.ts"
 }
 `;
 
@@ -25,9 +21,9 @@ const createDirPackage = dir => `{
 
 Object.entries(publicFiles)
   .filter(([module]) => module !== "index")
-  .forEach(([module, file]) => {
+  .forEach(([module]) => {
     mkdirSync(module);
-    writeFileSync(`${module}/package.json`, createProxyPackage(module, file));
+    writeFileSync(`${module}/package.json`, createProxyPackage(module));
   });
 
 ["lib", "es"].forEach(dir => {

--- a/packages/reakit/scripts/makeProxies.js
+++ b/packages/reakit/scripts/makeProxies.js
@@ -8,7 +8,7 @@ const createProxyPackage = module => `{
   "private": true,
   "main": "../lib/${module}",
   "module": "../es/${module}",
-  "types": "../ts/${module}/index.d.ts"
+  "types": "../ts/${module}"
 }
 `;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

This fixes the issue where the "types" key in proxy packages were pointing to @diegohaz local machine. See #316.

I'm not too sure if we need to reference the `src/` folder though? Hence why I got rid of `getTSPath`... Just exposing the module's respective `ts/` folder should be enough? Let me know if I'm wrong. :) 