### PR TITLE
Apply the `data-active` attribute when a Tabbable is in the `:active` state

### DIFF
--- a/packages/reakit/src/Tabbable/__tests__/Tabbable-test.tsx
+++ b/packages/reakit/src/Tabbable/__tests__/Tabbable-test.tsx
@@ -154,6 +154,15 @@ test("non-native button click disabled focusable", () => {
   expect(fn).toHaveBeenCalledTimes(0);
 });
 
+test("data-active", () => {
+  const { getByText } = render(<Tabbable>tabbable</Tabbable>);
+  const tabbable = getByText("tabbable");
+  fireEvent.mouseDown(tabbable);
+  expect(tabbable).toHaveAttribute("data-active");
+  fireEvent.mouseUp(tabbable);
+  expect(tabbable).not.toHaveAttribute("data-active");
+});
+
 test("non-native button focus", () => {
   const { getByText } = render(<Tabbable as="div">tabbable</Tabbable>);
   const tabbable = getByText("tabbable");


### PR DESCRIPTION
**Explain the motivation for making this change and try to link to an open issue for more information.**

Provides a selector hook to style a Tabbable's active state. Works around Firefox's behavior to not apply the `:active` pseudoselector if `preventDefault()` is called on the mouseevent which would otherwise cause it to be applied. See #432. 

**Does this PR introduce a breaking change?**

No
