### PR TITLE
feat: Add support for `HiddenDisclosure` to control multiple `Hidden` components

### DIFF
--- a/packages/reakit/src/Hidden/Hidden.ts
+++ b/packages/reakit/src/Hidden/Hidden.ts
@@ -5,6 +5,8 @@ import { cx } from "reakit-utils/cx";
 import { useAllCallbacks } from "reakit-utils/useAllCallbacks";
 import { BoxOptions, BoxHTMLProps, useBox } from "../Box/Box";
 import { useHiddenState, HiddenStateReturn } from "./HiddenState";
+import { useWarningIfMultiple } from "./__utils/useWarningIfMultiple";
+import { useSetIsMounted } from "./__utils/useSetIsMounted";
 
 export type HiddenOptions = BoxOptions &
   Pick<
@@ -38,16 +40,8 @@ export const useHidden = createHook<HiddenOptions, HiddenHTMLProps>({
   ) {
     const [hiddenClass, setHiddenClass] = React.useState<string | null>(null);
 
-    React.useEffect(() => {
-      if (options.unstable_setIsMounted) {
-        options.unstable_setIsMounted(true);
-      }
-      return () => {
-        if (options.unstable_setIsMounted) {
-          options.unstable_setIsMounted(false);
-        }
-      };
-    }, [options.unstable_setIsMounted]);
+    useWarningIfMultiple(options);
+    useSetIsMounted(options);
 
     React.useEffect(() => {
       setHiddenClass(!options.visible ? "hidden" : null);

--- a/packages/reakit/src/Hidden/HiddenDisclosure.ts
+++ b/packages/reakit/src/Hidden/HiddenDisclosure.ts
@@ -21,11 +21,18 @@ export const useHiddenDisclosure = createHook<
   compose: useButton,
   useState: useHiddenState,
 
-  useProps(options, { onClick: htmlOnClick, ...htmlProps }) {
+  useProps(
+    options,
+    { onClick: htmlOnClick, "aria-controls": ariaControls, ...htmlProps }
+  ) {
+    const controls = ariaControls
+      ? `${ariaControls} ${options.unstable_hiddenId}`
+      : options.unstable_hiddenId;
+
     return {
       onClick: useAllCallbacks(options.toggle, htmlOnClick),
       "aria-expanded": Boolean(options.visible),
-      "aria-controls": options.unstable_hiddenId,
+      "aria-controls": controls,
       ...htmlProps
     };
   }

--- a/packages/reakit/src/Hidden/HiddenState.ts
+++ b/packages/reakit/src/Hidden/HiddenState.ts
@@ -143,8 +143,7 @@ export function useHiddenState(
     hide,
     toggle,
     unstable_stopAnimation: stopAnimation,
-    unstable_setIsMounted:
-      process.env.NODE_ENV !== "production" ? setIsMounted : undefined
+    unstable_setIsMounted: setIsMounted
   };
 }
 

--- a/packages/reakit/src/Hidden/README.md
+++ b/packages/reakit/src/Hidden/README.md
@@ -59,6 +59,34 @@ function Example() {
 }
 ```
 
+### Multiple components
+
+Each `Hidden` component should have its own `useHiddenState`. This is also true for derivative modules like [Dialog](/docs/dialog/), [Popover](/docs/popover/), [Menu](/docs/menu/), [Tooltip](/docs/tooltip/) etc.
+
+If you want to have only one `HiddenDisclosure` element controling multiple `Hidden` components, you can use [render props](/docs/composition/#render-props) to apply the same state to different `HiddenDisclosure`s that will result in a single element.
+
+```jsx
+import { useHiddenState, Hidden, HiddenDisclosure } from "reakit/Hidden";
+
+function Example() {
+  const hidden1 = useHiddenState();
+  const hidden2 = useHiddenState();
+  return (
+    <>
+      <HiddenDisclosure {...hidden1}>
+        {props => (
+          <HiddenDisclosure {...props} {...hidden2}>
+            Toggle All
+          </HiddenDisclosure>
+        )}
+      </HiddenDisclosure>
+      <Hidden {...hidden1}>Hidden 1</Hidden>
+      <Hidden {...hidden2}>Hidden 2</Hidden>
+    </>
+  );
+}
+```
+
 ## Accessibility
 
 - `HiddenDisclosure` extends the accessibility features of [Button](/docs/button/#accessibility).

--- a/packages/reakit/src/Hidden/__tests__/HiddenDisclosure-test.tsx
+++ b/packages/reakit/src/Hidden/__tests__/HiddenDisclosure-test.tsx
@@ -12,15 +12,15 @@ test("render", () => {
     <HiddenDisclosure {...props}>disclosure</HiddenDisclosure>
   );
   expect(getByText("disclosure")).toMatchInlineSnapshot(`
-        <button
-          aria-controls="test"
-          aria-expanded="false"
-          tabindex="0"
-          type="button"
-        >
-          disclosure
-        </button>
-    `);
+    <button
+      aria-controls="test"
+      aria-expanded="false"
+      tabindex="0"
+      type="button"
+    >
+      disclosure
+    </button>
+  `);
 });
 
 test("render visible", () => {
@@ -33,6 +33,24 @@ test("render visible", () => {
     <button
       aria-controls="test"
       aria-expanded="true"
+      tabindex="0"
+      type="button"
+    >
+      disclosure
+    </button>
+  `);
+});
+
+test("render with aria-controls", () => {
+  const { getByText } = render(
+    <HiddenDisclosure {...props} aria-controls="a">
+      disclosure
+    </HiddenDisclosure>
+  );
+  expect(getByText("disclosure")).toMatchInlineSnapshot(`
+    <button
+      aria-controls="a test"
+      aria-expanded="false"
       tabindex="0"
       type="button"
     >

--- a/packages/reakit/src/Hidden/__tests__/index-test.tsx
+++ b/packages/reakit/src/Hidden/__tests__/index-test.tsx
@@ -1,23 +1,17 @@
 import * as React from "react";
 import { render, fireEvent } from "@testing-library/react";
-import {
-  Hidden,
-  HiddenDisclosure,
-  useHiddenState,
-  HiddenInitialState
-} from "..";
-
-function Test(props: HiddenInitialState) {
-  const hidden = useHiddenState(props);
-  return (
-    <>
-      <HiddenDisclosure {...hidden}>disclosure</HiddenDisclosure>
-      <Hidden {...hidden}>hidden</Hidden>
-    </>
-  );
-}
+import { Hidden, HiddenDisclosure, useHiddenState } from "..";
 
 test("show", () => {
+  function Test() {
+    const hidden = useHiddenState();
+    return (
+      <>
+        <HiddenDisclosure {...hidden}>disclosure</HiddenDisclosure>
+        <Hidden {...hidden}>hidden</Hidden>
+      </>
+    );
+  }
   const { getByText } = render(<Test />);
   const disclosure = getByText("disclosure");
   const hidden = getByText("hidden");
@@ -27,10 +21,48 @@ test("show", () => {
 });
 
 test("hide", () => {
-  const { getByText } = render(<Test visible />);
+  function Test() {
+    const hidden = useHiddenState({ visible: true });
+    return (
+      <>
+        <HiddenDisclosure {...hidden}>disclosure</HiddenDisclosure>
+        <Hidden {...hidden}>hidden</Hidden>
+      </>
+    );
+  }
+  const { getByText } = render(<Test />);
   const disclosure = getByText("disclosure");
   const hidden = getByText("hidden");
   expect(hidden).toBeVisible();
   fireEvent.click(disclosure);
   expect(hidden).not.toBeVisible();
+});
+
+test("multiple components", () => {
+  function Test() {
+    const hidden1 = useHiddenState();
+    const hidden2 = useHiddenState();
+    return (
+      <>
+        <HiddenDisclosure {...hidden1}>
+          {props => (
+            <HiddenDisclosure {...props} {...hidden2}>
+              disclosure
+            </HiddenDisclosure>
+          )}
+        </HiddenDisclosure>
+        <Hidden {...hidden1}>hidden1</Hidden>
+        <Hidden {...hidden2}>hidden2</Hidden>
+      </>
+    );
+  }
+  const { getByText } = render(<Test />);
+  const disclosure = getByText("disclosure");
+  const hidden1 = getByText("hidden1");
+  const hidden2 = getByText("hidden2");
+  expect(hidden1).not.toBeVisible();
+  expect(hidden2).not.toBeVisible();
+  fireEvent.click(disclosure);
+  expect(hidden1).toBeVisible();
+  expect(hidden2).toBeVisible();
 });

--- a/packages/reakit/src/Hidden/__utils/useSetIsMounted.ts
+++ b/packages/reakit/src/Hidden/__utils/useSetIsMounted.ts
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { HiddenOptions } from "../Hidden";
+
+export function useSetIsMounted(options: HiddenOptions) {
+  if (process.env.NODE_ENV === "production") return;
+
+  React.useEffect(() => {
+    if (options.unstable_setIsMounted) {
+      options.unstable_setIsMounted(true);
+    }
+    return () => {
+      if (options.unstable_setIsMounted) {
+        options.unstable_setIsMounted(false);
+      }
+    };
+  }, [options.unstable_setIsMounted]);
+}

--- a/packages/reakit/src/Hidden/__utils/useWarningIfMultiple.ts
+++ b/packages/reakit/src/Hidden/__utils/useWarningIfMultiple.ts
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { warning } from "reakit-utils/warning";
+import { HiddenOptions } from "../Hidden";
+
+export function useWarningIfMultiple(options: HiddenOptions) {
+  if (process.env.NODE_ENV === "production") return;
+
+  React.useEffect(() => {
+    if (!options.unstable_hiddenId) return;
+
+    warning(
+      document.querySelectorAll(`#${options.unstable_hiddenId}`).length > 1,
+      "Hidden",
+      "You're reusing the same `useModuleState` for multiple components (Hidden, Dialog, Popover, Menu etc.).",
+      "This is not allowed! If you want to use multiple components, make sure you're using different states.",
+      "See https://reakit.io/docs/hidden/#multiple-components"
+    );
+  }, [options.unstable_hiddenId]);
+}


### PR DESCRIPTION
### Multiple components

 Each `Hidden` component should have its own `useHiddenState`. This is also true for derivative modules like [Dialog](https://reakit.io/docs/dialog/), [Popover](https://reakit.io/docs/popover/), [Menu](https://reakit.io/docs/menu/), [Tooltip](https://reakit.io/docs/tooltip/) etc.

 If you want to have only one `HiddenDisclosure` element controling multiple `Hidden` components, you can use [render props](https://reakit.io/docs/composition/#render-props) to apply the same state to different `HiddenDisclosure`s that will result in a single element.

 ```jsx
import { useHiddenState, Hidden, HiddenDisclosure } from "reakit/Hidden";

function Example() {
  const hidden1 = useHiddenState();
  const hidden2 = useHiddenState();
  return (
    <>
      <HiddenDisclosure {...hidden1}>
        {props => (
          <HiddenDisclosure {...props} {...hidden2}>
            Toggle All
          </HiddenDisclosure>
        )}
      </HiddenDisclosure>
      <Hidden {...hidden1}>Hidden 1</Hidden>
      <Hidden {...hidden2}>Hidden 2</Hidden>
    </>
  );
}
```