### PR TITLE
feat: Add experimental `unstable_portal` prop to `Tooltip`

### DIFF
--- a/packages/reakit/src/Popover/PopoverState.ts
+++ b/packages/reakit/src/Popover/PopoverState.ts
@@ -196,13 +196,21 @@ export function usePopoverState(
     fixed
   ]);
 
+  // This fixes cases when `unstable_portal` is `true` only when popover is visible
+  // https://spectrum.chat/reakit/general/i-was-wondering-if-can-hide-portal-of-tooltip-when-conditionally-rendered~4e05ffe1-93e8-4c72-8c85-eccb1c3f2ff1
+  React.useEffect(() => {
+    if (dialog.visible && popper.current) {
+      popper.current.scheduleUpdate();
+    }
+  }, [dialog.visible]);
+
   // Schedule an update if popover has initial visible state set to true
   // So it'll be correctly positioned
   React.useEffect(() => {
-    if (sealed.visible) {
-      scheduleUpdate();
+    if (sealed.visible && popper.current) {
+      popper.current.scheduleUpdate();
     }
-  }, [sealed.visible, scheduleUpdate]);
+  }, [sealed.visible]);
 
   return {
     ...dialog,

--- a/packages/reakit/src/Popover/__tests__/Popover-test.tsx
+++ b/packages/reakit/src/Popover/__tests__/Popover-test.tsx
@@ -54,18 +54,21 @@ test("render visible", () => {
   `);
 });
 
-test("render non-modal", () => {
+test("render modal", () => {
   const { baseElement } = render(
-    <Popover {...props} modal={false}>
+    <Popover {...props} modal>
       test
     </Popover>
   );
   expect(baseElement).toMatchInlineSnapshot(`
     <body>
-      <div>
+      <div />
+      <div
+        class="__reakit-portal"
+      >
         <div
           aria-label="popover"
-          aria-modal="false"
+          aria-modal="true"
           class="hidden"
           data-dialog="true"
           hidden=""

--- a/packages/reakit/src/Tooltip/README.md
+++ b/packages/reakit/src/Tooltip/README.md
@@ -194,6 +194,12 @@ element.
 
 ### `Tooltip`
 
+- **`unstable_portal`** <span title="Experimental">⚠️</span>
+  <code>boolean | undefined</code>
+
+  Whether or not the dialog should be rendered within `Portal`.
+It's `true` by default if `modal` is `true`.
+
 <details><summary>3 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.

--- a/packages/reakit/src/Tooltip/Tooltip.tsx
+++ b/packages/reakit/src/Tooltip/Tooltip.tsx
@@ -11,7 +11,13 @@ export type TooltipOptions = HiddenOptions &
   Pick<
     Partial<TooltipStateReturn>,
     "unstable_popoverRef" | "unstable_popoverStyles"
-  >;
+  > & {
+    /**
+     * Whether or not the dialog should be rendered within `Portal`.
+     * It's `true` by default if `modal` is `true`.
+     */
+    unstable_portal?: boolean;
+  };
 
 export type TooltipHTMLProps = HiddenHTMLProps;
 
@@ -21,15 +27,29 @@ export const useTooltip = createHook<TooltipOptions, TooltipHTMLProps>({
   name: "Tooltip",
   compose: useHidden,
   useState: useTooltipState,
+  keys: ["unstable_portal"],
+
+  useOptions({ unstable_portal = true, ...options }) {
+    return {
+      unstable_portal,
+      ...options
+    };
+  },
 
   useProps(
     options,
     { ref: htmlRef, style: htmlStyle, unstable_wrap: htmlWrap, ...htmlProps }
   ) {
     const wrap = React.useCallback(
-      (children: React.ReactNode) => <Portal>{children}</Portal>,
-      []
+      (children: React.ReactNode) => {
+        if (options.unstable_portal) {
+          return <Portal>{children}</Portal>;
+        }
+        return children;
+      },
+      [options.unstable_portal]
     );
+
     return {
       ref: mergeRefs(options.unstable_popoverRef, htmlRef),
       role: "tooltip",

--- a/packages/reakit/src/Tooltip/__tests__/Tooltip-test.tsx
+++ b/packages/reakit/src/Tooltip/__tests__/Tooltip-test.tsx
@@ -41,3 +41,23 @@ test("render visible", () => {
     </body>
   `);
 });
+
+test("render without portal", () => {
+  const { baseElement } = render(
+    <Tooltip unstable_portal={false}>tooltip</Tooltip>
+  );
+  expect(baseElement).toMatchInlineSnapshot(`
+    <body>
+      <div>
+        <div
+          class="hidden"
+          hidden=""
+          role="tooltip"
+          style="display: none; pointer-events: none;"
+        >
+          tooltip
+        </div>
+      </div>
+    </body>
+  `);
+});


### PR DESCRIPTION
This PR adds an `unstable_portal` prop to `Tooltip` so we have the option to render tooltips without `Portal`. A use case was raised by @lxcid on [Spectrum](https://spectrum.chat/reakit/general/i-was-wondering-if-can-hide-portal-of-tooltip-when-conditionally-rendered~4e05ffe1-93e8-4c72-8c85-eccb1c3f2ff1).

![Sep-20-2019 18-53-51](https://user-images.githubusercontent.com/3068563/65360898-0c762900-dbd8-11e9-9722-c2f0deb77db7.gif)


**Does this PR introduce a breaking change?**

No