### PR TITLE
feat: Support nested `Tabbable` and `Rover` components

### DIFF
--- a/packages/reakit-utils/src/hasFocusWithin.ts
+++ b/packages/reakit-utils/src/hasFocusWithin.ts
@@ -1,0 +1,4 @@
+export function hasFocusWithin(element: Element) {
+  if (!document.activeElement) return false;
+  return element.contains(document.activeElement);
+}

--- a/packages/reakit-utils/src/index.ts
+++ b/packages/reakit-utils/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./createOnKeyDown";
 export * from "./cx";
+export * from "./hasFocusWithin";
 export * from "./isEmpty";
 export * from "./isInteger";
 export * from "./isObject";

--- a/packages/reakit/src/Menu/Menu.tsx
+++ b/packages/reakit/src/Menu/Menu.tsx
@@ -100,6 +100,7 @@ export const useMenu = createHook<MenuOptions, MenuHTMLProps>({
           stopPropagation: true,
           shouldKeyDown: event => {
             return Boolean(
+              // https://github.com/facebook/react/issues/11387
               parent && event.currentTarget.contains(event.target as Element)
             );
           },

--- a/packages/reakit/src/Menu/Menu.tsx
+++ b/packages/reakit/src/Menu/Menu.tsx
@@ -93,7 +93,6 @@ export const useMenu = createHook<MenuOptions, MenuHTMLProps>({
       ]
     );
 
-    // TODO: Refactor
     const parentBindings = React.useMemo(
       () =>
         createOnKeyDown({

--- a/packages/reakit/src/Menu/__utils/useShortcuts.ts
+++ b/packages/reakit/src/Menu/__utils/useShortcuts.ts
@@ -53,6 +53,7 @@ export function useShortcuts(
       }
     };
 
+    // https://github.com/facebook/react/issues/11387#issuecomment-524113945
     menu.addEventListener("keydown", onKeyDown);
     return () => menu.removeEventListener("keydown", onKeyDown);
   }, [menuRef, setKeys]);

--- a/packages/reakit/src/Rover/Rover.ts
+++ b/packages/reakit/src/Rover/Rover.ts
@@ -97,7 +97,6 @@ export const useRover = createHook<RoverOptions, RoverHTMLProps>({
       };
     }, [options.move, stopId]);
 
-    // TODO: Refactor
     const onKeyDown = React.useMemo(
       () =>
         createOnKeyDown({

--- a/packages/reakit/src/Rover/Rover.ts
+++ b/packages/reakit/src/Rover/Rover.ts
@@ -2,11 +2,10 @@ import * as React from "react";
 import { createComponent } from "reakit-system/createComponent";
 import { createHook } from "reakit-system/createHook";
 import { useId } from "reakit-utils/useId";
-import { useUpdateEffect } from "reakit-utils/useUpdateEffect";
 import { createOnKeyDown } from "reakit-utils/createOnKeyDown";
 import { warning } from "reakit-utils/warning";
-import { useAllCallbacks } from "reakit-utils/useAllCallbacks";
 import { mergeRefs } from "reakit-utils/mergeRefs";
+import { hasFocusWithin } from "reakit-utils/hasFocusWithin";
 import {
   TabbableOptions,
   TabbableHTMLProps,
@@ -49,7 +48,6 @@ export const useRover = createHook<RoverOptions, RoverHTMLProps>({
     {
       ref: htmlRef,
       tabIndex: htmlTabIndex,
-      onFocus: htmlOnFocus,
       onKeyDown: htmlOnKeyDown,
       ...htmlProps
     }
@@ -70,7 +68,7 @@ export const useRover = createHook<RoverOptions, RoverHTMLProps>({
       return () => options.unregister(stopId);
     }, [stopId, trulyDisabled, options.register, options.unregister]);
 
-    useUpdateEffect(() => {
+    React.useEffect(() => {
       if (!ref.current) {
         warning(
           true,
@@ -80,20 +78,35 @@ export const useRover = createHook<RoverOptions, RoverHTMLProps>({
         );
         return;
       }
-      if (document.activeElement !== ref.current && focused) {
+      if (options.unstable_moves && focused && !hasFocusWithin(ref.current)) {
         ref.current.focus();
       }
     }, [focused, options.unstable_moves]);
 
-    const onFocus = React.useCallback(() => options.move(stopId), [
-      options.move,
-      stopId
-    ]);
+    React.useEffect(() => {
+      if (!ref.current) return undefined;
 
+      const onFocus = () => options.move(stopId);
+
+      // https://github.com/facebook/react/issues/11387#issuecomment-524113945
+      ref.current.addEventListener("focus", onFocus, true);
+      return () => {
+        if (ref.current) {
+          ref.current.removeEventListener("focus", onFocus, true);
+        }
+      };
+    }, [options.move, stopId]);
+
+    // TODO: Refactor
     const onKeyDown = React.useMemo(
       () =>
         createOnKeyDown({
           onKeyDown: htmlOnKeyDown,
+          stopPropagation: true,
+          // Ignore portals
+          shouldKeyDown: event =>
+            // https://github.com/facebook/react/issues/11387
+            event.currentTarget.contains(event.target as Node),
           keyMap: {
             ArrowUp: options.orientation !== "horizontal" && options.previous,
             ArrowRight: options.orientation !== "vertical" && options.next,
@@ -120,7 +133,6 @@ export const useRover = createHook<RoverOptions, RoverHTMLProps>({
       id: stopId,
       tabIndex: shouldTabIndex ? htmlTabIndex : -1,
       onKeyDown,
-      onFocus: useAllCallbacks(onFocus, htmlOnFocus),
       ...htmlProps
     };
   }

--- a/packages/reakit/src/Rover/__tests__/index-test.tsx
+++ b/packages/reakit/src/Rover/__tests__/index-test.tsx
@@ -206,3 +206,51 @@ test("move focus by calling state callbacks", () => {
   fireEvent.click(first);
   expect(rover1).toHaveFocus();
 });
+
+test("move focus in nested rover", () => {
+  const Test = () => {
+    const rover1 = useRoverState({ orientation: "horizontal" });
+    const rover2 = useRoverState({ orientation: "vertical" });
+    return (
+      <>
+        <Rover {...rover1}>rover11</Rover>
+        <Rover {...rover1} as="div">
+          rover12
+          <Rover {...rover2}>rover21</Rover>
+          <Rover {...rover2}>rover22</Rover>
+          <Rover {...rover2}>rover23</Rover>
+        </Rover>
+        <Rover {...rover1}>rover13</Rover>
+      </>
+    );
+  };
+  const { getByText } = render(<Test />);
+  const rover11 = getByText("rover11");
+  const rover12 = getByText("rover12");
+  const rover13 = getByText("rover13");
+  const rover21 = getByText("rover21");
+  const rover22 = getByText("rover22");
+  const rover23 = getByText("rover23");
+  act(() => rover11.focus());
+  expect(rover11).toHaveFocus();
+
+  keyDown("ArrowRight");
+  expect(rover12).toHaveFocus();
+  keyDown("ArrowRight");
+  expect(rover13).toHaveFocus();
+
+  act(() => rover22.focus());
+  expect(rover22).toHaveFocus();
+
+  keyDown("ArrowDown");
+  expect(rover23).toHaveFocus();
+  keyDown("ArrowUp");
+  expect(rover22).toHaveFocus();
+  keyDown("ArrowUp");
+  expect(rover21).toHaveFocus();
+  keyDown("ArrowDown");
+  expect(rover22).toHaveFocus();
+
+  keyDown("ArrowLeft");
+  expect(rover11).toHaveFocus();
+});

--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -74,7 +74,6 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
     const clickKeysRef = useLiveRef(options.unstable_clickKeys);
     const trulyDisabled = options.disabled && !options.focusable;
 
-    // TODO: Refactor
     const onMouseDown = React.useCallback(
       (event: React.MouseEvent) => {
         if (

--- a/packages/reakit/src/Tabbable/__tests__/Tabbable-test.tsx
+++ b/packages/reakit/src/Tabbable/__tests__/Tabbable-test.tsx
@@ -233,3 +233,16 @@ test("focus on mouse down", () => {
   fireEvent.mouseDown(tabbable);
   expect(tabbable).toHaveFocus();
 });
+
+test("focus nested native tabbables", () => {
+  const { getByText } = render(
+    <Tabbable as="div">
+      tabbable<button>button</button>
+    </Tabbable>
+  );
+  const button = getByText("button");
+  expect(button).not.toHaveFocus();
+  button.focus();
+  fireEvent.mouseDown(button);
+  expect(button).toHaveFocus();
+});


### PR DESCRIPTION
This PR updates `Tabbable` and `Rover` components to support nested interactive components.

It also fixes some issues around Portals bubbling events to `Tabbable` and `Rover` (reference: https://github.com/facebook/react/issues/11387#issuecomment-524113945)

Look at tests for usage examples.

Closes #376