### PR TITLE
feat: Add `unstable_animated` option to `useHiddenState` and its derivatives

### DIFF
--- a/packages/reakit/src/Dialog/README.md
+++ b/packages/reakit/src/Dialog/README.md
@@ -237,6 +237,14 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 
   Whether it's visible or not.
 
+- **`unstable_animated`** <span title="Experimental">⚠️</span>
+  <code>number | boolean</code>
+
+  If `true`, `animating` will be set to `true` when `visible` changes.
+It'll wait for `stopAnimation` to be called or a CSS transition ends.
+If it's a number, `stopAnimation` will be called automatically after
+given milliseconds.
+
 ### `Dialog`
 
 - **`visible`**
@@ -245,15 +253,18 @@ Learn more in [Composition](/docs/composition/#props-hooks).
   Whether it's visible or not.
 
 - **`unstable_animated`** <span title="Experimental">⚠️</span>
-  <code>boolean | undefined</code>
+  <code>number | boolean</code>
 
-  If `true`, the hidden element attributes will be set in different
-timings to enable CSS transitions. This means that you can safely use the `.hidden` selector in the CSS to
-create transitions.
-  - When it becomes visible, immediatelly remove the `hidden` attribute,
-then add the `hidden` class.
-  - When it becomes hidden, immediatelly remove the `hidden` class, then
-add the `hidden` attribute.
+  If `true`, `animating` will be set to `true` when `visible` changes.
+It'll wait for `stopAnimation` to be called or a CSS transition ends.
+If it's a number, `stopAnimation` will be called automatically after
+given milliseconds.
+
+- **`unstable_stopAnimation`** <span title="Experimental">⚠️</span>
+  <code>() =&#62; void</code>
+
+  Stops animation. It's called automatically if there's a CSS transition.
+It's called after given milliseconds if `animated` is a number.
 
 - **`hide`**
   <code>() =&#62; void</code>
@@ -319,15 +330,18 @@ It will be set to `false` if `modal` is `false`.
   Whether it's visible or not.
 
 - **`unstable_animated`** <span title="Experimental">⚠️</span>
-  <code>boolean | undefined</code>
+  <code>number | boolean</code>
 
-  If `true`, the hidden element attributes will be set in different
-timings to enable CSS transitions. This means that you can safely use the `.hidden` selector in the CSS to
-create transitions.
-  - When it becomes visible, immediatelly remove the `hidden` attribute,
-then add the `hidden` class.
-  - When it becomes hidden, immediatelly remove the `hidden` class, then
-add the `hidden` attribute.
+  If `true`, `animating` will be set to `true` when `visible` changes.
+It'll wait for `stopAnimation` to be called or a CSS transition ends.
+If it's a number, `stopAnimation` will be called automatically after
+given milliseconds.
+
+- **`unstable_stopAnimation`** <span title="Experimental">⚠️</span>
+  <code>() =&#62; void</code>
+
+  Stops animation. It's called automatically if there's a CSS transition.
+It's called after given milliseconds if `animated` is a number.
 
 ### `DialogDisclosure`
 

--- a/packages/reakit/src/Hidden/Hidden.ts
+++ b/packages/reakit/src/Hidden/Hidden.ts
@@ -13,7 +13,7 @@ export type HiddenOptions = BoxOptions &
     | "visible"
     | "unstable_animating"
     | "unstable_animated"
-    | "unstable_flushAnimation"
+    | "unstable_stopAnimation"
   >;
 
 export type HiddenHTMLProps = BoxHTMLProps;
@@ -35,34 +35,33 @@ export const useHidden = unstable_createHook<HiddenOptions, HiddenHTMLProps>({
       ...htmlProps
     }
   ) {
-    const [shouldAddClass, setShouldAddClass] = React.useState(false);
+    const [hiddenClass, setHiddenClass] = React.useState<string | null>(null);
 
     React.useEffect(() => {
-      setShouldAddClass(!options.visible);
+      setHiddenClass(!options.visible ? "hidden" : null);
     }, [options.visible]);
 
     const onTransitionEnd = React.useCallback(() => {
       if (
         options.unstable_animated &&
-        options.unstable_flushAnimation &&
+        options.unstable_stopAnimation &&
         !options.visible
       ) {
-        options.unstable_flushAnimation();
+        options.unstable_stopAnimation();
       }
     }, [
       options.unstable_animated,
-      options.unstable_flushAnimation,
+      options.unstable_stopAnimation,
       options.visible
     ]);
 
-    const hidden =
-      !options.visible &&
-      (!options.unstable_animating || !options.unstable_animated);
+    const animating = options.unstable_animated && options.unstable_animating;
+    const hidden = !options.visible && !animating;
 
     return {
       role: "region",
       id: options.unstable_hiddenId,
-      className: cx(shouldAddClass && "hidden", htmlClassName),
+      className: cx(hiddenClass, htmlClassName),
       onAnimationEnd: useAllCallbacks(onTransitionEnd, htmlOnAnimationEnd),
       onTransitionEnd: useAllCallbacks(onTransitionEnd, htmlOnTransitionEnd),
       hidden,

--- a/packages/reakit/src/Hidden/HiddenState.ts
+++ b/packages/reakit/src/Hidden/HiddenState.ts
@@ -15,6 +15,14 @@ export type HiddenState = {
    * Whether it's visible or not.
    */
   visible: boolean;
+  /**
+   * TODO: Description.
+   */
+  unstable_animated: boolean | number;
+  /**
+   * TODO: Description
+   */
+  unstable_animating: boolean;
 };
 
 export type HiddenActions = {
@@ -30,23 +38,53 @@ export type HiddenActions = {
    * Toggles the `visible` state
    */
   toggle: () => void;
+  /**
+   * Flushes `animatedVisible`.
+   */
+  unstable_flushAnimation: () => void;
 };
 
 export type HiddenInitialState = Partial<
-  Pick<HiddenState, "unstable_hiddenId" | "visible">
+  Pick<HiddenState, "unstable_hiddenId" | "visible" | "unstable_animated">
 >;
 
 export type HiddenStateReturn = HiddenState & HiddenActions;
+
+function useLastValue<T>(value: T) {
+  const lastValue = React.useRef<T | null>(null);
+  React.useLayoutEffect(() => {
+    lastValue.current = value;
+  }, [value]);
+  return lastValue;
+}
 
 export function useHiddenState(
   initialState: unstable_SealedInitialState<HiddenInitialState> = {}
 ): HiddenStateReturn {
   const {
     unstable_hiddenId: hiddenId = unstable_useId("hidden-"),
+    unstable_animated: animated = false,
     visible: sealedVisible = false
   } = unstable_useSealedState(initialState);
 
   const [visible, setVisible] = React.useState(sealedVisible);
+  const [animating, setAnimating] = React.useState(false);
+  const lastVisible = useLastValue(visible);
+
+  if (!lastVisible.current && visible && !animating && animated) {
+    setAnimating(true);
+  }
+
+  React.useLayoutEffect(() => {
+    if (!animated || visible) return undefined;
+
+    if (typeof animated === "number") {
+      const id = setTimeout(() => setAnimating(false), animated);
+      return () => clearTimeout(id);
+    }
+
+    return undefined;
+  }, [animated, visible]);
 
   const show = React.useCallback(() => setVisible(true), []);
 
@@ -54,21 +92,31 @@ export function useHiddenState(
 
   const toggle = React.useCallback(() => setVisible(v => !v), []);
 
+  const flushAnimation = React.useCallback(() => setAnimating(visible), [
+    visible
+  ]);
+
   return {
     unstable_hiddenId: hiddenId,
+    unstable_animated: animated,
+    unstable_animating: animating,
     visible,
     show,
     hide,
-    toggle
+    toggle,
+    unstable_flushAnimation: flushAnimation
   };
 }
 
 const keys: Array<keyof HiddenStateReturn> = [
   "unstable_hiddenId",
+  "unstable_animated",
+  "unstable_animating",
   "visible",
   "show",
   "hide",
-  "toggle"
+  "toggle",
+  "unstable_flushAnimation"
 ];
 
 useHiddenState.__keys = keys;

--- a/packages/reakit/src/Hidden/README.md
+++ b/packages/reakit/src/Hidden/README.md
@@ -64,6 +64,14 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 
   Whether it's visible or not.
 
+- **`unstable_animated`** <span title="Experimental">⚠️</span>
+  <code>number | boolean</code>
+
+  If `true`, `animating` will be set to `true` when `visible` changes.
+It'll wait for `stopAnimation` to be called or a CSS transition ends.
+If it's a number, `stopAnimation` will be called automatically after
+given milliseconds.
+
 ### `Hidden`
 
 - **`visible`**
@@ -72,15 +80,18 @@ Learn more in [Composition](/docs/composition/#props-hooks).
   Whether it's visible or not.
 
 - **`unstable_animated`** <span title="Experimental">⚠️</span>
-  <code>boolean | undefined</code>
+  <code>number | boolean</code>
 
-  If `true`, the hidden element attributes will be set in different
-timings to enable CSS transitions. This means that you can safely use the `.hidden` selector in the CSS to
-create transitions.
-  - When it becomes visible, immediatelly remove the `hidden` attribute,
-then add the `hidden` class.
-  - When it becomes hidden, immediatelly remove the `hidden` class, then
-add the `hidden` attribute.
+  If `true`, `animating` will be set to `true` when `visible` changes.
+It'll wait for `stopAnimation` to be called or a CSS transition ends.
+If it's a number, `stopAnimation` will be called automatically after
+given milliseconds.
+
+- **`unstable_stopAnimation`** <span title="Experimental">⚠️</span>
+  <code>() =&#62; void</code>
+
+  Stops animation. It's called automatically if there's a CSS transition.
+It's called after given milliseconds if `animated` is a number.
 
 ### `HiddenDisclosure`
 

--- a/packages/reakit/src/Hidden/README.md
+++ b/packages/reakit/src/Hidden/README.md
@@ -38,31 +38,6 @@ function Example() {
 }
 ```
 
-```jsx
-import { animated, useSpring } from "react-spring";
-import { useHiddenState, Hidden, HiddenDisclosure } from "reakit/Hidden";
-
-function Example() {
-  const state = useHiddenState({ unstable_animated: true });
-
-  const style = useSpring({
-    to: state.visible
-      ? { opacity: 1, transform: "translate3d(0, 0, 0)" }
-      : { opacity: 0, transform: "translate3d(0, -10px, 0)" },
-    onRest: state.unstable_flushAnimation
-  });
-
-  return (
-    <>
-      <HiddenDisclosure {...state}>Toggle</HiddenDisclosure>
-      <Hidden {...state} as={animated.div} style={style}>
-        Hidden
-      </Hidden>
-    </>
-  );
-}
-```
-
 ## Accessibility
 
 - `HiddenDisclosure` extends the accessibility features of [Button](/docs/button/#accessibility).

--- a/packages/reakit/src/Hidden/README.md
+++ b/packages/reakit/src/Hidden/README.md
@@ -38,6 +38,31 @@ function Example() {
 }
 ```
 
+```jsx
+import { animated, useSpring } from "react-spring";
+import { useHiddenState, Hidden, HiddenDisclosure } from "reakit/Hidden";
+
+function Example() {
+  const state = useHiddenState({ unstable_animated: true });
+
+  const style = useSpring({
+    to: state.visible
+      ? { opacity: 1, transform: "translate3d(0, 0, 0)" }
+      : { opacity: 0, transform: "translate3d(0, -10px, 0)" },
+    onRest: state.unstable_flushAnimation
+  });
+
+  return (
+    <>
+      <HiddenDisclosure {...state}>Toggle</HiddenDisclosure>
+      <Hidden {...state} as={animated.div} style={style}>
+        Hidden
+      </Hidden>
+    </>
+  );
+}
+```
+
 ## Accessibility
 
 - `HiddenDisclosure` extends the accessibility features of [Button](/docs/button/#accessibility).

--- a/packages/reakit/src/Hidden/__tests__/HiddenState-test.ts
+++ b/packages/reakit/src/Hidden/__tests__/HiddenState-test.ts
@@ -12,6 +12,8 @@ test("initial state", () => {
   const result = render({ unstable_hiddenId: "test" });
   expect(result.current).toMatchInlineSnapshot(`
     Object {
+      "unstable_animated": false,
+      "unstable_animating": false,
       "unstable_hiddenId": "test",
       "visible": false,
     }
@@ -26,6 +28,8 @@ test("initial state visible", () => {
     },
     `
     Object {
+      "unstable_animated": false,
+      "unstable_animating": false,
       "unstable_hiddenId": "test",
       "visible": true,
     }
@@ -41,6 +45,8 @@ test("initial state lazy", () => {
     },
     `
     Object {
+      "unstable_animated": false,
+      "unstable_animating": false,
       "unstable_hiddenId": "test",
       "visible": true,
     }
@@ -55,6 +61,8 @@ test("show", () => {
     { visible: true },
     `
     Object {
+      "unstable_animated": false,
+      "unstable_animating": false,
       "unstable_hiddenId": "test",
       "visible": true,
     }
@@ -69,6 +77,8 @@ test("hide", () => {
     { visible: false },
     `
     Object {
+      "unstable_animated": false,
+      "unstable_animating": false,
       "unstable_hiddenId": "test",
       "visible": false,
     }
@@ -83,6 +93,8 @@ test("toggle", () => {
     { visible: true },
     `
     Object {
+      "unstable_animated": false,
+      "unstable_animating": false,
       "unstable_hiddenId": "test",
       "visible": true,
     }

--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -323,6 +323,14 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 
   Whether it's visible or not.
 
+- **`unstable_animated`** <span title="Experimental">⚠️</span>
+  <code>number | boolean</code>
+
+  If `true`, `animating` will be set to `true` when `visible` changes.
+It'll wait for `stopAnimation` to be called or a CSS transition ends.
+If it's a number, `stopAnimation` will be called automatically after
+given milliseconds.
+
 - **`placement`**
   <code title="&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start&#34; | &#34;top&#34; | &#34;top-end&#34; | &#34;right-start&#34; | &#34;right&#34; | &#34;right-end&#34; | &#34;bottom-end&#34; | &#34;bottom&#34; | &#34;bottom-start&#34; | &#34;left-end&#34; | &#34;left&#34; | &#34;left-start&#34;">&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start...</code>
 
@@ -371,21 +379,24 @@ element.
 
   Whether it's visible or not.
 
+- **`unstable_animated`** <span title="Experimental">⚠️</span>
+  <code>number | boolean</code>
+
+  If `true`, `animating` will be set to `true` when `visible` changes.
+It'll wait for `stopAnimation` to be called or a CSS transition ends.
+If it's a number, `stopAnimation` will be called automatically after
+given milliseconds.
+
+- **`unstable_stopAnimation`** <span title="Experimental">⚠️</span>
+  <code>() =&#62; void</code>
+
+  Stops animation. It's called automatically if there's a CSS transition.
+It's called after given milliseconds if `animated` is a number.
+
 - **`hide`**
   <code>() =&#62; void</code>
 
   Changes the `visible` state to `false`
-
-- **`unstable_animated`** <span title="Experimental">⚠️</span>
-  <code>boolean | undefined</code>
-
-  If `true`, the hidden element attributes will be set in different
-timings to enable CSS transitions. This means that you can safely use the `.hidden` selector in the CSS to
-create transitions.
-  - When it becomes visible, immediatelly remove the `hidden` attribute,
-then add the `hidden` class.
-  - When it becomes hidden, immediatelly remove the `hidden` class, then
-add the `hidden` attribute.
 
 - **`hideOnClickOutside`**
   <code>boolean | undefined</code>

--- a/packages/reakit/src/Popover/README.md
+++ b/packages/reakit/src/Popover/README.md
@@ -74,6 +74,14 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 
   Whether it's visible or not.
 
+- **`unstable_animated`** <span title="Experimental">⚠️</span>
+  <code>number | boolean</code>
+
+  If `true`, `animating` will be set to `true` when `visible` changes.
+It'll wait for `stopAnimation` to be called or a CSS transition ends.
+If it's a number, `stopAnimation` will be called automatically after
+given milliseconds.
+
 - **`placement`**
   <code title="&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start&#34; | &#34;top&#34; | &#34;top-end&#34; | &#34;right-start&#34; | &#34;right&#34; | &#34;right-end&#34; | &#34;bottom-end&#34; | &#34;bottom&#34; | &#34;bottom-start&#34; | &#34;left-end&#34; | &#34;left&#34; | &#34;left-start&#34;">&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start...</code>
 
@@ -118,15 +126,18 @@ element.
   Whether it's visible or not.
 
 - **`unstable_animated`** <span title="Experimental">⚠️</span>
-  <code>boolean | undefined</code>
+  <code>number | boolean</code>
 
-  If `true`, the hidden element attributes will be set in different
-timings to enable CSS transitions. This means that you can safely use the `.hidden` selector in the CSS to
-create transitions.
-  - When it becomes visible, immediatelly remove the `hidden` attribute,
-then add the `hidden` class.
-  - When it becomes hidden, immediatelly remove the `hidden` class, then
-add the `hidden` attribute.
+  If `true`, `animating` will be set to `true` when `visible` changes.
+It'll wait for `stopAnimation` to be called or a CSS transition ends.
+If it's a number, `stopAnimation` will be called automatically after
+given milliseconds.
+
+- **`unstable_stopAnimation`** <span title="Experimental">⚠️</span>
+  <code>() =&#62; void</code>
+
+  Stops animation. It's called automatically if there's a CSS transition.
+It's called after given milliseconds if `animated` is a number.
 
 - **`hide`**
   <code>() =&#62; void</code>
@@ -199,15 +210,18 @@ It will be set to `false` if `modal` is `false`.
   Whether it's visible or not.
 
 - **`unstable_animated`** <span title="Experimental">⚠️</span>
-  <code>boolean | undefined</code>
+  <code>number | boolean</code>
 
-  If `true`, the hidden element attributes will be set in different
-timings to enable CSS transitions. This means that you can safely use the `.hidden` selector in the CSS to
-create transitions.
-  - When it becomes visible, immediatelly remove the `hidden` attribute,
-then add the `hidden` class.
-  - When it becomes hidden, immediatelly remove the `hidden` class, then
-add the `hidden` attribute.
+  If `true`, `animating` will be set to `true` when `visible` changes.
+It'll wait for `stopAnimation` to be called or a CSS transition ends.
+If it's a number, `stopAnimation` will be called automatically after
+given milliseconds.
+
+- **`unstable_stopAnimation`** <span title="Experimental">⚠️</span>
+  <code>() =&#62; void</code>
+
+  Stops animation. It's called automatically if there's a CSS transition.
+It's called after given milliseconds if `animated` is a number.
 
 ### `PopoverDisclosure`
 

--- a/packages/reakit/src/Tab/README.md
+++ b/packages/reakit/src/Tab/README.md
@@ -253,15 +253,18 @@ similarly to `readOnly` on form elements. In this case, only
   Whether it's visible or not.
 
 - **`unstable_animated`** <span title="Experimental">⚠️</span>
-  <code>boolean | undefined</code>
+  <code>number | boolean</code>
 
-  If `true`, the hidden element attributes will be set in different
-timings to enable CSS transitions. This means that you can safely use the `.hidden` selector in the CSS to
-create transitions.
-  - When it becomes visible, immediatelly remove the `hidden` attribute,
-then add the `hidden` class.
-  - When it becomes hidden, immediatelly remove the `hidden` class, then
-add the `hidden` attribute.
+  If `true`, `animating` will be set to `true` when `visible` changes.
+It'll wait for `stopAnimation` to be called or a CSS transition ends.
+If it's a number, `stopAnimation` will be called automatically after
+given milliseconds.
+
+- **`unstable_stopAnimation`** <span title="Experimental">⚠️</span>
+  <code>() =&#62; void</code>
+
+  Stops animation. It's called automatically if there's a CSS transition.
+It's called after given milliseconds if `animated` is a number.
 
 - **`selectedId`**
   <code>string | null</code>

--- a/packages/reakit/src/Tooltip/README.md
+++ b/packages/reakit/src/Tooltip/README.md
@@ -102,6 +102,14 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 
   Whether it's visible or not.
 
+- **`unstable_animated`** <span title="Experimental">⚠️</span>
+  <code>number | boolean</code>
+
+  If `true`, `animating` will be set to `true` when `visible` changes.
+It'll wait for `stopAnimation` to be called or a CSS transition ends.
+If it's a number, `stopAnimation` will be called automatically after
+given milliseconds.
+
 - **`placement`**
   <code title="&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start&#34; | &#34;top&#34; | &#34;top-end&#34; | &#34;right-start&#34; | &#34;right&#34; | &#34;right-end&#34; | &#34;bottom-end&#34; | &#34;bottom&#34; | &#34;bottom-start&#34; | &#34;left-end&#34; | &#34;left&#34; | &#34;left-start&#34;">&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start...</code>
 
@@ -146,15 +154,18 @@ element.
   Whether it's visible or not.
 
 - **`unstable_animated`** <span title="Experimental">⚠️</span>
-  <code>boolean | undefined</code>
+  <code>number | boolean</code>
 
-  If `true`, the hidden element attributes will be set in different
-timings to enable CSS transitions. This means that you can safely use the `.hidden` selector in the CSS to
-create transitions.
-  - When it becomes visible, immediatelly remove the `hidden` attribute,
-then add the `hidden` class.
-  - When it becomes hidden, immediatelly remove the `hidden` class, then
-add the `hidden` attribute.
+  If `true`, `animating` will be set to `true` when `visible` changes.
+It'll wait for `stopAnimation` to be called or a CSS transition ends.
+If it's a number, `stopAnimation` will be called automatically after
+given milliseconds.
+
+- **`unstable_stopAnimation`** <span title="Experimental">⚠️</span>
+  <code>() =&#62; void</code>
+
+  Stops animation. It's called automatically if there's a CSS transition.
+It's called after given milliseconds if `animated` is a number.
 
 ### `TooltipArrow`
 

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -51,6 +51,7 @@
     "react-dom": "16.9.0-alpha.0",
     "react-helmet": "5.2.1",
     "react-icons": "3.7.0",
+    "react-spring": "8.0.20",
     "reakit": "^1.0.0-beta.1",
     "reakit-system-bootstrap": "^0.5.0",
     "reakit-system-palette": "^0.5.0",

--- a/packages/website/src/components/Header.tsx
+++ b/packages/website/src/components/Header.tsx
@@ -43,7 +43,7 @@ export default function Header({ transparent }: HeaderProps) {
   const foreground = usePalette("foreground");
   const primary = usePalette("primary");
   const boxShadowColor = useFade(foreground, 0.85);
-  const dialog = useDialogState();
+  const dialog = useDialogState({ unstable_animated: true });
   const location = useLocation();
 
   React.useEffect(dialog.hide, [location.pathname]);
@@ -139,13 +139,12 @@ export default function Header({ transparent }: HeaderProps) {
             <VisuallyHidden>Open sidebar</VisuallyHidden>
           </DialogDisclosure>
           <Portal>
-            <DialogBackdrop {...dialog} />
+            <DialogBackdrop {...dialog} unstable_animated={false} />
           </Portal>
           <Dialog
             {...dialog}
             ref={ref}
             aria-label="Sidebar"
-            unstable_animated
             unstable_initialFocusRef={ref}
             className={css`
               top: 0;

--- a/packages/website/src/templates/Docs.tsx
+++ b/packages/website/src/templates/Docs.tsx
@@ -8,6 +8,7 @@ import {
   usePlaygroundState
 } from "reakit-playground";
 import * as emotion from "emotion";
+import * as spring from "react-spring";
 import createUseContext from "constate";
 import { FaUniversalAccess } from "react-icons/fa";
 import CarbonAd from "../components/CarbonAd";
@@ -100,6 +101,7 @@ const { Compiler: renderAst } = new RehypeReact({
                 modules={{
                   emotion,
                   constate: createUseContext,
+                  "react-spring": spring,
                   "./UniversalAccess": FaUniversalAccess
                 }}
                 {...state}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,6 +1080,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.3.1":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
+  integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.2.2", "@babel/template@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.0.tgz#12474e9c077bae585c5d835a95c0b0b790c25c8b"
@@ -12801,7 +12808,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@15.7.2, prop-types@^15.5.4, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -13142,6 +13149,14 @@ react-side-effect@^1.1.0:
   dependencies:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
+
+react-spring@8.0.20:
+  version "8.0.20"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-8.0.20.tgz#e25967f6059364b09cf0339168d73014e87c9d17"
+  integrity sha512-40ZUQ5uI5YHsoQWLPchWNcEUh6zQ6qvcVDeTI2vW10ldoCN3PvDsII9wBH2xEbMl+BQvYmHzGdfLTQxPxJWGnQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    prop-types "^15.5.8"
 
 react-test-renderer@16.9.0-alpha.0:
   version "16.9.0-alpha.0"


### PR DESCRIPTION
This PR adds an `unstable_animated` option to `useHiddenState` and its derivatives. The goal is to support animations via CSS transitions and `react-spring`.

```jsx
import { useHiddenState, Hidden } from "reakit";
import styled from "styled-components";

const AnimatedHidden = styled(Hidden)`
  opacity: 1;
  transition: opacity 1500ms;
  &.hidden {
    opacity: 0;
  }
`;

function App() {
  const hidden = useHiddenState({ unstable_animated: true }); 
  return <Hidden {...hidden} />;
}
```

### Changes

- `unstable_animated` should be passed to `useHiddenState` instead of `Hidden`.

  **Before:**
  ```jsx
  const hidden = useHiddenState();
  <Hidden {...hidden} unstable_animated />
  ```

  **After:**
  ```jsx
  const hidden = useHiddenState({ unstable_animated: true });
  <Hidden {...hidden} />
  ```