### PR TITLE
[playground] Unmount React components correctly

### DIFF
--- a/packages/reakit-playground/src/PlaygroundPreview.tsx
+++ b/packages/reakit-playground/src/PlaygroundPreview.tsx
@@ -103,8 +103,8 @@ export function PlaygroundPreview({
 
   React.useEffect(() => {
     // Ensure that we unmount the React component when the effect is destroyed.
-    return () => unmount()
-  })
+    return () => unmount();
+  });
 
   htmlProps = unstable_useProps("PlaygroundPreview", options, htmlProps);
 

--- a/packages/reakit-playground/src/PlaygroundPreview.tsx
+++ b/packages/reakit-playground/src/PlaygroundPreview.tsx
@@ -104,7 +104,7 @@ export function PlaygroundPreview({
   React.useEffect(() => {
     // Ensure that we unmount the React component when the effect is destroyed.
     return () => unmount();
-  });
+  }, [unmount]);
 
   htmlProps = unstable_useProps("PlaygroundPreview", options, htmlProps);
 

--- a/packages/reakit-playground/src/PlaygroundPreview.tsx
+++ b/packages/reakit-playground/src/PlaygroundPreview.tsx
@@ -84,18 +84,14 @@ export function PlaygroundPreview({
           options.modules,
           options.componentName
         );
-        
+        unmount();
         ReactDOM.render(renderChildren(<Example />), ref.current);
       } catch (e) {
         unmount();
         handleError(e);
       }
     }, 500);
-    return () => {
-      // Ensure that we unmount the React compontn when the effect is destroyed.
-      unmount();
-      clearTimeout(timer);
-    }
+    return () => clearTimeout(timer);
   }, [
     options.code,
     options.modules,
@@ -104,6 +100,11 @@ export function PlaygroundPreview({
     handleError,
     unmount
   ]);
+
+  React.useEffect(() => {
+    // Ensure that we unmount the React component when the effect is destroyed.
+    return () => unmount()
+  })
 
   htmlProps = unstable_useProps("PlaygroundPreview", options, htmlProps);
 

--- a/packages/reakit-playground/src/PlaygroundPreview.tsx
+++ b/packages/reakit-playground/src/PlaygroundPreview.tsx
@@ -84,14 +84,18 @@ export function PlaygroundPreview({
           options.modules,
           options.componentName
         );
-        unmount();
+        
         ReactDOM.render(renderChildren(<Example />), ref.current);
       } catch (e) {
         unmount();
         handleError(e);
       }
     }, 500);
-    return () => clearTimeout(timer);
+    return () => {
+      // Ensure that we unmount the React compontn when the effect is destroyed.
+      unmount();
+      clearTimeout(timer);
+    }
   }, [
     options.code,
     options.modules,


### PR DESCRIPTION
The components were only unmounted when the `useEffect` was rerun or threw an error.
This meant that unmount would not trigger when the hook itself was destroyed.

This ensures that the component is always unmounted when the effect is updated, by unmounting in the cleanup function.

See: https://github.com/reakit/reakit/issues/351#issuecomment-492960923