### PR TITLE
feat: Add new `MenuArrow` component

### DIFF
--- a/packages/reakit-playground/src/__deps/reakit.ts
+++ b/packages/reakit-playground/src/__deps/reakit.ts
@@ -50,6 +50,7 @@ export default {
   "reakit/Menu/MenuItem": require("reakit/Menu/MenuItem"),
   "reakit/Menu/MenuGroup": require("reakit/Menu/MenuGroup"),
   "reakit/Menu/MenuDisclosure": require("reakit/Menu/MenuDisclosure"),
+  "reakit/Menu/MenuArrow": require("reakit/Menu/MenuArrow"),
   "reakit/Menu/Menu": require("reakit/Menu/Menu"),
   "reakit/Hidden": require("reakit/Hidden"),
   "reakit/Hidden/HiddenState": require("reakit/Hidden/HiddenState"),

--- a/packages/reakit/src/Form/README.md
+++ b/packages/reakit/src/Form/README.md
@@ -521,6 +521,19 @@ If `onValidate` throws, `onSubmit` will not be called.
 just like `onValidate`. The only difference is that this validation will
 only occur on submit.
 
+### `Form`
+
+<details><summary>1 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
+- **`submit`**
+  <code>() =&#62; void</code>
+
+  Triggers form submission (calling `onValidate` and `onSubmit` underneath).
+
+</details>
+
 ### `FormCheckbox`
 
 - **`disabled`**
@@ -790,16 +803,36 @@ similarly to `readOnly` on form elements. In this case, only
 
 </details>
 
-### `Form`
+### `FormRadio`
 
-<details><summary>1 state props</summary>
+- **`name`**
+  <code>P</code>
+
+  FormRadio's name as in form values.
+
+- **`value`**
+  <code title="P extends DeepPathArray&#60;V, P&#62; ? DeepPathArrayValue&#60;V, P&#62; : P extends keyof V ? V[P] : any">P extends DeepPathArray&#60;V, P&#62; ? DeepPathArrayVa...</code>
+
+  FormRadio's value.
+
+<details><summary>3 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 
-- **`submit`**
-  <code>() =&#62; void</code>
+- **`values`**
+  <code>V</code>
 
-  Triggers form submission (calling `onValidate` and `onSubmit` underneath).
+  Form values.
+
+- **`update`**
+  <code>Update&#60;V&#62;</code>
+
+  Updates a form value.
+
+- **`blur`**
+  <code>&#60;P extends DeepPath&#60;V, P&#62;&#62;(name: P) =&#62; void</code>
+
+  Sets field's touched state to `true`.
 
 </details>
 
@@ -911,38 +944,5 @@ similarly to `readOnly` on form elements. In this case, only
   <code>() =&#62; void</code>
 
   Triggers form submission (calling `onValidate` and `onSubmit` underneath).
-
-</details>
-
-### `FormRadio`
-
-- **`name`**
-  <code>P</code>
-
-  FormRadio's name as in form values.
-
-- **`value`**
-  <code title="P extends DeepPathArray&#60;V, P&#62; ? DeepPathArrayValue&#60;V, P&#62; : P extends keyof V ? V[P] : any">P extends DeepPathArray&#60;V, P&#62; ? DeepPathArrayVa...</code>
-
-  FormRadio's value.
-
-<details><summary>3 state props</summary>
-
-> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
-
-- **`values`**
-  <code>V</code>
-
-  Form values.
-
-- **`update`**
-  <code>Update&#60;V&#62;</code>
-
-  Updates a form value.
-
-- **`blur`**
-  <code>&#60;P extends DeepPath&#60;V, P&#62;&#62;(name: P) =&#62; void</code>
-
-  Sets field's touched state to `true`.
 
 </details>

--- a/packages/reakit/src/Menu/MenuArrow.ts
+++ b/packages/reakit/src/Menu/MenuArrow.ts
@@ -1,0 +1,25 @@
+import { createComponent } from "reakit-system/createComponent";
+import { createHook } from "reakit-system/createHook";
+import {
+  PopoverArrowOptions,
+  PopoverArrowHTMLProps,
+  usePopoverArrow
+} from "../Popover/PopoverArrow";
+import { useMenuState } from "./MenuState";
+
+export type MenuArrowOptions = PopoverArrowOptions;
+
+export type MenuArrowHTMLProps = PopoverArrowHTMLProps;
+
+export type MenuArrowProps = MenuArrowOptions & MenuArrowHTMLProps;
+
+export const useMenuArrow = createHook<MenuArrowOptions, MenuArrowHTMLProps>({
+  name: "MenuArrow",
+  compose: usePopoverArrow,
+  useState: useMenuState
+});
+
+export const MenuArrow = createComponent({
+  as: "div",
+  useHook: useMenuArrow
+});

--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -50,6 +50,7 @@ function Example() {
 You can use either `onClick` or `href` props on `MenuItem` to define menu actions.
 
 <!-- eslint-disable no-console -->
+
 ```jsx
 import {
   useMenuState,
@@ -553,6 +554,24 @@ It's called after given milliseconds if `animated` is a number.
   <code>() =&#62; void</code>
 
   Moves focus to the previous element.
+
+</details>
+
+### `MenuArrow`
+
+- **`size`**
+  <code>string | number | undefined</code>
+
+  Arrow's size
+
+<details><summary>1 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
+- **`placement`**
+  <code title="&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start&#34; | &#34;top&#34; | &#34;top-end&#34; | &#34;right-start&#34; | &#34;right&#34; | &#34;right-end&#34; | &#34;bottom-end&#34; | &#34;bottom&#34; | &#34;bottom-start&#34; | &#34;left-end&#34; | &#34;left&#34; | &#34;left-start&#34;">&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start...</code>
+
+  Actual `placement`.
 
 </details>
 

--- a/packages/reakit/src/Menu/__tests__/MenuArrow-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/MenuArrow-test.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { render } from "@testing-library/react";
+import { MenuArrow } from "../MenuArrow";
+
+test("render", () => {
+  const { baseElement } = render(<MenuArrow placement="top" />);
+  expect(baseElement).toMatchInlineSnapshot(`
+    <body>
+      <div>
+        <div
+          style="top: 100%; position: absolute; font-size: 30px; width: 1em; height: 1em; pointer-events: none; transform: rotateZ(180deg);"
+        >
+          <svg
+            viewBox="0 0 30 30"
+          >
+            <path
+              class="stroke"
+              d="M23.7,27.1L17,19.9C16.5,19.3,15.8,19,15,19s-1.6,0.3-2.1,0.9l-6.6,7.2C5.3,28.1,3.4,29,2,29h26 C26.7,29,24.6,28.1,23.7,27.1z"
+            />
+            <path
+              class="fill"
+              d="M23,27.8c1.1,1.2,3.4,2.2,5,2.2h2H0h2c1.7,0,3.9-1,5-2.2l6.6-7.2c0.7-0.8,2-0.8,2.7,0L23,27.8L23,27.8z"
+            />
+          </svg>
+        </div>
+      </div>
+    </body>
+  `);
+});

--- a/packages/reakit/src/Menu/index.ts
+++ b/packages/reakit/src/Menu/index.ts
@@ -1,4 +1,5 @@
 export * from "./Menu";
+export * from "./MenuArrow";
 export * from "./MenuDisclosure";
 export * from "./MenuGroup";
 export * from "./MenuItem";


### PR DESCRIPTION
Usage:

```jsx
import {
  useMenuState,
  Menu,
  MenuArrow,
  MenuItem,
  MenuDisclosure,
  MenuSeparator
} from "reakit/Menu";

function Example() {
  const menu = useMenuState({ unstable_gutter: 14 });
  return (
    <>
      <MenuDisclosure {...menu}>Preferences</MenuDisclosure>
      <Menu {...menu} aria-label="Preferences">
        <MenuArrow {...menu} />
        <MenuItem {...menu}>Settings</MenuItem>
        <MenuItem {...menu} disabled>
          Extensions
        </MenuItem>
        <MenuSeparator {...menu} />
        <MenuItem {...menu}>Keyboard shortcuts</MenuItem>
      </Menu>
    </>
  );
}

```