### PR TITLE
Fix: Stop messing with nested <label> tags inside the <Label /> component

### DIFF
--- a/packages/reakit-theme-default/src/index.ts
+++ b/packages/reakit-theme-default/src/index.ts
@@ -154,7 +154,7 @@ export const Field = css`
   display: flex;
   flex-direction: column;
   flex: 1;
-  label {
+  > label {
     padding-bottom: 0.5em;
   }
   > *:not(label):not(:last-child) {


### PR DESCRIPTION
# Motivation

The current CSS applies a `padding-bottom: 0.5em` to *every* `label` tag inside the `<Label />` component, resulting in inconsistencies in third-party components some times when used nested. 

This small fix makes it contained, keeping it working within `reakit` components, simply targeting the first `<label />` element from the `<Label />` component only, instead of any label that can exist inside of it. 

**What kind of change does this PR introduce?**
A bugfix

**Does this PR introduce a breaking change?**
Nope