### PR TITLE
fix: Always focus `Rover` when calling `rover.{move|first|last}()`

### DIFF
--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -588,6 +588,12 @@ similarly to `readOnly` on form elements. In this case, only
 
   Defines the orientation of the rover list.
 
+- **`unstable_moves`** <span title="Experimental">⚠️</span>
+  <code>number</code>
+
+  Stores the number of moves that have been made by calling `move`, `next`,
+`previous`, `first` or `last`.
+
 - **`currentId`**
   <code>string | null</code>
 
@@ -695,6 +701,12 @@ array.
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
   Defines the orientation of the rover list.
+
+- **`unstable_moves`** <span title="Experimental">⚠️</span>
+  <code>number</code>
+
+  Stores the number of moves that have been made by calling `move`, `next`,
+`previous`, `first` or `last`.
 
 - **`currentId`**
   <code>string | null</code>
@@ -817,6 +829,12 @@ array.
   <code>() =&#62; void</code>
 
   Moves focus to the previous element.
+
+- **`unstable_moves`** <span title="Experimental">⚠️</span>
+  <code>number</code>
+
+  Stores the number of moves that have been made by calling `move`, `next`,
+`previous`, `first` or `last`.
 
 - **`register`**
   <code>(id: string, ref: RefObject&#60;HTMLElement&#62;) =&#62; void</code>

--- a/packages/reakit/src/Radio/README.md
+++ b/packages/reakit/src/Radio/README.md
@@ -94,6 +94,12 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 
   The current focused element ID.
 
+- **`unstable_moves`** <span title="Experimental">⚠️</span>
+  <code>number</code>
+
+  Stores the number of moves that have been made by calling `move`, `next`,
+`previous`, `first` or `last`.
+
 - **`stops`**
   <code>Stop[]</code>
 

--- a/packages/reakit/src/Radio/__tests__/RadioState-test.ts
+++ b/packages/reakit/src/Radio/__tests__/RadioState-test.ts
@@ -12,6 +12,7 @@ test("initial state", () => {
       "loop": true,
       "state": undefined,
       "stops": Array [],
+      "unstable_moves": 0,
       "unstable_pastId": null,
     }
   `);

--- a/packages/reakit/src/Rover/README.md
+++ b/packages/reakit/src/Rover/README.md
@@ -115,6 +115,12 @@ similarly to `readOnly` on form elements. In this case, only
 
   Defines the orientation of the rover list.
 
+- **`unstable_moves`** <span title="Experimental">⚠️</span>
+  <code>number</code>
+
+  Stores the number of moves that have been made by calling `move`, `next`,
+`previous`, `first` or `last`.
+
 - **`currentId`**
   <code>string | null</code>
 

--- a/packages/reakit/src/Rover/Rover.ts
+++ b/packages/reakit/src/Rover/Rover.ts
@@ -15,7 +15,7 @@ import {
 import { RoverStateReturn, useRoverState } from "./RoverState";
 
 export type RoverOptions = TabbableOptions &
-  Pick<Partial<RoverStateReturn>, "orientation"> &
+  Pick<Partial<RoverStateReturn>, "orientation" | "unstable_moves"> &
   Pick<
     RoverStateReturn,
     | "stops"
@@ -80,10 +80,10 @@ export const useRover = createHook<RoverOptions, RoverHTMLProps>({
         );
         return;
       }
-      if (focused) {
+      if (document.activeElement !== ref.current && focused) {
         ref.current.focus();
       }
-    }, [focused]);
+    }, [focused, options.unstable_moves]);
 
     const onFocus = React.useCallback(() => options.move(stopId), [
       options.move,

--- a/packages/reakit/src/Rover/__tests__/RoverState-test.ts
+++ b/packages/reakit/src/Rover/__tests__/RoverState-test.ts
@@ -19,13 +19,14 @@ function createRef(id: string) {
 test("initial state", () => {
   const result = render();
   expect(result.current).toMatchInlineSnapshot(`
-    Object {
-      "currentId": null,
-      "loop": false,
-      "stops": Array [],
-      "unstable_pastId": null,
-    }
-  `);
+            Object {
+              "currentId": null,
+              "loop": false,
+              "stops": Array [],
+              "unstable_moves": 0,
+              "unstable_pastId": null,
+            }
+      `);
 });
 
 test("initial state activeRef", () => {
@@ -33,13 +34,14 @@ test("initial state activeRef", () => {
   expect(result.current).toMatchInlineSnapshot(
     { currentId: "a" },
     `
-    Object {
-      "currentId": "a",
-      "loop": false,
-      "stops": Array [],
-      "unstable_pastId": null,
-    }
-  `
+            Object {
+              "currentId": "a",
+              "loop": false,
+              "stops": Array [],
+              "unstable_moves": 0,
+              "unstable_pastId": null,
+            }
+      `
   );
 });
 
@@ -48,13 +50,14 @@ test("initial state loop", () => {
   expect(result.current).toMatchInlineSnapshot(
     { loop: true },
     `
-    Object {
-      "currentId": null,
-      "loop": true,
-      "stops": Array [],
-      "unstable_pastId": null,
-    }
-  `
+            Object {
+              "currentId": null,
+              "loop": true,
+              "stops": Array [],
+              "unstable_moves": 0,
+              "unstable_pastId": null,
+            }
+      `
   );
 });
 
@@ -63,14 +66,15 @@ test("initial state orientation", () => {
   expect(result.current).toMatchInlineSnapshot(
     { orientation: "vertical" },
     `
-    Object {
-      "currentId": null,
-      "loop": false,
-      "orientation": "vertical",
-      "stops": Array [],
-      "unstable_pastId": null,
-    }
-  `
+            Object {
+              "currentId": null,
+              "loop": false,
+              "orientation": "vertical",
+              "stops": Array [],
+              "unstable_moves": 0,
+              "unstable_pastId": null,
+            }
+      `
   );
 });
 
@@ -78,22 +82,23 @@ test("register", () => {
   const result = render();
   act(() => result.current.register("a", createRef("a")));
   expect(result.current).toMatchInlineSnapshot(`
-    Object {
-      "currentId": null,
-      "loop": false,
-      "stops": Array [
-        Object {
-          "id": "a",
-          "ref": Object {
-            "current": <div
-              id="a"
-            />,
-          },
-        },
-      ],
-      "unstable_pastId": null,
-    }
-  `);
+            Object {
+              "currentId": null,
+              "loop": false,
+              "stops": Array [
+                Object {
+                  "id": "a",
+                  "ref": Object {
+                    "current": <div
+                      id="a"
+                    />,
+                  },
+                },
+              ],
+              "unstable_moves": 0,
+              "unstable_pastId": null,
+            }
+      `);
 });
 
 test("register already registered", () => {
@@ -102,44 +107,46 @@ test("register already registered", () => {
   act(() => result.current.register("a", ref));
   act(() => result.current.register("a", ref));
   expect(result.current).toMatchInlineSnapshot(`
-    Object {
-      "currentId": null,
-      "loop": false,
-      "stops": Array [
-        Object {
-          "id": "a",
-          "ref": Object {
-            "current": <div
-              id="a"
-            />,
-          },
-        },
-      ],
-      "unstable_pastId": null,
-    }
-  `);
+            Object {
+              "currentId": null,
+              "loop": false,
+              "stops": Array [
+                Object {
+                  "id": "a",
+                  "ref": Object {
+                    "current": <div
+                      id="a"
+                    />,
+                  },
+                },
+              ],
+              "unstable_moves": 0,
+              "unstable_pastId": null,
+            }
+      `);
 });
 
 test("register currentId", () => {
   const result = render({ currentId: "a" });
   act(() => result.current.register("a", createRef("a")));
   expect(result.current).toMatchInlineSnapshot(`
-    Object {
-      "currentId": "a",
-      "loop": false,
-      "stops": Array [
-        Object {
-          "id": "a",
-          "ref": Object {
-            "current": <div
-              id="a"
-            />,
-          },
-        },
-      ],
-      "unstable_pastId": null,
-    }
-  `);
+            Object {
+              "currentId": "a",
+              "loop": false,
+              "stops": Array [
+                Object {
+                  "id": "a",
+                  "ref": Object {
+                    "current": <div
+                      id="a"
+                    />,
+                  },
+                },
+              ],
+              "unstable_moves": 0,
+              "unstable_pastId": null,
+            }
+      `);
 });
 
 test("unregister", () => {
@@ -147,26 +154,28 @@ test("unregister", () => {
   act(() => result.current.register("a", createRef("a")));
   act(() => result.current.unregister("a"));
   expect(result.current).toMatchInlineSnapshot(`
-    Object {
-      "currentId": null,
-      "loop": false,
-      "stops": Array [],
-      "unstable_pastId": null,
-    }
-  `);
+            Object {
+              "currentId": null,
+              "loop": false,
+              "stops": Array [],
+              "unstable_moves": 0,
+              "unstable_pastId": null,
+            }
+      `);
 });
 
 test("unregister inexistent", () => {
   const result = render();
   act(() => result.current.unregister("a"));
   expect(result.current).toMatchInlineSnapshot(`
-    Object {
-      "currentId": null,
-      "loop": false,
-      "stops": Array [],
-      "unstable_pastId": null,
-    }
-  `);
+            Object {
+              "currentId": null,
+              "loop": false,
+              "stops": Array [],
+              "unstable_moves": 0,
+              "unstable_pastId": null,
+            }
+      `);
 });
 
 test("unregister currentId", () => {
@@ -179,13 +188,14 @@ test("unregister currentId", () => {
       stops: []
     },
     `
-    Object {
-      "currentId": null,
-      "loop": false,
-      "stops": Array [],
-      "unstable_pastId": null,
-    }
-  `
+            Object {
+              "currentId": null,
+              "loop": false,
+              "stops": Array [],
+              "unstable_moves": 0,
+              "unstable_pastId": null,
+            }
+      `
   );
 });
 
@@ -201,22 +211,23 @@ test("unregister pastId", () => {
       unstable_pastId: null
     },
     `
-    Object {
-      "currentId": "b",
-      "loop": false,
-      "stops": Array [
-        Object {
-          "id": "b",
-          "ref": Object {
-            "current": <div
-              id="b"
-            />,
-          },
-        },
-      ],
-      "unstable_pastId": null,
-    }
-  `
+            Object {
+              "currentId": "b",
+              "loop": false,
+              "stops": Array [
+                Object {
+                  "id": "b",
+                  "ref": Object {
+                    "current": <div
+                      id="b"
+                    />,
+                  },
+                },
+              ],
+              "unstable_moves": 1,
+              "unstable_pastId": null,
+            }
+      `
   );
 });
 
@@ -229,22 +240,23 @@ test("move", () => {
       currentId: "a"
     },
     `
-    Object {
-      "currentId": "a",
-      "loop": false,
-      "stops": Array [
-        Object {
-          "id": "a",
-          "ref": Object {
-            "current": <div
-              id="a"
-            />,
-          },
-        },
-      ],
-      "unstable_pastId": null,
-    }
-  `
+            Object {
+              "currentId": "a",
+              "loop": false,
+              "stops": Array [
+                Object {
+                  "id": "a",
+                  "ref": Object {
+                    "current": <div
+                      id="a"
+                    />,
+                  },
+                },
+              ],
+              "unstable_moves": 1,
+              "unstable_pastId": null,
+            }
+      `
   );
 });
 
@@ -260,30 +272,31 @@ test("move twice", () => {
       unstable_pastId: "a"
     },
     `
-    Object {
-      "currentId": "b",
-      "loop": false,
-      "stops": Array [
-        Object {
-          "id": "a",
-          "ref": Object {
-            "current": <div
-              id="a"
-            />,
-          },
-        },
-        Object {
-          "id": "b",
-          "ref": Object {
-            "current": <div
-              id="b"
-            />,
-          },
-        },
-      ],
-      "unstable_pastId": "a",
-    }
-  `
+            Object {
+              "currentId": "b",
+              "loop": false,
+              "stops": Array [
+                Object {
+                  "id": "a",
+                  "ref": Object {
+                    "current": <div
+                      id="a"
+                    />,
+                  },
+                },
+                Object {
+                  "id": "b",
+                  "ref": Object {
+                    "current": <div
+                      id="b"
+                    />,
+                  },
+                },
+              ],
+              "unstable_moves": 2,
+              "unstable_pastId": "a",
+            }
+      `
   );
 });
 
@@ -299,30 +312,31 @@ test("move to the same ref", () => {
       unstable_pastId: null
     },
     `
-    Object {
-      "currentId": "b",
-      "loop": false,
-      "stops": Array [
-        Object {
-          "id": "a",
-          "ref": Object {
-            "current": <div
-              id="a"
-            />,
-          },
-        },
-        Object {
-          "id": "b",
-          "ref": Object {
-            "current": <div
-              id="b"
-            />,
-          },
-        },
-      ],
-      "unstable_pastId": null,
-    }
-  `
+            Object {
+              "currentId": "b",
+              "loop": false,
+              "stops": Array [
+                Object {
+                  "id": "a",
+                  "ref": Object {
+                    "current": <div
+                      id="a"
+                    />,
+                  },
+                },
+                Object {
+                  "id": "b",
+                  "ref": Object {
+                    "current": <div
+                      id="b"
+                    />,
+                  },
+                },
+              ],
+              "unstable_moves": 2,
+              "unstable_pastId": null,
+            }
+      `
   );
 });
 
@@ -338,30 +352,31 @@ test("move to null", () => {
       unstable_pastId: "b"
     },
     `
-    Object {
-      "currentId": null,
-      "loop": false,
-      "stops": Array [
-        Object {
-          "id": "a",
-          "ref": Object {
-            "current": <div
-              id="a"
-            />,
-          },
-        },
-        Object {
-          "id": "b",
-          "ref": Object {
-            "current": <div
-              id="b"
-            />,
-          },
-        },
-      ],
-      "unstable_pastId": "b",
-    }
-  `
+            Object {
+              "currentId": null,
+              "loop": false,
+              "stops": Array [
+                Object {
+                  "id": "a",
+                  "ref": Object {
+                    "current": <div
+                      id="a"
+                    />,
+                  },
+                },
+                Object {
+                  "id": "b",
+                  "ref": Object {
+                    "current": <div
+                      id="b"
+                    />,
+                  },
+                },
+              ],
+              "unstable_moves": 2,
+              "unstable_pastId": "b",
+            }
+      `
   );
 });
 
@@ -378,38 +393,39 @@ test("next", () => {
       unstable_pastId: "a"
     },
     `
-    Object {
-      "currentId": "b",
-      "loop": false,
-      "stops": Array [
-        Object {
-          "id": "a",
-          "ref": Object {
-            "current": <div
-              id="a"
-            />,
-          },
-        },
-        Object {
-          "id": "b",
-          "ref": Object {
-            "current": <div
-              id="b"
-            />,
-          },
-        },
-        Object {
-          "id": "c",
-          "ref": Object {
-            "current": <div
-              id="c"
-            />,
-          },
-        },
-      ],
-      "unstable_pastId": "a",
-    }
-  `
+            Object {
+              "currentId": "b",
+              "loop": false,
+              "stops": Array [
+                Object {
+                  "id": "a",
+                  "ref": Object {
+                    "current": <div
+                      id="a"
+                    />,
+                  },
+                },
+                Object {
+                  "id": "b",
+                  "ref": Object {
+                    "current": <div
+                      id="b"
+                    />,
+                  },
+                },
+                Object {
+                  "id": "c",
+                  "ref": Object {
+                    "current": <div
+                      id="c"
+                    />,
+                  },
+                },
+              ],
+              "unstable_moves": 2,
+              "unstable_pastId": "a",
+            }
+      `
   );
 });
 
@@ -457,6 +473,7 @@ test("next thrice", () => {
           },
         },
       ],
+      "unstable_moves": 3,
       "unstable_pastId": "b",
     }
   `
@@ -478,38 +495,39 @@ test("next thrice loop", () => {
       unstable_pastId: "c"
     },
     `
-    Object {
-      "currentId": "a",
-      "loop": true,
-      "stops": Array [
-        Object {
-          "id": "a",
-          "ref": Object {
-            "current": <div
-              id="a"
-            />,
-          },
-        },
-        Object {
-          "id": "b",
-          "ref": Object {
-            "current": <div
-              id="b"
-            />,
-          },
-        },
-        Object {
-          "id": "c",
-          "ref": Object {
-            "current": <div
-              id="c"
-            />,
-          },
-        },
-      ],
-      "unstable_pastId": "c",
-    }
-  `
+            Object {
+              "currentId": "a",
+              "loop": true,
+              "stops": Array [
+                Object {
+                  "id": "a",
+                  "ref": Object {
+                    "current": <div
+                      id="a"
+                    />,
+                  },
+                },
+                Object {
+                  "id": "b",
+                  "ref": Object {
+                    "current": <div
+                      id="b"
+                    />,
+                  },
+                },
+                Object {
+                  "id": "c",
+                  "ref": Object {
+                    "current": <div
+                      id="c"
+                    />,
+                  },
+                },
+              ],
+              "unstable_moves": 4,
+              "unstable_pastId": "c",
+            }
+      `
   );
 });
 
@@ -526,38 +544,39 @@ test("previous", () => {
       unstable_pastId: "b"
     },
     `
-    Object {
-      "currentId": "a",
-      "loop": false,
-      "stops": Array [
         Object {
-          "id": "a",
-          "ref": Object {
-            "current": <div
-              id="a"
-            />,
-          },
-        },
-        Object {
-          "id": "b",
-          "ref": Object {
-            "current": <div
-              id="b"
-            />,
-          },
-        },
-        Object {
-          "id": "c",
-          "ref": Object {
-            "current": <div
-              id="c"
-            />,
-          },
-        },
-      ],
-      "unstable_pastId": "b",
-    }
-  `
+          "currentId": "a",
+          "loop": false,
+          "stops": Array [
+            Object {
+              "id": "a",
+              "ref": Object {
+                "current": <div
+                  id="a"
+                />,
+              },
+            },
+            Object {
+              "id": "b",
+              "ref": Object {
+                "current": <div
+                  id="b"
+                />,
+              },
+            },
+            Object {
+              "id": "c",
+              "ref": Object {
+                "current": <div
+                  id="c"
+                />,
+              },
+            },
+          ],
+          "unstable_moves": 2,
+          "unstable_pastId": "b",
+        }
+    `
   );
 });
 
@@ -574,38 +593,39 @@ test("previous loop", () => {
       unstable_pastId: "a"
     },
     `
-    Object {
-      "currentId": "c",
-      "loop": true,
-      "stops": Array [
         Object {
-          "id": "a",
-          "ref": Object {
-            "current": <div
-              id="a"
-            />,
-          },
-        },
-        Object {
-          "id": "b",
-          "ref": Object {
-            "current": <div
-              id="b"
-            />,
-          },
-        },
-        Object {
-          "id": "c",
-          "ref": Object {
-            "current": <div
-              id="c"
-            />,
-          },
-        },
-      ],
-      "unstable_pastId": "a",
-    }
-  `
+          "currentId": "c",
+          "loop": true,
+          "stops": Array [
+            Object {
+              "id": "a",
+              "ref": Object {
+                "current": <div
+                  id="a"
+                />,
+              },
+            },
+            Object {
+              "id": "b",
+              "ref": Object {
+                "current": <div
+                  id="b"
+                />,
+              },
+            },
+            Object {
+              "id": "c",
+              "ref": Object {
+                "current": <div
+                  id="c"
+                />,
+              },
+            },
+          ],
+          "unstable_moves": 2,
+          "unstable_pastId": "a",
+        }
+    `
   );
 });
 
@@ -620,30 +640,31 @@ test("first", () => {
       unstable_pastId: null
     },
     `
-    Object {
-      "currentId": "a",
-      "loop": false,
-      "stops": Array [
-        Object {
-          "id": "a",
-          "ref": Object {
-            "current": <div
-              id="a"
-            />,
-          },
-        },
-        Object {
-          "id": "b",
-          "ref": Object {
-            "current": <div
-              id="b"
-            />,
-          },
-        },
-      ],
-      "unstable_pastId": null,
-    }
-  `
+            Object {
+              "currentId": "a",
+              "loop": false,
+              "stops": Array [
+                Object {
+                  "id": "a",
+                  "ref": Object {
+                    "current": <div
+                      id="a"
+                    />,
+                  },
+                },
+                Object {
+                  "id": "b",
+                  "ref": Object {
+                    "current": <div
+                      id="b"
+                    />,
+                  },
+                },
+              ],
+              "unstable_moves": 1,
+              "unstable_pastId": null,
+            }
+      `
   );
 });
 
@@ -658,30 +679,31 @@ test("last", () => {
       unstable_pastId: null
     },
     `
-    Object {
-      "currentId": "b",
-      "loop": false,
-      "stops": Array [
-        Object {
-          "id": "a",
-          "ref": Object {
-            "current": <div
-              id="a"
-            />,
-          },
-        },
-        Object {
-          "id": "b",
-          "ref": Object {
-            "current": <div
-              id="b"
-            />,
-          },
-        },
-      ],
-      "unstable_pastId": null,
-    }
-  `
+            Object {
+              "currentId": "b",
+              "loop": false,
+              "stops": Array [
+                Object {
+                  "id": "a",
+                  "ref": Object {
+                    "current": <div
+                      id="a"
+                    />,
+                  },
+                },
+                Object {
+                  "id": "b",
+                  "ref": Object {
+                    "current": <div
+                      id="b"
+                    />,
+                  },
+                },
+              ],
+              "unstable_moves": 1,
+              "unstable_pastId": null,
+            }
+      `
   );
 });
 
@@ -693,13 +715,14 @@ test("orientate", () => {
       orientation: "horizontal"
     },
     `
-    Object {
-      "currentId": null,
-      "loop": false,
-      "orientation": "horizontal",
-      "stops": Array [],
-      "unstable_pastId": null,
-    }
-  `
+            Object {
+              "currentId": null,
+              "loop": false,
+              "orientation": "horizontal",
+              "stops": Array [],
+              "unstable_moves": 0,
+              "unstable_pastId": null,
+            }
+      `
   );
 });

--- a/packages/reakit/src/Rover/__tests__/index-test.tsx
+++ b/packages/reakit/src/Rover/__tests__/index-test.tsx
@@ -178,3 +178,31 @@ test("move focus with keys and vertical orientation", () => {
   keyDown("ArrowUp");
   expect(rover1).toHaveFocus();
 });
+
+test("move focus by calling state callbacks", () => {
+  const Test = () => {
+    const rover = useRoverState();
+    return (
+      <>
+        <button onClick={rover.first}>first</button>
+        <Rover {...rover}>rover1</Rover>
+        <Rover {...rover}>rover2</Rover>
+        <Rover {...rover}>rover3</Rover>
+      </>
+    );
+  };
+  const { getByText } = render(<Test />);
+  const first = getByText("first");
+  const rover1 = getByText("rover1");
+  act(() => first.focus());
+  expect(first).toHaveFocus();
+
+  fireEvent.click(first);
+  expect(rover1).toHaveFocus();
+
+  act(() => first.focus());
+  expect(first).toHaveFocus();
+
+  fireEvent.click(first);
+  expect(rover1).toHaveFocus();
+});

--- a/packages/reakit/src/Tab/README.md
+++ b/packages/reakit/src/Tab/README.md
@@ -137,6 +137,12 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 
   The current focused element ID.
 
+- **`unstable_moves`** <span title="Experimental">⚠️</span>
+  <code>number</code>
+
+  Stores the number of moves that have been made by calling `move`, `next`,
+`previous`, `first` or `last`.
+
 - **`loop`**
   <code>boolean</code>
 
@@ -172,6 +178,12 @@ similarly to `readOnly` on form elements. In this case, only
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
   Defines the orientation of the rover list.
+
+- **`unstable_moves`** <span title="Experimental">⚠️</span>
+  <code>number</code>
+
+  Stores the number of moves that have been made by calling `move`, `next`,
+`previous`, `first` or `last`.
 
 - **`stops`**
   <code>Stop[]</code>

--- a/packages/reakit/src/Tab/__tests__/TabState-test.ts
+++ b/packages/reakit/src/Tab/__tests__/TabState-test.ts
@@ -18,6 +18,7 @@ test("initial state", () => {
       "selectedId": null,
       "stops": Array [],
       "unstable_baseId": "base",
+      "unstable_moves": 0,
       "unstable_pastId": null,
     }
   `);
@@ -38,6 +39,7 @@ test("initial state selectedId", () => {
       "selectedId": "a",
       "stops": Array [],
       "unstable_baseId": "base",
+      "unstable_moves": 0,
       "unstable_pastId": null,
     }
   `

--- a/packages/reakit/src/Toolbar/README.md
+++ b/packages/reakit/src/Toolbar/README.md
@@ -114,6 +114,12 @@ similarly to `readOnly` on form elements. In this case, only
 
   Defines the orientation of the rover list.
 
+- **`unstable_moves`** <span title="Experimental">⚠️</span>
+  <code>number</code>
+
+  Stores the number of moves that have been made by calling `move`, `next`,
+`previous`, `first` or `last`.
+
 - **`currentId`**
   <code>string | null</code>
 

--- a/packages/reakit/src/Toolbar/__tests__/ToolbarState-test.ts
+++ b/packages/reakit/src/Toolbar/__tests__/ToolbarState-test.ts
@@ -16,6 +16,7 @@ test("initial state", () => {
       "loop": false,
       "orientation": "horizontal",
       "stops": Array [],
+      "unstable_moves": 0,
       "unstable_pastId": null,
     }
   `);


### PR DESCRIPTION
Behavior before this change:

- Call `rover.first()` (focuses the first `Rover`)
- Move focus elsewhere
- Call `rover.first()` again (focus isn't returned to `Rover`)

This happens because `Rover` is only focused when there's a change on the current selec
ted rover (that is, a change on `rover.currentId`). Since it keeps being the `currentId` when we move focus elsewhere, it doesn't receive focus back when we try to re-select it.

This may be considered a bug as the behavior of `rover.first()` and other move methods
will be inconsistent.

With this change, the behavior is corrected:

- Call `rover.first()` (focuses the first `Rover`)
- Move focus elsewhere
- Call `rover.first()` (focuses the first `Rover`)

To do so, we simply increment a `unstable_moves` state and check if `Rover` is focused
whenever it changes.