### PR TITLE
Add generic parameter to Radio and useRadioState

### DIFF
--- a/packages/reakit/src/Menu/MenuItemRadio.ts
+++ b/packages/reakit/src/Menu/MenuItemRadio.ts
@@ -5,7 +5,7 @@ import { RadioOptions, RadioHTMLProps, useRadio } from "../Radio/Radio";
 import { MenuStateReturn, useMenuState } from "./MenuState";
 import { useMenuItem, MenuItemOptions, MenuItemHTMLProps } from "./MenuItem";
 
-export type MenuItemRadioOptions = RadioOptions<any> &
+export type MenuItemRadioOptions = RadioOptions &
   MenuItemOptions &
   Pick<MenuStateReturn, "unstable_values" | "unstable_setValue"> & {
     /**

--- a/packages/reakit/src/Menu/MenuItemRadio.ts
+++ b/packages/reakit/src/Menu/MenuItemRadio.ts
@@ -5,7 +5,7 @@ import { RadioOptions, RadioHTMLProps, useRadio } from "../Radio/Radio";
 import { MenuStateReturn, useMenuState } from "./MenuState";
 import { useMenuItem, MenuItemOptions, MenuItemHTMLProps } from "./MenuItem";
 
-export type MenuItemRadioOptions = RadioOptions &
+export type MenuItemRadioOptions = RadioOptions<any> &
   MenuItemOptions &
   Pick<MenuStateReturn, "unstable_values" | "unstable_setValue"> & {
     /**

--- a/packages/reakit/src/Radio/Radio.ts
+++ b/packages/reakit/src/Radio/Radio.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { createComponent } from "reakit-system/createComponent";
 import { createHook } from "reakit-system/createHook";
-import { PropsWithAs, As } from "reakit-utils/src/types";
+import { PropsWithAs, As } from "reakit-utils/types";
 import { useAllCallbacks } from "reakit-utils/useAllCallbacks";
 import { RoverOptions, RoverHTMLProps, useRover } from "../Rover/Rover";
 import { useRadioState, RadioStateReturn } from "./RadioState";

--- a/packages/reakit/src/Radio/Radio.ts
+++ b/packages/reakit/src/Radio/Radio.ts
@@ -22,7 +22,7 @@ export type RadioHTMLProps = RoverHTMLProps & React.InputHTMLAttributes<any>;
 
 export type RadioProps<T = any> = RadioOptions<T> & RadioHTMLProps;
 
-export const useRadio = createHook<RadioOptions<string>, RadioHTMLProps>({
+export const useRadio = createHook<RadioOptions, RadioHTMLProps>({
   name: "Radio",
   compose: useRover,
   useState: useRadioState,

--- a/packages/reakit/src/Radio/Radio.ts
+++ b/packages/reakit/src/Radio/Radio.ts
@@ -22,7 +22,6 @@ export type RadioHTMLProps = RoverHTMLProps & React.InputHTMLAttributes<any>;
 
 export type RadioProps<T> = RadioOptions<T> & RadioHTMLProps;
 
-
 export const useRadio = createHook<RadioOptions<string>, RadioHTMLProps>({
   name: "Radio",
   compose: useRover,

--- a/packages/reakit/src/Radio/Radio.ts
+++ b/packages/reakit/src/Radio/Radio.ts
@@ -1,16 +1,17 @@
 import * as React from "react";
 import { createComponent } from "reakit-system/createComponent";
 import { createHook } from "reakit-system/createHook";
+import { PropsWithAs, As } from "reakit-utils/src/types";
 import { useAllCallbacks } from "reakit-utils/useAllCallbacks";
 import { RoverOptions, RoverHTMLProps, useRover } from "../Rover/Rover";
 import { useRadioState, RadioStateReturn } from "./RadioState";
 
-export type RadioOptions = RoverOptions &
-  Pick<Partial<RadioStateReturn>, "state" | "setState"> & {
+export type RadioOptions<T> = RoverOptions &
+  Pick<Partial<RadioStateReturn<T>>, "state" | "setState"> & {
     /**
      * Same as the `value` attribute.
      */
-    value: any;
+    value: T;
     /**
      * Same as the `checked` attribute.
      */
@@ -19,9 +20,10 @@ export type RadioOptions = RoverOptions &
 
 export type RadioHTMLProps = RoverHTMLProps & React.InputHTMLAttributes<any>;
 
-export type RadioProps = RadioOptions & RadioHTMLProps;
+export type RadioProps<T> = RadioOptions<T> & RadioHTMLProps;
 
-export const useRadio = createHook<RadioOptions, RadioHTMLProps>({
+
+export const useRadio = createHook<RadioOptions<string>, RadioHTMLProps>({
   name: "Radio",
   compose: useRover,
   useState: useRadioState,
@@ -75,7 +77,9 @@ export const useRadio = createHook<RadioOptions, RadioHTMLProps>({
   }
 });
 
-export const Radio = createComponent({
+export const Radio: <T, S extends As = "input">(
+  props: PropsWithAs<RadioOptions<T>, S>
+) => JSX.Element = createComponent({
   as: "input",
   useHook: useRadio
 });

--- a/packages/reakit/src/Radio/Radio.ts
+++ b/packages/reakit/src/Radio/Radio.ts
@@ -6,7 +6,7 @@ import { useAllCallbacks } from "reakit-utils/useAllCallbacks";
 import { RoverOptions, RoverHTMLProps, useRover } from "../Rover/Rover";
 import { useRadioState, RadioStateReturn } from "./RadioState";
 
-export type RadioOptions<T> = RoverOptions &
+export type RadioOptions<T = any> = RoverOptions &
   Pick<Partial<RadioStateReturn<T>>, "state" | "setState"> & {
     /**
      * Same as the `value` attribute.

--- a/packages/reakit/src/Radio/Radio.ts
+++ b/packages/reakit/src/Radio/Radio.ts
@@ -20,7 +20,7 @@ export type RadioOptions<T = any> = RoverOptions &
 
 export type RadioHTMLProps = RoverHTMLProps & React.InputHTMLAttributes<any>;
 
-export type RadioProps<T> = RadioOptions<T> & RadioHTMLProps;
+export type RadioProps<T = any> = RadioOptions<T> & RadioHTMLProps;
 
 export const useRadio = createHook<RadioOptions<string>, RadioHTMLProps>({
   name: "Radio",

--- a/packages/reakit/src/Radio/RadioState.ts
+++ b/packages/reakit/src/Radio/RadioState.ts
@@ -47,7 +47,7 @@ export function useRadioState<T = string>(
   };
 }
 
-const keys: Array<keyof RadioStateReturn<any>> = [
+const keys: Array<keyof RadioStateReturn> = [
   ...useRoverState.__keys,
   "state",
   "setState"

--- a/packages/reakit/src/Radio/RadioState.ts
+++ b/packages/reakit/src/Radio/RadioState.ts
@@ -10,28 +10,28 @@ import {
   useRoverState
 } from "../Rover";
 
-export type RadioState = RoverState & {
+export type RadioState<T> = RoverState & {
   /**
    * The `value` attribute of the current checked radio.
    */
-  state: any;
+  state: T;
 };
 
-export type RadioActions = RoverActions & {
+export type RadioActions<T> = RoverActions & {
   /**
    * Sets `state`.
    */
-  setState: React.Dispatch<React.SetStateAction<any>>;
+  setState: React.Dispatch<React.SetStateAction<T>>;
 };
 
-export type RadioInitialState = RoverInitialState &
-  Partial<Pick<RadioState, "state">>;
+export type RadioInitialState<T = string> = RoverInitialState &
+  Partial<Pick<RadioState<T>, "state">>;
 
-export type RadioStateReturn = RadioState & RadioActions;
+export type RadioStateReturn<T> = RadioState<T> & RadioActions<T>;
 
-export function useRadioState(
-  initialState: SealedInitialState<RadioInitialState> = {}
-): RadioStateReturn {
+export function useRadioState<T = string>(
+  initialState: SealedInitialState<RadioInitialState<T>> = {}
+): RadioStateReturn<T | undefined> {
   const { state: initialCurrentValue, loop = true, ...sealed } = useSealedState(
     initialState
   );
@@ -47,7 +47,7 @@ export function useRadioState(
   };
 }
 
-const keys: Array<keyof RadioStateReturn> = [
+const keys: Array<keyof RadioStateReturn<any>> = [
   ...useRoverState.__keys,
   "state",
   "setState"

--- a/packages/reakit/src/Radio/RadioState.ts
+++ b/packages/reakit/src/Radio/RadioState.ts
@@ -29,7 +29,7 @@ export type RadioInitialState<T = string> = RoverInitialState &
 
 export type RadioStateReturn<T = any> = RadioState<T> & RadioActions<T>;
 
-export function useRadioState<T = string>(
+export function useRadioState<T = any>(
   initialState: SealedInitialState<RadioInitialState<T>> = {}
 ): RadioStateReturn<T | undefined> {
   const { state: initialCurrentValue, loop = true, ...sealed } = useSealedState(

--- a/packages/reakit/src/Radio/RadioState.ts
+++ b/packages/reakit/src/Radio/RadioState.ts
@@ -27,7 +27,7 @@ export type RadioActions<T> = RoverActions & {
 export type RadioInitialState<T = string> = RoverInitialState &
   Partial<Pick<RadioState<T>, "state">>;
 
-export type RadioStateReturn<T> = RadioState<T> & RadioActions<T>;
+export type RadioStateReturn<T = any> = RadioState<T> & RadioActions<T>;
 
 export function useRadioState<T = string>(
   initialState: SealedInitialState<RadioInitialState<T>> = {}

--- a/packages/reakit/src/Radio/__tests__/index-test.tsx
+++ b/packages/reakit/src/Radio/__tests__/index-test.tsx
@@ -82,18 +82,17 @@ test("onChange non-native radio", () => {
 
 test("group", () => {
   const Test = () => {
-    type Superhero = "superman" | "batman";
-    const radio = useRadioState<Superhero>({ state: "superman" });
-
+    const radio = useRadioState();
     return (
-      <RadioGroup {...radio} aria-label="superhero">
+      <RadioGroup {...radio} aria-label="radiogroup" id="base">
         <label>
-          <Radio<Superhero> {...radio} id="base-1" value="superman" />
-          Clark Kent
+          <Radio {...radio} value="a" />a
         </label>
         <label>
-          <Radio {...radio} id="base-2" value="batman" />
-          Bruce Wayne
+          <Radio {...radio} value="b" />b
+        </label>
+        <label>
+          <Radio {...radio} value="c" />c
         </label>
       </RadioGroup>
     );
@@ -102,20 +101,20 @@ test("group", () => {
   expect(container).toMatchInlineSnapshot(`
     <div>
       <fieldset
-        aria-label="superhero"
+        aria-label="radiogroup"
+        id="base"
         role="radiogroup"
       >
         <label>
           <input
-            aria-checked="true"
-            checked=""
+            aria-checked="false"
             id="base-1"
             role="radio"
             tabindex="0"
             type="radio"
-            value="superman"
+            value="a"
           />
-          Clark Kent
+          a
         </label>
         <label>
           <input
@@ -124,9 +123,20 @@ test("group", () => {
             role="radio"
             tabindex="-1"
             type="radio"
-            value="batman"
+            value="b"
           />
-          Bruce Wayne
+          b
+        </label>
+        <label>
+          <input
+            aria-checked="false"
+            id="base-3"
+            role="radio"
+            tabindex="-1"
+            type="radio"
+            value="c"
+          />
+          c
         </label>
       </fieldset>
     </div>

--- a/packages/reakit/src/Radio/__tests__/index-test.tsx
+++ b/packages/reakit/src/Radio/__tests__/index-test.tsx
@@ -21,7 +21,7 @@ test("click on radio", () => {
 
 test("click on non-native radio", () => {
   const Test = () => {
-    const radio = useRadioState();
+    const radio = useRadioState<"radio">();
     return (
       <label>
         <Radio {...radio} as="div" value="radio" />
@@ -82,17 +82,18 @@ test("onChange non-native radio", () => {
 
 test("group", () => {
   const Test = () => {
-    const radio = useRadioState();
+    type Superhero = "superman" | "batman";
+    const radio = useRadioState<Superhero>({ state: "superman" });
+
     return (
-      <RadioGroup {...radio} aria-label="radiogroup" id="base">
+      <RadioGroup {...radio} aria-label="superhero">
         <label>
-          <Radio {...radio} value="a" />a
+          <Radio<Superhero> {...radio} id="base-1" value="superman" />
+          Clark Kent
         </label>
         <label>
-          <Radio {...radio} value="b" />b
-        </label>
-        <label>
-          <Radio {...radio} value="c" />c
+          <Radio {...radio} id="base-2" value="batman" />
+          Bruce Wayne
         </label>
       </RadioGroup>
     );
@@ -101,20 +102,20 @@ test("group", () => {
   expect(container).toMatchInlineSnapshot(`
     <div>
       <fieldset
-        aria-label="radiogroup"
-        id="base"
+        aria-label="superhero"
         role="radiogroup"
       >
         <label>
           <input
-            aria-checked="false"
+            aria-checked="true"
+            checked=""
             id="base-1"
             role="radio"
             tabindex="0"
             type="radio"
-            value="a"
+            value="superman"
           />
-          a
+          Clark Kent
         </label>
         <label>
           <input
@@ -123,20 +124,9 @@ test("group", () => {
             role="radio"
             tabindex="-1"
             type="radio"
-            value="b"
+            value="batman"
           />
-          b
-        </label>
-        <label>
-          <input
-            aria-checked="false"
-            id="base-3"
-            role="radio"
-            tabindex="-1"
-            type="radio"
-            value="c"
-          />
-          c
+          Bruce Wayne
         </label>
       </fieldset>
     </div>


### PR DESCRIPTION
Hi! :) I've added a generic parameter to Radio and useRadioState to typecheck typos like the one below.

![image](https://user-images.githubusercontent.com/15332326/63089060-f29d5280-bf56-11e9-9386-cb37421ee44c.png)


**Does this PR introduce a breaking change?**

Yup. If someone is importing `RadioProps` or `RadioOptions`, he'd have to add `<any>` to them.

We could get rid of this breaking change by defaulting to `any` (`RadioOptions<T = any>`).
I'm happy to do another commit if you think it's the right course of action.

- `useRadioState` is now generic

  **Before:**
  ```ts
  const radio = useRadioState();
  ```
  **After:**
  ```ts
  const radio = useRadioState<string>();
  // or
  const radio = useRadioState<"superman" | "batman">();
  ```

- `RadioProps` and `RadioOptions` are now generic

  **Before:**
  ```ts
  interface MyRadioProps extends RadioOptions { /* ... */ }
  ```
  **After:**
  ```ts
  interface MyRadioProps extends RadioOptions<any> { /* ... */ }
  // or
  interface MyRadioProps<T> extends RadioOptions<T> { /* ... */ }
  ```
