### PR TITLE
feat(website): Hide state hook props from docs

### DIFF
--- a/packages/reakit/src/Checkbox/README.md
+++ b/packages/reakit/src/Checkbox/README.md
@@ -177,6 +177,7 @@ array.
 <details><summary>2 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`state`**
   <code>boolean | any[] | &#34;indeterminate&#34;</code>
 

--- a/packages/reakit/src/Checkbox/README.md
+++ b/packages/reakit/src/Checkbox/README.md
@@ -162,6 +162,21 @@ going to be an array.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`value`**
+  <code>any</code>
+
+  Checkbox's value is going to be used when multiple checkboxes share the
+same state. Checking a checkbox with value will add it to the state
+array.
+
+- **`checked`**
+  <code>boolean | undefined</code>
+
+  Checkbox's checked state. If present, it's used instead of `state`.
+
+<details><summary>2 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`state`**
   <code>boolean | any[] | &#34;indeterminate&#34;</code>
 
@@ -174,14 +189,4 @@ going to be an array.
 
   Sets `state`.
 
-- **`value`**
-  <code>any</code>
-
-  Checkbox's value is going to be used when multiple checkboxes share the
-same state. Checking a checkbox with value will add it to the state
-array.
-
-- **`checked`**
-  <code>boolean | undefined</code>
-
-  Checkbox's checked state. If present, it's used instead of `state`.
+</details>

--- a/packages/reakit/src/Dialog/README.md
+++ b/packages/reakit/src/Dialog/README.md
@@ -282,30 +282,6 @@ given milliseconds.
 
 ### `Dialog`
 
-- **`visible`**
-  <code>boolean</code>
-
-  Whether it's visible or not.
-
-- **`unstable_animated`** <span title="Experimental">⚠️</span>
-  <code>number | boolean</code>
-
-  If `true`, `animating` will be set to `true` when `visible` changes.
-It'll wait for `stopAnimation` to be called or a CSS transition ends.
-If it's a number, `stopAnimation` will be called automatically after
-given milliseconds.
-
-- **`unstable_stopAnimation`** <span title="Experimental">⚠️</span>
-  <code>() =&#62; void</code>
-
-  Stops animation. It's called automatically if there's a CSS transition.
-It's called after given milliseconds if `animated` is a number.
-
-- **`hide`**
-  <code>() =&#62; void</code>
-
-  Changes the `visible` state to `false`
-
 - **`modal`**
   <code>boolean | undefined</code>
 
@@ -357,8 +333,9 @@ Opening a nested orphan dialog will close its parent dialog if
 `hideOnClickOutside` is set to `true` on the parent.
 It will be set to `false` if `modal` is `false`.
 
-### `DialogBackdrop`
+<details><summary>4 state props</summary>
 
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`visible`**
   <code>boolean</code>
 
@@ -378,6 +355,39 @@ given milliseconds.
   Stops animation. It's called automatically if there's a CSS transition.
 It's called after given milliseconds if `animated` is a number.
 
+- **`hide`**
+  <code>() =&#62; void</code>
+
+  Changes the `visible` state to `false`
+
+</details>
+
+### `DialogBackdrop`
+
+<details><summary>3 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+- **`visible`**
+  <code>boolean</code>
+
+  Whether it's visible or not.
+
+- **`unstable_animated`** <span title="Experimental">⚠️</span>
+  <code>number | boolean</code>
+
+  If `true`, `animating` will be set to `true` when `visible` changes.
+It'll wait for `stopAnimation` to be called or a CSS transition ends.
+If it's a number, `stopAnimation` will be called automatically after
+given milliseconds.
+
+- **`unstable_stopAnimation`** <span title="Experimental">⚠️</span>
+  <code>() =&#62; void</code>
+
+  Stops animation. It's called automatically if there's a CSS transition.
+It's called after given milliseconds if `animated` is a number.
+
+</details>
+
 ### `DialogDisclosure`
 
 - **`disabled`**
@@ -392,6 +402,9 @@ It's called after given milliseconds if `animated` is a number.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+<details><summary>2 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`visible`**
   <code>boolean</code>
 
@@ -401,3 +414,5 @@ similarly to `readOnly` on form elements. In this case, only
   <code>() =&#62; void</code>
 
   Toggles the `visible` state
+
+</details>

--- a/packages/reakit/src/Dialog/README.md
+++ b/packages/reakit/src/Dialog/README.md
@@ -336,6 +336,7 @@ It will be set to `false` if `modal` is `false`.
 <details><summary>4 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`visible`**
   <code>boolean</code>
 
@@ -367,6 +368,7 @@ It's called after given milliseconds if `animated` is a number.
 <details><summary>3 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`visible`**
   <code>boolean</code>
 
@@ -405,6 +407,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>2 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`visible`**
   <code>boolean</code>
 

--- a/packages/reakit/src/Form/README.md
+++ b/packages/reakit/src/Form/README.md
@@ -198,13 +198,6 @@ If `onValidate` throws, `onSubmit` will not be called.
 just like `onValidate`. The only difference is that this validation will
 only occur on submit.
 
-### `Form`
-
-- **`submit`**
-  <code>() =&#62; void</code>
-
-  Triggers form submission (calling `onValidate` and `onSubmit` underneath).
-
 ### `FormCheckbox`
 
 - **`disabled`**
@@ -224,6 +217,21 @@ similarly to `readOnly` on form elements. In this case, only
 
   Checkbox's checked state. If present, it's used instead of `state`.
 
+- **`name`**
+  <code>P</code>
+
+  Checkbox's name as in form values.
+
+- **`value`**
+  <code>ArrayValue&#60;DeepPathValue&#60;V, P&#62;&#62; | undefined</code>
+
+  Checkbox's value is going to be used when multiple checkboxes share the
+same state. Checking a checkbox with value will add it to the state
+array.
+
+<details><summary>6 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`baseId`**
   <code>string</code>
 
@@ -257,20 +265,18 @@ been blurred.
   An object with the same shape as `form.values` with string error messages.
 This stores the error messages throwed by `onValidate` and `onSubmit`.
 
-- **`name`**
-  <code>P</code>
-
-  Checkbox's name as in form values.
-
-- **`value`**
-  <code>ArrayValue&#60;DeepPathValue&#60;V, P&#62;&#62; | undefined</code>
-
-  Checkbox's value is going to be used when multiple checkboxes share the
-same state. Checking a checkbox with value will add it to the state
-array.
+</details>
 
 ### `FormGroup`
 
+- **`name`**
+  <code>P</code>
+
+  FormGroup's name as in form values.
+
+<details><summary>3 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`baseId`**
   <code>string</code>
 
@@ -289,10 +295,7 @@ been blurred.
   An object with the same shape as `form.values` with string error messages.
 This stores the error messages throwed by `onValidate` and `onSubmit`.
 
-- **`name`**
-  <code>P</code>
-
-  FormGroup's name as in form values.
+</details>
 
 ### `FormInput`
 
@@ -308,6 +311,14 @@ This stores the error messages throwed by `onValidate` and `onSubmit`.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`name`**
+  <code>P</code>
+
+  FormInput's name as in form values.
+
+<details><summary>6 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`baseId`**
   <code>string</code>
 
@@ -341,22 +352,9 @@ been blurred.
   An object with the same shape as `form.values` with string error messages.
 This stores the error messages throwed by `onValidate` and `onSubmit`.
 
-- **`name`**
-  <code>P</code>
-
-  FormInput's name as in form values.
+</details>
 
 ### `FormLabel`
-
-- **`baseId`**
-  <code>string</code>
-
-  An ID that will serve as a base for the form elements.
-
-- **`values`**
-  <code>V</code>
-
-  Form values.
 
 - **`name`**
   <code>P</code>
@@ -368,8 +366,31 @@ This stores the error messages throwed by `onValidate` and `onSubmit`.
 
   Label can be passed as the `label` prop or `children`.
 
+<details><summary>2 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+- **`baseId`**
+  <code>string</code>
+
+  An ID that will serve as a base for the form elements.
+
+- **`values`**
+  <code>V</code>
+
+  Form values.
+
+</details>
+
 ### `FormMessage`
 
+- **`name`**
+  <code>P</code>
+
+  FormInput's name as in form values.
+
+<details><summary>4 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`baseId`**
   <code>string</code>
 
@@ -394,10 +415,7 @@ This stores the error messages throwed by `onValidate` and `onSubmit`.
   An object with the same shape as `form.values` with string messages.
 This stores the messages returned by `onValidate` and `onSubmit`.
 
-- **`name`**
-  <code>P</code>
-
-  FormInput's name as in form values.
+</details>
 
 ### `FormPushButton`
 
@@ -413,6 +431,19 @@ This stores the messages returned by `onValidate` and `onSubmit`.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`name`**
+  <code>P</code>
+
+  FormInput's name as in form values. This should point to array value.
+
+- **`value`**
+  <code title="DeepPathValue&#60;V, P&#62; extends (infer U)[] ? U : never">DeepPathValue&#60;V, P&#62; extends (infer U)[] ? U : n...</code>
+
+  The value that is going to be pushed to `form.values[name]`.
+
+<details><summary>3 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`baseId`**
   <code>string</code>
 
@@ -428,45 +459,30 @@ similarly to `readOnly` on form elements. In this case, only
 
   Pushes a new item into `form.values[name]`, which should be an array.
 
-- **`name`**
-  <code>P</code>
+</details>
 
-  FormInput's name as in form values. This should point to array value.
+### `Form`
 
-- **`value`**
-  <code title="DeepPathValue&#60;V, P&#62; extends (infer U)[] ? U : never">DeepPathValue&#60;V, P&#62; extends (infer U)[] ? U : n...</code>
+<details><summary>1 state props</summary>
 
-  The value that is going to be pushed to `form.values[name]`.
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+- **`submit`**
+  <code>() =&#62; void</code>
 
-### `FormRadio`
+  Triggers form submission (calling `onValidate` and `onSubmit` underneath).
 
-- **`values`**
-  <code>V</code>
-
-  Form values.
-
-- **`update`**
-  <code>Update&#60;V&#62;</code>
-
-  Updates a form value.
-
-- **`blur`**
-  <code>&#60;P extends DeepPath&#60;V, P&#62;&#62;(name: P) =&#62; void</code>
-
-  Sets field's touched state to `true`.
-
-- **`name`**
-  <code>P</code>
-
-  FormRadio's name as in form values.
-
-- **`value`**
-  <code title="P extends DeepPathArray&#60;V, P&#62; ? DeepPathArrayValue&#60;V, P&#62; : P extends keyof V ? V[P] : any">P extends DeepPathArray&#60;V, P&#62; ? DeepPathArrayVa...</code>
-
-  FormRadio's value.
+</details>
 
 ### `FormRadioGroup`
 
+- **`name`**
+  <code>P</code>
+
+  FormGroup's name as in form values.
+
+<details><summary>3 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`baseId`**
   <code>string</code>
 
@@ -485,10 +501,7 @@ been blurred.
   An object with the same shape as `form.values` with string error messages.
 This stores the error messages throwed by `onValidate` and `onSubmit`.
 
-- **`name`**
-  <code>P</code>
-
-  FormGroup's name as in form values.
+</details>
 
 ### `FormRemoveButton`
 
@@ -504,6 +517,19 @@ This stores the error messages throwed by `onValidate` and `onSubmit`.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`name`**
+  <code>P</code>
+
+  FormInput's name as in form values. This should point to array value.
+
+- **`index`**
+  <code>number</code>
+
+  The index in `form.values[name]` that will be removed.
+
+<details><summary>3 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`baseId`**
   <code>string</code>
 
@@ -519,15 +545,7 @@ similarly to `readOnly` on form elements. In this case, only
 
   Removes `form.values[name][index]`.
 
-- **`name`**
-  <code>P</code>
-
-  FormInput's name as in form values. This should point to array value.
-
-- **`index`**
-  <code>number</code>
-
-  The index in `form.values[name]` that will be removed.
+</details>
 
 ### `FormSubmitButton`
 
@@ -543,6 +561,9 @@ similarly to `readOnly` on form elements. In this case, only
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+<details><summary>3 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`submitting`**
   <code>boolean</code>
 
@@ -557,3 +578,37 @@ similarly to `readOnly` on form elements. In this case, only
   <code>() =&#62; void</code>
 
   Triggers form submission (calling `onValidate` and `onSubmit` underneath).
+
+</details>
+
+### `FormRadio`
+
+- **`name`**
+  <code>P</code>
+
+  FormRadio's name as in form values.
+
+- **`value`**
+  <code title="P extends DeepPathArray&#60;V, P&#62; ? DeepPathArrayValue&#60;V, P&#62; : P extends keyof V ? V[P] : any">P extends DeepPathArray&#60;V, P&#62; ? DeepPathArrayVa...</code>
+
+  FormRadio's value.
+
+<details><summary>3 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+- **`values`**
+  <code>V</code>
+
+  Form values.
+
+- **`update`**
+  <code>Update&#60;V&#62;</code>
+
+  Updates a form value.
+
+- **`blur`**
+  <code>&#60;P extends DeepPath&#60;V, P&#62;&#62;(name: P) =&#62; void</code>
+
+  Sets field's touched state to `true`.
+
+</details>

--- a/packages/reakit/src/Form/README.md
+++ b/packages/reakit/src/Form/README.md
@@ -232,6 +232,7 @@ array.
 <details><summary>6 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`baseId`**
   <code>string</code>
 
@@ -277,6 +278,7 @@ This stores the error messages throwed by `onValidate` and `onSubmit`.
 <details><summary>3 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`baseId`**
   <code>string</code>
 
@@ -319,6 +321,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>6 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`baseId`**
   <code>string</code>
 
@@ -369,6 +372,7 @@ This stores the error messages throwed by `onValidate` and `onSubmit`.
 <details><summary>2 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`baseId`**
   <code>string</code>
 
@@ -391,6 +395,7 @@ This stores the error messages throwed by `onValidate` and `onSubmit`.
 <details><summary>4 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`baseId`**
   <code>string</code>
 
@@ -444,6 +449,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>3 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`baseId`**
   <code>string</code>
 
@@ -466,6 +472,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>1 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`submit`**
   <code>() =&#62; void</code>
 
@@ -483,6 +490,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>3 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`baseId`**
   <code>string</code>
 
@@ -530,6 +538,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>3 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`baseId`**
   <code>string</code>
 
@@ -564,6 +573,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>3 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`submitting`**
   <code>boolean</code>
 
@@ -596,6 +606,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>3 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`values`**
   <code>V</code>
 

--- a/packages/reakit/src/Hidden/README.md
+++ b/packages/reakit/src/Hidden/README.md
@@ -98,6 +98,7 @@ given milliseconds.
 <details><summary>3 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`visible`**
   <code>boolean</code>
 
@@ -136,6 +137,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>2 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`visible`**
   <code>boolean</code>
 

--- a/packages/reakit/src/Hidden/README.md
+++ b/packages/reakit/src/Hidden/README.md
@@ -95,6 +95,9 @@ given milliseconds.
 
 ### `Hidden`
 
+<details><summary>3 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`visible`**
   <code>boolean</code>
 
@@ -114,6 +117,8 @@ given milliseconds.
   Stops animation. It's called automatically if there's a CSS transition.
 It's called after given milliseconds if `animated` is a number.
 
+</details>
+
 ### `HiddenDisclosure`
 
 - **`disabled`**
@@ -128,6 +133,9 @@ It's called after given milliseconds if `animated` is a number.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+<details><summary>2 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`visible`**
   <code>boolean</code>
 
@@ -137,3 +145,5 @@ similarly to `readOnly` on form elements. In this case, only
   <code>() =&#62; void</code>
 
   Toggles the `visible` state
+
+</details>

--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -424,6 +424,32 @@ element.
 
 ### `Menu`
 
+- **`hideOnClickOutside`**
+  <code>boolean | undefined</code>
+
+  When enabled, user can hide the dialog by clicking outside it.
+
+- **`preventBodyScroll`**
+  <code>boolean | undefined</code>
+
+  When enabled, user can't scroll on body when the dialog is visible.
+This option doesn't work if the dialog isn't modal.
+
+- **`unstable_initialFocusRef`** <span title="Experimental">⚠️</span>
+  <code>RefObject&#60;HTMLElement&#62; | undefined</code>
+
+  The element that will be focused when the dialog shows.
+When not set, the first tabbable element within the dialog will be used.
+
+- **`unstable_finalFocusRef`** <span title="Experimental">⚠️</span>
+  <code>RefObject&#60;HTMLElement&#62; | undefined</code>
+
+  The element that will be focused when the dialog hides.
+When not set, the disclosure component will be used.
+
+<details><summary>12 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`visible`**
   <code>boolean</code>
 
@@ -447,29 +473,6 @@ It's called after given milliseconds if `animated` is a number.
   <code>() =&#62; void</code>
 
   Changes the `visible` state to `false`
-
-- **`hideOnClickOutside`**
-  <code>boolean | undefined</code>
-
-  When enabled, user can hide the dialog by clicking outside it.
-
-- **`preventBodyScroll`**
-  <code>boolean | undefined</code>
-
-  When enabled, user can't scroll on body when the dialog is visible.
-This option doesn't work if the dialog isn't modal.
-
-- **`unstable_initialFocusRef`** <span title="Experimental">⚠️</span>
-  <code>RefObject&#60;HTMLElement&#62; | undefined</code>
-
-  The element that will be focused when the dialog shows.
-When not set, the first tabbable element within the dialog will be used.
-
-- **`unstable_finalFocusRef`** <span title="Experimental">⚠️</span>
-  <code>RefObject&#60;HTMLElement&#62; | undefined</code>
-
-  The element that will be focused when the dialog hides.
-When not set, the disclosure component will be used.
 
 - **`placement`**
   <code title="&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start&#34; | &#34;top&#34; | &#34;top-end&#34; | &#34;right-start&#34; | &#34;right&#34; | &#34;right-end&#34; | &#34;bottom-end&#34; | &#34;bottom&#34; | &#34;bottom-start&#34; | &#34;left-end&#34; | &#34;left&#34; | &#34;left-start&#34;">&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start...</code>
@@ -511,6 +514,8 @@ When not set, the disclosure component will be used.
 
   Moves focus to the previous element.
 
+</details>
+
 ### `MenuDisclosure`
 
 - **`disabled`**
@@ -525,6 +530,9 @@ When not set, the disclosure component will be used.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+<details><summary>8 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`visible`**
   <code>boolean</code>
 
@@ -565,6 +573,8 @@ similarly to `readOnly` on form elements. In this case, only
 
   Changes the `visible` state to `true`
 
+</details>
+
 ### `MenuGroup`
 
 No props to show
@@ -583,6 +593,14 @@ No props to show
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`stopId`**
+  <code>string | undefined</code>
+
+  Element ID.
+
+<details><summary>14 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
@@ -639,11 +657,6 @@ similarly to `readOnly` on form elements. In this case, only
 
   Unregisters the roving item.
 
-- **`stopId`**
-  <code>string | undefined</code>
-
-  Element ID.
-
 - **`visible`**
   <code>boolean</code>
 
@@ -658,6 +671,8 @@ similarly to `readOnly` on form elements. In this case, only
   <code>() =&#62; void</code>
 
   Changes the `visible` state to `false`
+
+</details>
 
 ### `MenuItemCheckbox`
 
@@ -673,18 +688,6 @@ similarly to `readOnly` on form elements. In this case, only
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
-- **`state`**
-  <code>boolean | any[] | &#34;indeterminate&#34;</code>
-
-  Stores the state of the checkbox.
-If checkboxes that share this state have defined a `value` prop, it's
-going to be an array.
-
-- **`setState`**
-  <code title="(value: SetStateAction&#60;boolean | any[] | &#34;indeterminate&#34;&#62;) =&#62; void">(value: SetStateAction&#60;boolean | any[] | &#34;indet...</code>
-
-  Sets `state`.
-
 - **`value`**
   <code>any</code>
 
@@ -696,6 +699,31 @@ array.
   <code>boolean | undefined</code>
 
   Checkbox's checked state. If present, it's used instead of `state`.
+
+- **`stopId`**
+  <code>string | undefined</code>
+
+  Element ID.
+
+- **`name`**
+  <code>string</code>
+
+  MenuItemCheckbox's name as in `menu.values`.
+
+<details><summary>18 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+- **`state`**
+  <code>boolean | any[] | &#34;indeterminate&#34;</code>
+
+  Stores the state of the checkbox.
+If checkboxes that share this state have defined a `value` prop, it's
+going to be an array.
+
+- **`setState`**
+  <code title="(value: SetStateAction&#60;boolean | any[] | &#34;indeterminate&#34;&#62;) =&#62; void">(value: SetStateAction&#60;boolean | any[] | &#34;indet...</code>
+
+  Sets `state`.
 
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
@@ -752,11 +780,6 @@ array.
   <code>(id: string) =&#62; void</code>
 
   Unregisters the roving item.
-
-- **`stopId`**
-  <code>string | undefined</code>
-
-  Element ID.
 
 - **`visible`**
   <code>boolean</code>
@@ -783,68 +806,9 @@ array.
 
   Updates checkboxes and radios values within the menu.
 
-- **`name`**
-  <code>string</code>
-
-  MenuItemCheckbox's name as in `menu.values`.
+</details>
 
 ### `MenuItemRadio`
-
-- **`orientation`**
-  <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
-
-  Defines the orientation of the rover list.
-
-- **`currentId`**
-  <code>string | null</code>
-
-  The current focused element ID.
-
-- **`first`**
-  <code>() =&#62; void</code>
-
-  Moves focus to the first element.
-
-- **`last`**
-  <code>() =&#62; void</code>
-
-  Moves focus to the last element.
-
-- **`stops`**
-  <code>Stop[]</code>
-
-  A list of element refs and IDs of the roving items.
-
-- **`move`**
-  <code>(id: string | null) =&#62; void</code>
-
-  Moves focus to a given element ID.
-
-- **`next`**
-  <code>() =&#62; void</code>
-
-  Moves focus to the next element.
-
-- **`previous`**
-  <code>() =&#62; void</code>
-
-  Moves focus to the previous element.
-
-- **`unstable_moves`** <span title="Experimental">⚠️</span>
-  <code>number</code>
-
-  Stores the number of moves that have been made by calling `move`, `next`,
-`previous`, `first` or `last`.
-
-- **`register`**
-  <code>(id: string, ref: RefObject&#60;HTMLElement&#62;) =&#62; void</code>
-
-  Registers the element ID and ref in the roving tab index list.
-
-- **`unregister`**
-  <code>(id: string) =&#62; void</code>
-
-  Unregisters the roving item.
 
 - **`disabled`**
   <code>boolean | undefined</code>
@@ -863,16 +827,6 @@ similarly to `readOnly` on form elements. In this case, only
 
   Element ID.
 
-- **`state`**
-  <code>any</code>
-
-  The `value` attribute of the current checked radio.
-
-- **`setState`**
-  <code>(value: any) =&#62; void</code>
-
-  Sets `state`.
-
 - **`value`**
   <code>any</code>
 
@@ -882,6 +836,80 @@ similarly to `readOnly` on form elements. In this case, only
   <code>boolean | undefined</code>
 
   Same as the `checked` attribute.
+
+- **`name`**
+  <code>string</code>
+
+  MenuItemRadio's name as in `menu.values`.
+
+<details><summary>18 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+- **`orientation`**
+  <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
+
+  Defines the orientation of the rover list.
+
+- **`currentId`**
+  <code>string | null</code>
+
+  The current focused element ID.
+
+- **`first`**
+  <code>() =&#62; void</code>
+
+  Moves focus to the first element.
+
+- **`last`**
+  <code>() =&#62; void</code>
+
+  Moves focus to the last element.
+
+- **`stops`**
+  <code>Stop[]</code>
+
+  A list of element refs and IDs of the roving items.
+
+- **`move`**
+  <code>(id: string | null) =&#62; void</code>
+
+  Moves focus to a given element ID.
+
+- **`next`**
+  <code>() =&#62; void</code>
+
+  Moves focus to the next element.
+
+- **`previous`**
+  <code>() =&#62; void</code>
+
+  Moves focus to the previous element.
+
+- **`unstable_moves`** <span title="Experimental">⚠️</span>
+  <code>number</code>
+
+  Stores the number of moves that have been made by calling `move`, `next`,
+`previous`, `first` or `last`.
+
+- **`register`**
+  <code>(id: string, ref: RefObject&#60;HTMLElement&#62;) =&#62; void</code>
+
+  Registers the element ID and ref in the roving tab index list.
+
+- **`unregister`**
+  <code>(id: string) =&#62; void</code>
+
+  Unregisters the roving item.
+
+- **`state`**
+  <code>any</code>
+
+  The `value` attribute of the current checked radio.
+
+- **`setState`**
+  <code>(value: any) =&#62; void</code>
+
+  Sets `state`.
 
 - **`visible`**
   <code>boolean</code>
@@ -908,20 +936,25 @@ similarly to `readOnly` on form elements. In this case, only
 
   Updates checkboxes and radios values within the menu.
 
-- **`name`**
-  <code>string</code>
-
-  MenuItemRadio's name as in `menu.values`.
+</details>
 
 ### `MenuSeparator`
 
+<details><summary>1 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
   Separator's orientation.
 
+</details>
+
 ### `StaticMenu`
 
+<details><summary>5 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
@@ -946,3 +979,5 @@ similarly to `readOnly` on form elements. In this case, only
   <code>() =&#62; void</code>
 
   Moves focus to the previous element.
+
+</details>

--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -450,6 +450,7 @@ When not set, the disclosure component will be used.
 <details><summary>12 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`visible`**
   <code>boolean</code>
 
@@ -533,6 +534,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>8 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`visible`**
   <code>boolean</code>
 
@@ -601,6 +603,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>14 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
@@ -713,6 +716,7 @@ array.
 <details><summary>18 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`state`**
   <code>boolean | any[] | &#34;indeterminate&#34;</code>
 
@@ -845,6 +849,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>18 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
@@ -943,6 +948,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>1 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
@@ -955,6 +961,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>5 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 

--- a/packages/reakit/src/Popover/README.md
+++ b/packages/reakit/src/Popover/README.md
@@ -162,30 +162,6 @@ element.
 
 ### `Popover`
 
-- **`visible`**
-  <code>boolean</code>
-
-  Whether it's visible or not.
-
-- **`unstable_animated`** <span title="Experimental">⚠️</span>
-  <code>number | boolean</code>
-
-  If `true`, `animating` will be set to `true` when `visible` changes.
-It'll wait for `stopAnimation` to be called or a CSS transition ends.
-If it's a number, `stopAnimation` will be called automatically after
-given milliseconds.
-
-- **`unstable_stopAnimation`** <span title="Experimental">⚠️</span>
-  <code>() =&#62; void</code>
-
-  Stops animation. It's called automatically if there's a CSS transition.
-It's called after given milliseconds if `animated` is a number.
-
-- **`hide`**
-  <code>() =&#62; void</code>
-
-  Changes the `visible` state to `false`
-
 - **`modal`**
   <code>boolean | undefined</code>
 
@@ -237,15 +213,9 @@ Opening a nested orphan dialog will close its parent dialog if
 `hideOnClickOutside` is set to `true` on the parent.
 It will be set to `false` if `modal` is `false`.
 
-### `PopoverArrow`
+<details><summary>4 state props</summary>
 
-- **`placement`**
-  <code title="&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start&#34; | &#34;top&#34; | &#34;top-end&#34; | &#34;right-start&#34; | &#34;right&#34; | &#34;right-end&#34; | &#34;bottom-end&#34; | &#34;bottom&#34; | &#34;bottom-start&#34; | &#34;left-end&#34; | &#34;left&#34; | &#34;left-start&#34;">&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start...</code>
-
-  Actual `placement`.
-
-### `PopoverBackdrop`
-
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`visible`**
   <code>boolean</code>
 
@@ -265,6 +235,51 @@ given milliseconds.
   Stops animation. It's called automatically if there's a CSS transition.
 It's called after given milliseconds if `animated` is a number.
 
+- **`hide`**
+  <code>() =&#62; void</code>
+
+  Changes the `visible` state to `false`
+
+</details>
+
+### `PopoverArrow`
+
+<details><summary>1 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+- **`placement`**
+  <code title="&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start&#34; | &#34;top&#34; | &#34;top-end&#34; | &#34;right-start&#34; | &#34;right&#34; | &#34;right-end&#34; | &#34;bottom-end&#34; | &#34;bottom&#34; | &#34;bottom-start&#34; | &#34;left-end&#34; | &#34;left&#34; | &#34;left-start&#34;">&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start...</code>
+
+  Actual `placement`.
+
+</details>
+
+### `PopoverBackdrop`
+
+<details><summary>3 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+- **`visible`**
+  <code>boolean</code>
+
+  Whether it's visible or not.
+
+- **`unstable_animated`** <span title="Experimental">⚠️</span>
+  <code>number | boolean</code>
+
+  If `true`, `animating` will be set to `true` when `visible` changes.
+It'll wait for `stopAnimation` to be called or a CSS transition ends.
+If it's a number, `stopAnimation` will be called automatically after
+given milliseconds.
+
+- **`unstable_stopAnimation`** <span title="Experimental">⚠️</span>
+  <code>() =&#62; void</code>
+
+  Stops animation. It's called automatically if there's a CSS transition.
+It's called after given milliseconds if `animated` is a number.
+
+</details>
+
 ### `PopoverDisclosure`
 
 - **`disabled`**
@@ -279,6 +294,9 @@ It's called after given milliseconds if `animated` is a number.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+<details><summary>3 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`visible`**
   <code>boolean</code>
 
@@ -293,3 +311,5 @@ similarly to `readOnly` on form elements. In this case, only
   <code>RefObject&#60;HTMLElement | null&#62;</code>
 
   The reference element.
+
+</details>

--- a/packages/reakit/src/Popover/README.md
+++ b/packages/reakit/src/Popover/README.md
@@ -216,6 +216,7 @@ It will be set to `false` if `modal` is `false`.
 <details><summary>4 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`visible`**
   <code>boolean</code>
 
@@ -247,6 +248,7 @@ It's called after given milliseconds if `animated` is a number.
 <details><summary>1 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`placement`**
   <code title="&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start&#34; | &#34;top&#34; | &#34;top-end&#34; | &#34;right-start&#34; | &#34;right&#34; | &#34;right-end&#34; | &#34;bottom-end&#34; | &#34;bottom&#34; | &#34;bottom-start&#34; | &#34;left-end&#34; | &#34;left&#34; | &#34;left-start&#34;">&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start...</code>
 
@@ -259,6 +261,7 @@ It's called after given milliseconds if `animated` is a number.
 <details><summary>3 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`visible`**
   <code>boolean</code>
 
@@ -297,6 +300,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>3 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`visible`**
   <code>boolean</code>
 

--- a/packages/reakit/src/Radio/README.md
+++ b/packages/reakit/src/Radio/README.md
@@ -114,6 +114,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>13 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 

--- a/packages/reakit/src/Radio/README.md
+++ b/packages/reakit/src/Radio/README.md
@@ -84,6 +84,36 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 
 ### `Radio`
 
+- **`disabled`**
+  <code>boolean | undefined</code>
+
+  Same as the HTML attribute.
+
+- **`focusable`**
+  <code>boolean | undefined</code>
+
+  When an element is `disabled`, it may still be `focusable`. It works
+similarly to `readOnly` on form elements. In this case, only
+`aria-disabled` will be set.
+
+- **`stopId`**
+  <code>string | undefined</code>
+
+  Element ID.
+
+- **`value`**
+  <code>any</code>
+
+  Same as the `value` attribute.
+
+- **`checked`**
+  <code>boolean | undefined</code>
+
+  Same as the `checked` attribute.
+
+<details><summary>13 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
@@ -140,23 +170,6 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 
   Moves focus to the last element.
 
-- **`disabled`**
-  <code>boolean | undefined</code>
-
-  Same as the HTML attribute.
-
-- **`focusable`**
-  <code>boolean | undefined</code>
-
-  When an element is `disabled`, it may still be `focusable`. It works
-similarly to `readOnly` on form elements. In this case, only
-`aria-disabled` will be set.
-
-- **`stopId`**
-  <code>string | undefined</code>
-
-  Element ID.
-
 - **`state`**
   <code>any</code>
 
@@ -167,15 +180,7 @@ similarly to `readOnly` on form elements. In this case, only
 
   Sets `state`.
 
-- **`value`**
-  <code>any</code>
-
-  Same as the `value` attribute.
-
-- **`checked`**
-  <code>boolean | undefined</code>
-
-  Same as the `checked` attribute.
+</details>
 
 ### `RadioGroup`
 

--- a/packages/reakit/src/Rover/README.md
+++ b/packages/reakit/src/Rover/README.md
@@ -110,6 +110,14 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`stopId`**
+  <code>string | undefined</code>
+
+  Element ID.
+
+<details><summary>11 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
@@ -166,7 +174,4 @@ similarly to `readOnly` on form elements. In this case, only
 
   Moves focus to the last element.
 
-- **`stopId`**
-  <code>string | undefined</code>
-
-  Element ID.
+</details>

--- a/packages/reakit/src/Rover/README.md
+++ b/packages/reakit/src/Rover/README.md
@@ -118,6 +118,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>11 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 

--- a/packages/reakit/src/Separator/README.md
+++ b/packages/reakit/src/Separator/README.md
@@ -46,7 +46,12 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 
 ### `Separator`
 
+<details><summary>1 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
   Separator's orientation.
+
+</details>

--- a/packages/reakit/src/Separator/README.md
+++ b/packages/reakit/src/Separator/README.md
@@ -49,6 +49,7 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 <details><summary>1 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 

--- a/packages/reakit/src/Tab/README.md
+++ b/packages/reakit/src/Tab/README.md
@@ -174,6 +174,14 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`stopId`**
+  <code>string | undefined</code>
+
+  Element ID.
+
+<details><summary>14 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
@@ -230,11 +238,6 @@ similarly to `readOnly` on form elements. In this case, only
 
   Moves focus to the last element.
 
-- **`stopId`**
-  <code>string | undefined</code>
-
-  Element ID.
-
 - **`manual`**
   <code>boolean</code>
 
@@ -250,15 +253,30 @@ similarly to `readOnly` on form elements. In this case, only
 
   Selects a tab by its `stopId`.
 
+</details>
+
 ### `TabList`
 
+<details><summary>1 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
   Defines the orientation of the rover list.
 
+</details>
+
 ### `TabPanel`
 
+- **`stopId`**
+  <code>string</code>
+
+  Tab's `stopId`.
+
+<details><summary>4 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`visible`**
   <code>boolean</code>
 
@@ -283,7 +301,4 @@ It's called after given milliseconds if `animated` is a number.
 
   The current selected tab's `stopId`.
 
-- **`stopId`**
-  <code>string</code>
-
-  Tab's `stopId`.
+</details>

--- a/packages/reakit/src/Tab/README.md
+++ b/packages/reakit/src/Tab/README.md
@@ -182,6 +182,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>14 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
@@ -260,6 +261,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>1 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
@@ -277,6 +279,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>4 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`visible`**
   <code>boolean</code>
 

--- a/packages/reakit/src/Toolbar/README.md
+++ b/packages/reakit/src/Toolbar/README.md
@@ -93,6 +93,7 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 <details><summary>1 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
@@ -122,6 +123,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>11 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
@@ -185,6 +187,7 @@ similarly to `readOnly` on form elements. In this case, only
 <details><summary>1 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 

--- a/packages/reakit/src/Toolbar/README.md
+++ b/packages/reakit/src/Toolbar/README.md
@@ -90,10 +90,15 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 
 ### `Toolbar`
 
+<details><summary>1 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
   Defines the orientation of the rover list.
+
+</details>
 
 ### `ToolbarItem`
 
@@ -109,6 +114,14 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`stopId`**
+  <code>string | undefined</code>
+
+  Element ID.
+
+<details><summary>11 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
@@ -165,14 +178,16 @@ similarly to `readOnly` on form elements. In this case, only
 
   Moves focus to the last element.
 
-- **`stopId`**
-  <code>string | undefined</code>
-
-  Element ID.
+</details>
 
 ### `ToolbarSeparator`
 
+<details><summary>1 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
   Separator's orientation.
+
+</details>

--- a/packages/reakit/src/Tooltip/README.md
+++ b/packages/reakit/src/Tooltip/README.md
@@ -147,6 +147,9 @@ element.
 
 ### `Tooltip`
 
+<details><summary>3 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`visible`**
   <code>boolean</code>
 
@@ -166,15 +169,25 @@ given milliseconds.
   Stops animation. It's called automatically if there's a CSS transition.
 It's called after given milliseconds if `animated` is a number.
 
+</details>
+
 ### `TooltipArrow`
 
+<details><summary>1 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`placement`**
   <code title="&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start&#34; | &#34;top&#34; | &#34;top-end&#34; | &#34;right-start&#34; | &#34;right&#34; | &#34;right-end&#34; | &#34;bottom-end&#34; | &#34;bottom&#34; | &#34;bottom-start&#34; | &#34;left-end&#34; | &#34;left&#34; | &#34;left-start&#34;">&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start...</code>
 
   Actual `placement`.
 
+</details>
+
 ### `TooltipReference`
 
+<details><summary>3 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 - **`unstable_referenceRef`** <span title="Experimental">⚠️</span>
   <code>RefObject&#60;HTMLElement | null&#62;</code>
 
@@ -189,3 +202,5 @@ It's called after given milliseconds if `animated` is a number.
   <code>() =&#62; void</code>
 
   Changes the `visible` state to `false`
+
+</details>

--- a/packages/reakit/src/Tooltip/README.md
+++ b/packages/reakit/src/Tooltip/README.md
@@ -150,6 +150,7 @@ element.
 <details><summary>3 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`visible`**
   <code>boolean</code>
 
@@ -176,6 +177,7 @@ It's called after given milliseconds if `animated` is a number.
 <details><summary>1 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`placement`**
   <code title="&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start&#34; | &#34;top&#34; | &#34;top-end&#34; | &#34;right-start&#34; | &#34;right&#34; | &#34;right-end&#34; | &#34;bottom-end&#34; | &#34;bottom&#34; | &#34;bottom-start&#34; | &#34;left-end&#34; | &#34;left&#34; | &#34;left-start&#34;">&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start...</code>
 
@@ -188,6 +190,7 @@ It's called after given milliseconds if `animated` is a number.
 <details><summary>3 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
 - **`unstable_referenceRef`** <span title="Experimental">⚠️</span>
   <code>RefObject&#60;HTMLElement | null&#62;</code>
 

--- a/packages/website/src/components/List.ts
+++ b/packages/website/src/components/List.ts
@@ -16,7 +16,8 @@ export const useList = createHook<ListOptions, ListHTMLProps>({
       li {
         margin-bottom: 0.5em;
       }
-      #props ~ & {
+      #props ~ &,
+      #props ~ details > & {
         & > li {
           li {
             margin: 0;

--- a/packages/website/src/components/Summary.tsx
+++ b/packages/website/src/components/Summary.tsx
@@ -1,0 +1,39 @@
+import { css, cx } from "emotion";
+import { useBox, BoxHTMLProps, BoxOptions } from "reakit";
+import { createHook, createComponent } from "reakit-system";
+import { useAnchor } from "./Anchor";
+
+export type SummaryOptions = BoxOptions & {
+  experimental?: "true" | "false";
+};
+
+export type SummaryHTMLProps = BoxHTMLProps;
+
+export type SummaryProps = SummaryOptions & SummaryHTMLProps;
+
+export const useSummary = createHook<SummaryOptions, SummaryHTMLProps>({
+  name: "Summary",
+  compose: useBox,
+
+  useProps(options, htmlProps) {
+    const anchor = useAnchor(options, htmlProps);
+    const summary = css`
+      display: inline-block;
+      padding: 0.5em 1.5em;
+      cursor: pointer;
+    `;
+
+    return {
+      ...htmlProps,
+      ...anchor,
+      className: cx(anchor.className, summary, htmlProps.className)
+    };
+  }
+});
+
+const Summary = createComponent({
+  as: "summary",
+  useHook: useSummary
+});
+
+export default Summary;

--- a/packages/website/src/templates/Docs.tsx
+++ b/packages/website/src/templates/Docs.tsx
@@ -23,6 +23,7 @@ import Heading from "../components/Heading";
 import SEO from "../components/SEO";
 import track from "../utils/track";
 import DocsBackNext from "../components/DocsBackNext";
+import Summary from "../components/Summary";
 
 type DocsProps = {
   pageContext: {
@@ -63,6 +64,7 @@ const { Compiler: renderAst } = new RehypeReact({
     ul: List,
     kbd: KeyboardInput,
     blockquote: Blockquote,
+    summary: Summary,
     h1: Heading,
     h2: props => <Heading as="h2" {...props} />,
     h3: props => <Heading as="h3" {...props} />,

--- a/scripts/build/utils.js
+++ b/scripts/build/utils.js
@@ -532,6 +532,7 @@ function getPropTypesMarkdown(types) {
 <details><summary>${stateProps.length} state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (\`{...state}\`) or pass them separately. You can also provide these props from your own state logic.
+
 ${stateProps.map(getPropTypesRow).join("\n")}
 </details>`
         : "";

--- a/scripts/build/utils.js
+++ b/scripts/build/utils.js
@@ -335,13 +335,39 @@ function getEscapedName(node) {
 /**
  * @param {import("ts-morph").Node<Node>} node
  */
-function isPropsDeclaration(node) {
+function isStateReturnDeclaration(node) {
   const kindName = node.getKindName();
   const escapedName = getEscapedName(node);
   return (
-    kindName === "TypeAliasDeclaration" &&
-    /.+(Options|InitialState)$/.test(escapedName)
+    kindName === "TypeAliasDeclaration" && /.+StateReturn$/.test(escapedName)
   );
+}
+
+/**
+ * @param {import("ts-morph").Node<Node>} node
+ */
+function isInitialStateDeclaration(node) {
+  const kindName = node.getKindName();
+  const escapedName = getEscapedName(node);
+  return (
+    kindName === "TypeAliasDeclaration" && /.+InitialState$/.test(escapedName)
+  );
+}
+
+/**
+ * @param {import("ts-morph").Node<Node>} node
+ */
+function isOptionsDeclaration(node) {
+  const kindName = node.getKindName();
+  const escapedName = getEscapedName(node);
+  return kindName === "TypeAliasDeclaration" && /.+Options$/.test(escapedName);
+}
+
+/**
+ * @param {import("ts-morph").Node<Node>} node
+ */
+function isPropsDeclaration(node) {
+  return isOptionsDeclaration(node) || isInitialStateDeclaration(node);
 }
 
 /**
@@ -461,6 +487,22 @@ function createPropTypeObject(rootPath, prop) {
 }
 
 /**
+ * @param {string} rootPath
+ * @param {import("ts-morph").Node<Node>} node
+ */
+function createPropTypeObjects(rootPath, node) {
+  return getProps(node).map(prop => createPropTypeObject(rootPath, prop));
+}
+/**
+ * @param {import("ts-morph").SourceFile[]} sourceFiles
+ */
+function sortStateFirst(sourceFiles) {
+  return sourceFiles.sort(a =>
+    /State$/.test(a.getBaseNameWithoutExtension()) ? -1 : 0
+  );
+}
+
+/**
  * @param {ReturnType<typeof createPropTypeObject>} prop
  */
 function getPropTypesRow(prop) {
@@ -482,11 +524,23 @@ function getPropTypesRow(prop) {
 function getPropTypesMarkdown(types) {
   const content = Object.keys(types)
     .map(title => {
-      const rows = types[title].map(getPropTypesRow).join("\n");
+      const props = types[title];
+      const rows = props.map(getPropTypesRow).join("\n");
+      const stateProps = props.stateProps || [];
+      const hiddenRows = stateProps.length
+        ? `
+<details><summary>${stateProps.length} state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (\`{...state}\`) or pass them separately. You can also provide these props from your own state logic.
+${stateProps.map(getPropTypesRow).join("\n")}
+</details>`
+        : "";
+
       return `
 ### \`${title}\`
 
-${rows || "No props to show"}`;
+${rows || (hiddenRows ? "" : "No props to show")}
+${hiddenRows}`;
     })
     .join("\n\n");
 
@@ -503,6 +557,7 @@ ${content}`;
 function injectPropTypes(rootPath) {
   const pkg = getPackage(rootPath);
   const readmePaths = getReadmePaths(rootPath);
+  const stateTypes = [];
   const created = [];
 
   const project = new Project({
@@ -522,12 +577,28 @@ function injectPropTypes(rootPath) {
       project.resolveSourceFileDependencies();
       const types = {};
 
-      sourceFiles.forEach(sourceFile => {
+      sortStateFirst(sourceFiles).forEach(sourceFile => {
         sourceFile.forEachChild(node => {
+          if (isStateReturnDeclaration(node)) {
+            const propTypes = createPropTypeObjects(rootPath, node);
+            stateTypes.push(...propTypes.map(prop => prop.name));
+          }
           if (isPropsDeclaration(node)) {
-            types[getModuleName(node)] = getProps(node).map(prop =>
-              createPropTypeObject(rootPath, prop)
-            );
+            const moduleName = getModuleName(node);
+            const propTypes = createPropTypeObjects(rootPath, node);
+
+            if (isInitialStateDeclaration(node)) {
+              types[moduleName] = propTypes;
+            } else {
+              const propTypesWithoutState = propTypes.filter(
+                prop => !stateTypes.includes(prop.name)
+              );
+              const propTypesReturnedByState = propTypes.filter(prop =>
+                stateTypes.includes(prop.name)
+              );
+              types[moduleName] = propTypesWithoutState;
+              types[moduleName].stateProps = propTypesReturnedByState;
+            }
           }
         });
       });


### PR DESCRIPTION
This puts props returned by state hooks (e.g. `useDialogState`) into hidden sections in the documentation. The goal is to improve the readability of the props documentation by hiding props that will usually be spread directly from the state hook to the component.