### PR TITLE
fix: Fix `Dialog` with `tabIndex={0}` not being included in the tab order

### DIFF
--- a/packages/reakit-utils/src/tabbable.ts
+++ b/packages/reakit-utils/src/tabbable.ts
@@ -53,14 +53,16 @@ export function isFocusable(element: Element) {
 }
 
 export function isTabbable(element: Element) {
-  if (!isHTMLElement(element)) return false;
-  if (!isFocusable(element)) return false;
-  if (hasNegativeTabIndex(element)) return false;
-  return true;
+  return (
+    isHTMLElement(element) &&
+    isFocusable(element) &&
+    !hasNegativeTabIndex(element)
+  );
 }
 
 export function getAllFocusableIn<T extends Element>(container: T) {
   const allFocusable = Array.from(container.querySelectorAll<T>(selector));
+  allFocusable.unshift(container);
   return allFocusable.filter(isFocusable);
 }
 
@@ -75,6 +77,11 @@ export function getAllTabbableIn<T extends Element>(
 ) {
   const allFocusable = Array.from(container.querySelectorAll<T>(selector));
   const allTabbable = allFocusable.filter(isTabbable);
+
+  if (isTabbable(container)) {
+    allTabbable.unshift(container);
+  }
+
   if (!allTabbable.length && fallbackToFocusable) {
     return allFocusable;
   }

--- a/packages/reakit/src/Dialog/__tests__/index-test.tsx
+++ b/packages/reakit/src/Dialog/__tests__/index-test.tsx
@@ -45,6 +45,27 @@ test("focus the first tabbable element when dialog opens", () => {
   expect(button1).toHaveFocus();
 });
 
+test("focus the dialog element when dialog opens with tabIndex={0}", () => {
+  const Test = () => {
+    const dialog = useDialogState();
+    return (
+      <>
+        <DialogDisclosure {...dialog}>disclosure</DialogDisclosure>
+        <Dialog {...dialog} tabIndex={0} aria-label="dialog">
+          <button>button1</button>
+          <button>button2</button>
+        </Dialog>
+      </>
+    );
+  };
+  const { getByText, getByLabelText } = render(<Test />);
+  const disclosure = getByText("disclosure");
+  const dialog = getByLabelText("dialog");
+  expect(document.body).toHaveFocus();
+  fireEvent.click(disclosure);
+  expect(dialog).toHaveFocus();
+});
+
 test("does not auto focus when autoFocusOnShow is falsy", () => {
   const Test = () => {
     const dialog = useDialogState();
@@ -198,6 +219,42 @@ test("focus is trapped within the dialog", () => {
 
   act(() => focusPreviousTabbableIn(baseElement));
   expect(button3).toHaveFocus();
+});
+
+test("focus is trapped within the dialog with tabIndex={0}", () => {
+  const Test = () => {
+    const dialog = useDialogState();
+    return (
+      <>
+        <button>button1</button>
+        <DialogDisclosure {...dialog}>disclosure</DialogDisclosure>
+        <Dialog {...dialog} tabIndex={0} aria-label="dialog">
+          <button>button2</button>
+          <button>button3</button>
+        </Dialog>
+        <button>button4</button>
+      </>
+    );
+  };
+  const { getByText, getByLabelText, baseElement } = render(<Test />);
+  const disclosure = getByText("disclosure");
+  const dialog = getByLabelText("dialog");
+  const button2 = getByText("button2");
+  const button3 = getByText("button3");
+  fireEvent.click(disclosure);
+  expect(dialog).toHaveFocus();
+
+  act(() => focusNextTabbableIn(baseElement));
+  expect(button2).toHaveFocus();
+  act(() => focusNextTabbableIn(baseElement));
+  expect(button3).toHaveFocus();
+  act(() => focusNextTabbableIn(baseElement));
+  expect(dialog).toHaveFocus();
+  act(() => focusNextTabbableIn(baseElement));
+  expect(button2).toHaveFocus();
+
+  act(() => focusPreviousTabbableIn(baseElement));
+  expect(dialog).toHaveFocus();
 });
 
 test("focus is trapped within the dialog when hideOnClickOutside is falsy", () => {


### PR DESCRIPTION
If `tabIndex={0}` is passed to the `Dialog` component, it should be included in the tab stops.

Before this change, it would be ignored if the dialog had focusable children already.