### PR TITLE
feat: Remove z-index and extra styles from `Dialog` and `DialogBackdrop`

### DIFF
--- a/packages/reakit-system-bootstrap/src/Dialog.ts
+++ b/packages/reakit-system-bootstrap/src/Dialog.ts
@@ -46,6 +46,7 @@ export function useDialogProps(
     outline: 0;
     border: 1px solid ${borderColor};
     color: ${color};
+    z-index: 999;
 
     &:focus {
       box-shadow: 0 0 0 0.2em ${boxShadowColor};
@@ -64,6 +65,12 @@ export function useDialogBackdropProps(
 ): DialogBackdropHTMLProps {
   const dialogBackdrop = css`
     background-color: rgba(0, 0, 0, 0.5);
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 999;
   `;
 
   return { ...htmlProps, className: cx(dialogBackdrop, htmlProps.className) };

--- a/packages/reakit-system-bootstrap/src/Tooltip.ts
+++ b/packages/reakit-system-bootstrap/src/Tooltip.ts
@@ -28,6 +28,7 @@ export function useTooltipProps(
     font-size: 0.8em;
     padding: 0.5rem;
     border-radius: 0.25rem;
+    z-index: 999;
 
     & > .arrow {
       background-color: transparent;

--- a/packages/reakit/src/Dialog/Dialog.tsx
+++ b/packages/reakit/src/Dialog/Dialog.tsx
@@ -127,7 +127,6 @@ export const useDialog = unstable_createHook<DialogOptions, DialogHTMLProps>({
       ref: htmlRef,
       onKeyDown: htmlOnKeyDown,
       unstable_wrap: htmlWrap,
-      style: htmlStyle,
       ...htmlProps
     }
   ) {
@@ -177,7 +176,6 @@ export const useDialog = unstable_createHook<DialogOptions, DialogHTMLProps>({
       tabIndex: -1,
       "aria-modal": options.modal,
       "data-dialog": true,
-      style: { zIndex: 999, ...htmlStyle },
       onKeyDown: useAllCallbacks(onKeyDown, htmlOnKeyDown),
       unstable_wrap: usePipe(wrapChildren, htmlWrap),
       ...htmlProps

--- a/packages/reakit/src/Dialog/DialogBackdrop.ts
+++ b/packages/reakit/src/Dialog/DialogBackdrop.ts
@@ -18,19 +18,10 @@ export const useDialogBackdrop = unstable_createHook<
   compose: useHidden,
   useState: useDialogState,
 
-  useProps(_, { style: htmlStyle, ...htmlProps }) {
+  useProps(_, htmlProps) {
     return {
       id: undefined,
       role: "presentation",
-      style: {
-        position: "fixed",
-        top: 0,
-        right: 0,
-        bottom: 0,
-        left: 0,
-        zIndex: 998,
-        ...htmlStyle
-      },
       ...htmlProps
     };
   }

--- a/packages/reakit/src/Dialog/__tests__/Dialog-test.tsx
+++ b/packages/reakit/src/Dialog/__tests__/Dialog-test.tsx
@@ -23,7 +23,7 @@ test("render", () => {
           hidden=""
           id="dialog"
           role="dialog"
-          style="display: none; z-index: 999;"
+          style="display: none;"
           tabindex="-1"
         >
           dialog
@@ -57,7 +57,6 @@ test("render visible", () => {
           data-dialog="true"
           id="dialog"
           role="dialog"
-          style="z-index: 999;"
           tabindex="-1"
         >
           dialog
@@ -90,7 +89,7 @@ test("render non-modal", () => {
           hidden=""
           id="dialog"
           role="dialog"
-          style="display: none; z-index: 999;"
+          style="display: none;"
           tabindex="-1"
         >
           test

--- a/packages/reakit/src/Dialog/__tests__/DialogBackdrop-test.tsx
+++ b/packages/reakit/src/Dialog/__tests__/DialogBackdrop-test.tsx
@@ -11,7 +11,7 @@ test("render", () => {
           class="hidden"
           hidden=""
           role="presentation"
-          style="display: none; position: fixed; top: 0px; right: 0px; bottom: 0px; left: 0px; z-index: 998;"
+          style="display: none;"
         />
       </div>
     </body>
@@ -25,7 +25,6 @@ test("render visible", () => {
       <div>
         <div
           role="presentation"
-          style="position: fixed; top: 0px; right: 0px; bottom: 0px; left: 0px; z-index: 998;"
         />
       </div>
     </body>

--- a/packages/reakit/src/Menu/__tests__/Menu-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/Menu-test.tsx
@@ -32,7 +32,7 @@ test("render", () => {
           hidden=""
           id="hidden"
           role="menu"
-          style="display: none; z-index: 999;"
+          style="display: none;"
           tabindex="-1"
         />
       </div>

--- a/packages/reakit/src/Popover/__tests__/Popover-test.tsx
+++ b/packages/reakit/src/Popover/__tests__/Popover-test.tsx
@@ -20,7 +20,7 @@ test("render", () => {
           hidden=""
           id="popover"
           role="dialog"
-          style="display: none; z-index: 999;"
+          style="display: none;"
           tabindex="-1"
         >
           popover
@@ -45,7 +45,6 @@ test("render visible", () => {
           data-dialog="true"
           id="popover"
           role="dialog"
-          style="z-index: 999;"
           tabindex="-1"
         >
           popover
@@ -72,7 +71,7 @@ test("render non-modal", () => {
           hidden=""
           id="popover"
           role="dialog"
-          style="display: none; z-index: 999;"
+          style="display: none;"
           tabindex="-1"
         >
           test

--- a/packages/reakit/src/Popover/__tests__/PopoverBackdrop-test.tsx
+++ b/packages/reakit/src/Popover/__tests__/PopoverBackdrop-test.tsx
@@ -11,7 +11,7 @@ test("render", () => {
           class="hidden"
           hidden=""
           role="presentation"
-          style="display: none; position: fixed; top: 0px; right: 0px; bottom: 0px; left: 0px; z-index: 998;"
+          style="display: none;"
         />
       </div>
     </body>
@@ -25,7 +25,6 @@ test("render visible", () => {
       <div>
         <div
           role="presentation"
-          style="position: fixed; top: 0px; right: 0px; bottom: 0px; left: 0px; z-index: 998;"
         />
       </div>
     </body>

--- a/packages/reakit/src/Tooltip/Tooltip.tsx
+++ b/packages/reakit/src/Tooltip/Tooltip.tsx
@@ -37,7 +37,6 @@ export const useTooltip = unstable_createHook<TooltipOptions, TooltipHTMLProps>(
         style: {
           ...options.unstable_popoverStyles,
           pointerEvents: "none",
-          zIndex: 999,
           ...htmlStyle
         },
         unstable_wrap: usePipe(wrap, htmlWrap),

--- a/packages/reakit/src/Tooltip/__tests__/Tooltip-test.tsx
+++ b/packages/reakit/src/Tooltip/__tests__/Tooltip-test.tsx
@@ -14,7 +14,7 @@ test("render", () => {
           class="hidden"
           hidden=""
           role="tooltip"
-          style="display: none; pointer-events: none; z-index: 999;"
+          style="display: none; pointer-events: none;"
         >
           tooltip
         </div>
@@ -33,7 +33,7 @@ test("render visible", () => {
       >
         <div
           role="tooltip"
-          style="pointer-events: none; z-index: 999;"
+          style="pointer-events: none;"
         >
           tooltip
         </div>


### PR DESCRIPTION
Closes #366

### BREAKING CHANGES

- Removed extra styles from `Dialog` and `DialogBackdrop` and all their derivative components. Also removed default `z-index` from `Tooltip`. These styles have been moved to the `reakit-system-bootstrap` package. If you're not using this system package, you should apply the styles manually.

  **Before:**
  ```jsx
  <DialogBackdrop />
  <Dialog />
  <Popover />
  <Menu />
  <Tooltip />
  ```

  **After:**
  ```jsx
  <DialogBackdrop
    style={{
      position: "fixed",
      top: 0,
      right: 0,
      bottom: 0,
      left: 0,
      zIndex: 998
    }}
  />
  <Dialog style={{ zIndex: 999 }} />
  <Popover style={{ zIndex: 999 }} />
  <Menu style={{ zIndex: 999 }} />
  <Tooltip style={{ zIndex: 999 }} />
  ```