### PR TITLE
fix: Replace IE11 incompatible DOM features

### DIFF
--- a/packages/reakit-playground/src/__deps/reakit-utils.ts
+++ b/packages/reakit-playground/src/__deps/reakit-utils.ts
@@ -25,5 +25,6 @@ export default {
   "reakit-utils/isEmpty": require("reakit-utils/isEmpty"),
   "reakit-utils/hasFocusWithin": require("reakit-utils/hasFocusWithin"),
   "reakit-utils/cx": require("reakit-utils/cx"),
-  "reakit-utils/createOnKeyDown": require("reakit-utils/createOnKeyDown")
+  "reakit-utils/createOnKeyDown": require("reakit-utils/createOnKeyDown"),
+  "reakit-utils/closest": require("reakit-utils/closest")
 };

--- a/packages/reakit-utils/.gitignore
+++ b/packages/reakit-utils/.gitignore
@@ -27,3 +27,4 @@
 /hasFocusWithin
 /cx
 /createOnKeyDown
+/closest

--- a/packages/reakit-utils/src/closest.ts
+++ b/packages/reakit-utils/src/closest.ts
@@ -1,0 +1,17 @@
+// closest ponyfill
+
+function matches(element: Element, selectors: string): boolean {
+  if ("matches" in element) return element.matches(selectors);
+  if ("msMatchesSelector" in element)
+    return (element as any).msMatchesSelector(selectors);
+  return (element as any).webkitMatchesSelector(selectors);
+}
+
+export function closest<T extends Element>(element: T, selectors: string) {
+  if ("closest" in element) return element.closest(selectors);
+  do {
+    if (matches(element, selectors)) return element;
+    element = (element.parentElement || element.parentNode) as any;
+  } while (element !== null && element.nodeType === 1);
+  return null;
+}

--- a/packages/reakit-utils/src/index.ts
+++ b/packages/reakit-utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./closest";
 export * from "./createOnKeyDown";
 export * from "./cx";
 export * from "./hasFocusWithin";

--- a/packages/reakit/src/Dialog/__utils/useFocusTrap.ts
+++ b/packages/reakit/src/Dialog/__utils/useFocusTrap.ts
@@ -4,6 +4,11 @@ import { getFirstTabbableIn, getLastTabbableIn } from "reakit-utils/tabbable";
 import { DialogOptions } from "../Dialog";
 import { usePortalRef } from "./usePortalRef";
 
+function removeFromDOM(element: Element) {
+  if (element.parentNode == null) return;
+  element.parentNode.removeChild(element);
+}
+
 function hasNestedOpenModals(
   nestedDialogs: Array<React.RefObject<HTMLElement>>
 ) {
@@ -65,8 +70,8 @@ export function useFocusTrap(
     portal.insertAdjacentElement("afterend", afterElement.current);
 
     return () => {
-      if (beforeElement.current) beforeElement.current.remove();
-      if (afterElement.current) afterElement.current.remove();
+      if (beforeElement.current) removeFromDOM(beforeElement.current);
+      if (afterElement.current) removeFromDOM(afterElement.current);
     };
   }, [portalRef, shouldTrap]);
 

--- a/packages/reakit/src/Dialog/__utils/usePortalRef.ts
+++ b/packages/reakit/src/Dialog/__utils/usePortalRef.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { closest } from "reakit-utils/closest";
 import { Portal } from "../../Portal/Portal";
 import { DialogOptions } from "../Dialog";
 
@@ -11,7 +12,7 @@ export function usePortalRef(
   React.useEffect(() => {
     const dialog = dialogRef.current;
     if (!dialog || !options.visible) return;
-    portalRef.current = dialog.closest(Portal.__selector) as HTMLElement;
+    portalRef.current = closest(dialog, Portal.__selector) as HTMLElement;
   }, [dialogRef, options.visible]);
 
   return portalRef;

--- a/packages/reakit/src/Menu/__utils/useShortcuts.ts
+++ b/packages/reakit/src/Menu/__utils/useShortcuts.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { closest } from "reakit-utils/closest";
 import { MenuStateReturn } from "../MenuState";
 
 export function useShortcuts(
@@ -42,7 +43,7 @@ export function useShortcuts(
       const targetIsMenuItem =
         role &&
         role.indexOf("menuitem") >= 0 &&
-        target.closest("[role=menu],[role=menubar]") === menu;
+        closest(target, "[role=menu],[role=menubar]") === menu;
 
       if (!targetIsMenu && !targetIsMenuItem) return;
 

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -15,7 +15,7 @@
     "test": "jest",
     "build": "gatsby build",
     "develop": "gatsby develop -H 0.0.0.0 -p 8000",
-    "serve": "gatsby serve"
+    "serve": "gatsby serve -H 0.0.0.0 -p 9000"
   },
   "dependencies": {
     "@emotion/core": "10.0.17",


### PR DESCRIPTION
Closes #360

This PR replaces `Element.prototype.closest` and `Element.prototype.remove` by their [ponyfilled](https://github.com/sindresorhus/ponyfill) versions. These methods aren't automatically polyfilled by Babel on apps. So, with this, Reakit should work with IE11 by simply using Babel (production build).

**Does this PR introduce a breaking change?**

No