### PR TITLE
Changing Pallet primary dark from #005AFF to #006DFF due to constrat

### DIFF
--- a/packages/reakit-system-palette/src/__tests__/index-test.tsx
+++ b/packages/reakit-system-palette/src/__tests__/index-test.tsx
@@ -13,7 +13,7 @@ test("useBox", () => {
     <body>
       <div>
         <div
-          style="color: rgb(255, 255, 255); background-color: rgb(0, 123, 255);"
+          style="color: rgb(255, 255, 255); background-color: rgb(0, 109, 255);"
         >
           Box
         </div>

--- a/packages/reakit-system-palette/src/palette.ts
+++ b/packages/reakit-system-palette/src/palette.ts
@@ -7,7 +7,7 @@ export const palette: Palette = {
   black: "#212121",
   light: "#f8f9fa",
   dark: "#343a40",
-  primary: "#007BFF",
+  primary: "#006DFF",
   secondary: "#6C757D",
   success: "#28A745",
   info: "#17A2B8",

--- a/packages/website/src/components/Provider.tsx
+++ b/packages/website/src/components/Provider.tsx
@@ -6,7 +6,7 @@ import * as playgroundSystem from "reakit-playground/system";
 const system = unstable_mergeSystem(bootstrapSystem, playgroundSystem, {
   palette: {
     ...bootstrapSystem.palette,
-    primary: "#006DFF",
+    primary: "#6a50ee",
     link: "#006DFF",
     secondary: "#504984"
   }

--- a/packages/website/src/components/Provider.tsx
+++ b/packages/website/src/components/Provider.tsx
@@ -7,7 +7,7 @@ const system = unstable_mergeSystem(bootstrapSystem, playgroundSystem, {
   palette: {
     ...bootstrapSystem.palette,
     primary: "#006DFF",
-    link: "#007bff",
+    link: "#006DFF",
     secondary: "#504984"
   }
 });

--- a/packages/website/src/components/Provider.tsx
+++ b/packages/website/src/components/Provider.tsx
@@ -6,7 +6,7 @@ import * as playgroundSystem from "reakit-playground/system";
 const system = unstable_mergeSystem(bootstrapSystem, playgroundSystem, {
   palette: {
     ...bootstrapSystem.palette,
-    primary: "#6a50ee",
+    primary: "#006DFF",
     link: "#007bff",
     secondary: "#504984"
   }


### PR DESCRIPTION
As pointed on #354 when you run a contrast ratio test it with `#007BFF` on primary color it gets a ratio below 4.5.

I just changed the primary dark color to `#006DFF` which gets a contrast ratio of 4.53. =D

I tried another values, but i think that changing the color values to more distinct values can cause some trouble on projects that are already using the default colors.

Closes #354 