### PR TITLE
perf: improve space complexity for `createHook` method

### DIFF
--- a/packages/reakit-system/src/createHook.ts
+++ b/packages/reakit-system/src/createHook.ts
@@ -50,7 +50,10 @@ export function createHook<O, P>(options: CreateHookOptions<O, P>) {
 
   useHook.__keys = [
     ...composedHooks.reduce(
-      (allKeys, hook) => [...allKeys, ...(hook.__keys || [])],
+      (allKeys, hook) => {
+        allKeys.push(...(hook.__keys || []));
+        return allKeys;
+      },
       [] as string[]
     ),
     ...(options.useState ? options.useState.__keys : []),


### PR DESCRIPTION
First off, thanks for this awesome project. Reading through the codebase has been a delight so far. This PR is something small I picked up while reading through the code.

The PR aims to improve performance by decreasing the space complexity (memory usage) of the `createHook` method. Instead of creating a new array for each iteration of the `reduce` method, it simply pushes to the new accumulator array. This is a *minor* improvement, but seeing that almost all components are using this method, it could have a negative performance impact on a large number of components and `composedHooks`.

There are no breaking changes for this change and all test are still passing locally.