### PR TITLE
Add previous/next links on documentation for better navigation

### DIFF
--- a/packages/website/gatsby-node.js
+++ b/packages/website/gatsby-node.js
@@ -6,6 +6,7 @@
 const { resolve, relative, dirname } = require("path");
 const rehype = require("rehype");
 const { repository } = require("./package.json");
+const getAdjacentPaths = require("./src/utils/getAdjacentPaths.ts");
 
 exports.createPages = ({ actions, graphql }) => {
   const { createPage, createRedirect } = actions;
@@ -25,15 +26,33 @@ exports.createPages = ({ actions, graphql }) => {
           }
         }
       }
+      allDocsYaml {
+        edges {
+          node {
+            section
+            paths
+          }
+        }
+      }
     }
   `).then(result => {
     if (result.errors) {
       return Promise.reject(result.errors);
     }
+    const flatArray = [];
+    result.data.allDocsYaml.edges.forEach(async ({ node }) => {
+      node.paths.forEach(path => flatArray.push(path));
+    });
 
     return result.data.allMarkdownRemark.edges.forEach(async ({ node }) => {
       const { frontmatter, fileAbsolutePath, tableOfContents } = node;
       const { path, redirect_from } = frontmatter;
+
+      const currentIndexInFlatArray = flatArray.findIndex(el => el === path);
+      const { nextPagePath, prevPagePath } = getAdjacentPaths(
+        flatArray,
+        currentIndexInFlatArray
+      );
 
       const root = `${__dirname}/../..`;
       const repo = `${repository.replace(/(\/tree.+|\/)$/, "")}/tree/master/`;
@@ -49,7 +68,9 @@ exports.createPages = ({ actions, graphql }) => {
         context: {
           sourceUrl,
           readmeUrl,
-          tableOfContentsAst
+          tableOfContentsAst,
+          nextPagePath,
+          prevPagePath
         }
       });
 

--- a/packages/website/src/components/DocsBackNext.tsx
+++ b/packages/website/src/components/DocsBackNext.tsx
@@ -1,0 +1,113 @@
+import * as React from "react";
+import { useStaticQuery, graphql, Link } from "gatsby";
+import { Separator } from "reakit/Separator";
+import { css } from "emotion";
+import { usePalette, useLighten } from "reakit-system-palette/utils";
+import { VisuallyHidden } from "reakit/VisuallyHidden";
+
+type DocsBackNextProps = { nextPath: string; prevPath: string };
+
+type Data = {
+  allMarkdownRemark: {
+    nodes: Array<{
+      title: string;
+      frontmatter: {
+        path: string;
+      };
+    }>;
+  };
+};
+
+function useDocsBackNextCSS() {
+  const background = usePalette("background");
+  const foreground = usePalette("foreground");
+  const primary = usePalette("primary");
+  const currentBackgroundColor = useLighten(primary, 0.85);
+
+  const docsNavigation = css`
+    background-color: ${background};
+    color: ${foreground};
+    nav {
+      margin: 3em 0 0 0;
+    }
+    ul {
+      padding: 0;
+      display: flex;
+    }
+    li {
+      list-style: none;
+
+      &.next {
+        margin-left: auto;
+      }
+    }
+    a {
+      display: flex;
+      align-items: center;
+      padding: 0.5em 1em 0.5em 1em;
+      text-decoration: none;
+      color: inherit;
+      cursor: pointer;
+
+      &:focus {
+        outline: none;
+        background-color: ${currentBackgroundColor};
+      }
+
+      &:hover {
+        color: ${primary};
+      }
+    }
+  `;
+
+  return docsNavigation;
+}
+
+export default function DocsBackNext({
+  nextPath,
+  prevPath
+}: DocsBackNextProps) {
+  const data: Data = useStaticQuery(query);
+  const className = useDocsBackNextCSS();
+  const findMeta = (path: string) =>
+    data.allMarkdownRemark.nodes.find(node => node.frontmatter.path === path)!;
+  const getTitle = (path: string) => findMeta(path).title;
+  return (
+    <div className={className}>
+      <nav>
+        <Separator orientation="horizontal" />
+        <ul>
+          {prevPath && (
+            <li>
+              <Link to={prevPath}>
+                <VisuallyHidden>Previous </VisuallyHidden>
+                {getTitle(prevPath)}
+              </Link>
+            </li>
+          )}
+          {nextPath && (
+            <li className="next">
+              <Link to={nextPath}>
+                <VisuallyHidden>Next </VisuallyHidden>
+                {getTitle(nextPath)}
+              </Link>
+            </li>
+          )}
+        </ul>
+      </nav>
+    </div>
+  );
+}
+
+const query = graphql`
+  query DocsBackNextQuery {
+    allMarkdownRemark {
+      nodes {
+        title
+        frontmatter {
+          path
+        }
+      }
+    }
+  }
+`;

--- a/packages/website/src/templates/Docs.tsx
+++ b/packages/website/src/templates/Docs.tsx
@@ -20,8 +20,16 @@ import TestTube from "../icons/TestTube";
 import Heading from "../components/Heading";
 import SEO from "../components/SEO";
 import track from "../utils/track";
+import DocsBackNext from "../components/DocsBackNext";
 
 type DocsProps = {
+  pageContext: {
+    sourceUrl: string;
+    readmeUrl: string;
+    tableOfContentsAst: string;
+    nextPagePath: string;
+    prevPagePath: string;
+  };
   data: {
     markdownRemark: {
       title: string;
@@ -129,16 +137,18 @@ const { Compiler: renderAst } = new RehypeReact({
   }
 });
 
-export default function Docs({ data }: DocsProps) {
+export default function Docs({ data, pageContext }: DocsProps) {
   const {
     markdownRemark: { title, htmlAst, excerpt }
   } = data;
+  const { nextPagePath, prevPagePath } = pageContext;
 
   return (
     <>
       <SEO title={title} description={excerpt} />
       <Heading>{title}</Heading>
       {renderAst(htmlAst)}
+      <DocsBackNext nextPath={nextPagePath} prevPath={prevPagePath} />
     </>
   );
 }

--- a/packages/website/src/utils/getAdjacentPaths.ts
+++ b/packages/website/src/utils/getAdjacentPaths.ts
@@ -1,0 +1,7 @@
+// @ts-ignore
+module.exports = function getAdjacentPaths(arr, index) {
+  return {
+    nextPagePath: arr[index + 1] ? arr[index + 1] : null,
+    prevPagePath: arr[index - 1] ? arr[index - 1] : null
+  };
+};


### PR DESCRIPTION
Explain the motivation for making this change and try to link to an open issue for more information.

Tackles in `Previous/next links on documentation for better navigation` in #351

**Does this PR introduce a breaking change?**
No

- Added `nextPagePath` & `prevPagePath` to the context of each page in  `gatsby-node.js`
- Added a helper function `getAdjacentPaths.ts` in an attempt to keep `gatsby-node.js` a little tidier  
- Added a component for the links `DocsBackNext.tsx` & used it in `Docs.tsx`
