### PR TITLE
Add Stack container component

### DIFF
--- a/packages/reakit/src/Stack/Stack.md
+++ b/packages/reakit/src/Stack/Stack.md
@@ -1,0 +1,77 @@
+A [Box](../Box/Box.md) that stacks its children on top of each other. The first child element determines the size of the container, while the others positioned absolutely on top.
+
+```jsx
+import { Stack } from "reakit";
+
+<Stack>
+  <Box
+    border="1px solid rgb(219, 112, 147)"
+    width={80}
+    height={80}
+  />
+  <Box
+    backgroundColor="rgb(219, 112, 147)"
+    border="1px solid rgb(219, 112, 147)"
+    width={40}
+    height={40}
+  />
+</Stack>
+```
+
+By default, the stacked children are anchored to the top left corner of the stack. This can be customized by setting the `anchor` prop to an array that may contain any combination of `"top"`, `"right"`, `"bottom"` and `"left"`. For example, `["bottom", "right"]` places all stacked children at the bottom right corner of the container. To stretch the children horizontally, include both `"left"` and `"right"` in the array; similarly, specifying both `"top"` and `"bottom"` causes the stacked children to be stretched vertically.
+
+```jsx
+import { Stack } from "reakit";
+
+<Flex>
+  <Stack anchor={['top', 'right']}>
+    <Box
+      border="1px solid rgb(219, 112, 147)"
+      width={80}
+      height={80}
+    />
+    <Box
+      backgroundColor="rgb(219, 112, 147)"
+      width={40}
+      height={40}
+    />
+  </Stack>
+
+  <Stack anchor={['bottom', 'right']} marginLeft={8}>
+    <Box
+      border="1px solid rgb(219, 112, 147)"
+      width={80}
+      height={80}
+    />
+    <Box
+      backgroundColor="rgb(219, 112, 147)"
+      width={40}
+      height={40}
+    />
+  </Stack>
+
+  <Stack anchor={['top', 'bottom', 'left']} marginLeft={8}>
+    <Box
+      border="1px solid rgb(219, 112, 147)"
+      width={80}
+      height={80}
+    />
+    <Box
+      backgroundColor="rgb(219, 112, 147)"
+      width={40}
+    />
+  </Stack>
+
+  <Stack anchor={['top', 'left', 'right']} marginLeft={8}>
+    <Box
+      border="1px solid rgb(219, 112, 147)"
+      width={80}
+      height={80}
+    />
+    <Box
+      backgroundColor="rgb(219, 112, 147)"
+      height={40}
+    />
+  </Stack>
+</Flex>
+```

--- a/packages/reakit/src/Stack/Stack.ts
+++ b/packages/reakit/src/Stack/Stack.ts
@@ -1,0 +1,33 @@
+import { theme, withProp } from "styled-tools";
+import styled from "../styled";
+import use from "../use";
+import Box, { BoxProps } from "../Box";
+
+export type StackAnchor = "top" | "right" | "bottom" | "left";
+
+export interface StackProps extends BoxProps {
+  anchor?: StackAnchor[];
+}
+
+const ifAnchor = (anchor: StackAnchor, style: string) =>
+  withProp("anchor", anchors => (anchors.includes(anchor) ? style : ""));
+
+const Stack = styled(Box)<StackProps>`
+  position: relative;
+
+  > *:not(:first-child) {
+    position: absolute;
+    ${ifAnchor("top", "top: 0;")}
+    ${ifAnchor("right", "right: 0;")}
+    ${ifAnchor("bottom", "bottom: 0;")}
+    ${ifAnchor("left", "left: 0;")}
+  }
+
+  ${theme("Stack")};
+`;
+
+Stack.defaultProps = {
+  anchor: ["top", "left"]
+};
+
+export default use(Stack, "div");

--- a/packages/reakit/src/Stack/__tests__/Stack-test.tsx
+++ b/packages/reakit/src/Stack/__tests__/Stack-test.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { render } from "react-testing-library";
+import Stack from "../Stack";
+
+test("HTML attributes", () => {
+  const { getByTestId } = render(
+    <Stack id="test" aria-label="test" data-testid="test" />
+  );
+
+  expect(getByTestId("test")).toHaveAttribute("id", "test");
+  expect(getByTestId("test")).toHaveAttribute("aria-label", "test");
+});
+
+test("Default", () => {
+  const { container } = render(<Stack />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test("Anchor", () => {
+  const { container } = render(<Stack anchor={["bottom", "right"]} />);
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/packages/reakit/src/Stack/__tests__/__snapshots__/Stack-test.tsx.snap
+++ b/packages/reakit/src/Stack/__tests__/__snapshots__/Stack-test.tsx.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Anchor 1`] = `
+.c1 {
+  margin: unset;
+  padding: unset;
+  border: unset;
+  background: unset;
+  font: unset;
+  font-family: inherit;
+  font-size: 100%;
+  box-sizing: border-box;
+  background-color: unset;
+  color: inherit;
+}
+
+.c1:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.c0 {
+  position: relative;
+}
+
+.c0 > *:not(:first-child) {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+}
+
+<div
+  class="c0 c1"
+/>
+`;
+
+exports[`Default 1`] = `
+.c1 {
+  margin: unset;
+  padding: unset;
+  border: unset;
+  background: unset;
+  font: unset;
+  font-family: inherit;
+  font-size: 100%;
+  box-sizing: border-box;
+  background-color: unset;
+  color: inherit;
+}
+
+.c1:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.c0 {
+  position: relative;
+}
+
+.c0 > *:not(:first-child) {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+<div
+  class="c0 c1"
+/>
+`;

--- a/packages/reakit/src/Stack/index.ts
+++ b/packages/reakit/src/Stack/index.ts
@@ -1,0 +1,5 @@
+import Stack from "./Stack";
+
+export * from "./Stack";
+
+export default Stack;

--- a/packages/reakit/src/index.ts
+++ b/packages/reakit/src/index.ts
@@ -95,6 +95,9 @@ export * from "./Provider";
 export { default as Sidebar } from "./Sidebar";
 export * from "./Sidebar";
 
+export { default as Stack } from "./Stack";
+export * from "./Stack";
+
 export { default as Step } from "./Step";
 export * from "./Step";
 


### PR DESCRIPTION
This PR introduces a `Stack` container component inspired by the [similar one in Grommet](https://v2.grommet.io/stack) is a Box that stacks its children on top of each other. It stacks its children on top of each other by making every child except the first one `position: absolute`. There is an `anchor` prop to specify where to put the stacked children.

This is for uses cases like putting a badge on top of an icon, or a floating button on top of a content box.

<img width="437" alt="bildschirmfoto 2019-02-15 um 00 06 09" src="https://user-images.githubusercontent.com/1032624/52823523-8d56ca80-30b5-11e9-98b0-c47992771e59.png">
