### PR TITLE
feat: Add `gutter` option to `usePopoverState`

### DIFF
--- a/packages/reakit/src/Menu/MenuState.ts
+++ b/packages/reakit/src/Menu/MenuState.ts
@@ -28,11 +28,9 @@ export type MenuStateReturn = MenuState & MenuActions;
 export function useMenuState(
   initialState: SealedInitialState<MenuInitialState> = {}
 ): MenuStateReturn {
-  const {
-    orientation = "vertical",
-    unstable_gutter: initialGutter = 0,
-    ...sealed
-  } = useSealedState(initialState);
+  const { orientation = "vertical", gutter = 0, ...sealed } = useSealedState(
+    initialState
+  );
 
   const parent = React.useContext(MenuContext);
 
@@ -46,7 +44,7 @@ export function useMenuState(
   const popover = usePopoverState({
     ...sealed,
     placement,
-    unstable_gutter: initialGutter
+    gutter
   });
 
   React.useEffect(() => {

--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -532,7 +532,7 @@ element.
 
   Shift popover on the start or end of its reference element.
 
-- **`unstable_gutter`** <span title="Experimental">⚠️</span>
+- **`gutter`**
   <code>number | undefined</code>
 
   Offset between the reference and the popover.

--- a/packages/reakit/src/Popover/PopoverState.ts
+++ b/packages/reakit/src/Popover/PopoverState.ts
@@ -93,7 +93,7 @@ export type PopoverInitialState = DialogInitialState &
     /**
      * Offset between the reference and the popover.
      */
-    unstable_gutter?: number;
+    gutter?: number;
     /**
      * Prevents popover from being positioned outside the boundary.
      */
@@ -110,10 +110,10 @@ export function usePopoverState(
   initialState: SealedInitialState<PopoverInitialState> = {}
 ): PopoverStateReturn {
   const {
+    gutter = 12,
     placement: sealedPlacement = "bottom",
     unstable_flip: flip = true,
     unstable_shift: shift = true,
-    unstable_gutter: gutter = 12,
     unstable_preventOverflow: preventOverflow = true,
     unstable_boundariesElement: boundariesElement = "scrollParent",
     unstable_fixed: fixed = false,

--- a/packages/reakit/src/Popover/README.md
+++ b/packages/reakit/src/Popover/README.md
@@ -73,6 +73,26 @@ function Example() {
 }
 ```
 
+### Gutter
+
+You can control the margin between `Popover` and `PopoverDisclosure` by setting the `gutter` option on `usePopoverState`.
+
+```jsx
+import { usePopoverState, Popover, PopoverDisclosure } from "reakit/Popover";
+
+function Example() {
+  const popover = usePopoverState({ gutter: 0, placement: "bottom-start" });
+  return (
+    <>
+      <PopoverDisclosure {...popover}>Open Popover</PopoverDisclosure>
+      <Popover {...popover} aria-label="Welcome">
+        Welcome to Reakit!
+      </Popover>
+    </>
+  );
+}
+```
+
 ### Initial focus
 
 When opening `Popover`, focus is usually set on the first tabbable element within the popover, including itself. So, if you want to set the initial focus on the popover element, you can simply pass `tabIndex={0}` to it. It'll be also included in the tab order.
@@ -223,7 +243,7 @@ element.
 
   Shift popover on the start or end of its reference element.
 
-- **`unstable_gutter`** <span title="Experimental">⚠️</span>
+- **`gutter`**
   <code>number | undefined</code>
 
   Offset between the reference and the popover.

--- a/packages/reakit/src/Tooltip/README.md
+++ b/packages/reakit/src/Tooltip/README.md
@@ -177,7 +177,7 @@ element.
 
   Shift popover on the start or end of its reference element.
 
-- **`unstable_gutter`** <span title="Experimental">⚠️</span>
+- **`gutter`**
   <code>number | undefined</code>
 
   Offset between the reference and the popover.


### PR DESCRIPTION
It removes the `unstable_` prefix from the `gutter` option on `usePopoverState` and its derivatives (`useTooltipState`, `useMenuState`).

**Does this PR introduce a breaking change?**

No! But it removes the `unstable_gutter` option.