### PR TITLE
Add instructions for TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ npm i reakit
 
 > Thanks to [@nosebit](https://github.com/nosebit) for the package name on npm.
 
+If you are using TypeScript, you'll need to also install
+`@types/styled-components`.
+
 ## Example
 
 <p align="center">

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -10,6 +10,12 @@ Then, install `reakit` and `reakit-theme-default` (optional):
 npm install --save reakit reakit-theme-default
 ```
 
+If you are using TypeScript, install `@types/styled-components`:
+
+```sh
+npm install --save-dev @types/styled-components
+```
+
 ## Usage
 
 Play with an example on [CodeSandbox](https://codesandbox.io/s/m4n32vjkoj).

--- a/packages/reakit/README.md
+++ b/packages/reakit/README.md
@@ -38,6 +38,9 @@ npm i reakit
 
 > Thanks to [@nosebit](https://github.com/nosebit) for the package name on npm.
 
+If you are using TypeScript, you'll need to also install
+`@types/styled-components`.
+
 ## Example
 
 <p align="center">


### PR DESCRIPTION
As mentioned in #338, installing `@types/styled-components` is required to prevent TypeScript compile errors in certain scenarios.

**What kind of change does this PR introduce?**

Adds instruction to install `@types/styled-components` for TypeScript projects.

**Does this PR introduce a breaking change?**

No
