### PR TITLE
fix: Fix nested `Dialog`s not working with VoiceOver

### DIFF
--- a/packages/reakit/src/Dialog/__tests__/Dialog-test.tsx
+++ b/packages/reakit/src/Dialog/__tests__/Dialog-test.tsx
@@ -89,7 +89,6 @@ test("render non-modal", async () => {
       <div>
         <div
           aria-label="dialog"
-          aria-modal="false"
           class="hidden"
           data-dialog="true"
           hidden=""

--- a/packages/reakit/src/Dialog/__utils/useEventListenerOutside.ts
+++ b/packages/reakit/src/Dialog/__utils/useEventListenerOutside.ts
@@ -4,7 +4,7 @@ import { warning } from "reakit-utils/warning";
 import { isFocusTrap } from "./useFocusTrap";
 
 export function useEventListenerOutside(
-  targetRef: React.RefObject<HTMLElement>,
+  containerRef: React.RefObject<HTMLElement>,
   disclosuresRef: React.RefObject<HTMLElement[]>,
   nestedDialogs: Array<React.RefObject<HTMLElement>>,
   event: string,
@@ -19,19 +19,22 @@ export function useEventListenerOutside(
     const handleEvent = (e: MouseEvent) => {
       if (!listenerRef.current) return;
 
-      const element = targetRef.current;
+      const container = containerRef.current;
       const disclosures = disclosuresRef.current || [];
       const target = e.target as Element;
 
-      warning(
-        !element,
-        "Dialog",
-        "Can't detect events outside dialog because `ref` wasn't passed to component.",
-        "See https://reakit.io/docs/dialog"
-      );
+      if (!container) {
+        warning(
+          true,
+          "Dialog",
+          "Can't detect events outside dialog because `ref` wasn't passed to component.",
+          "See https://reakit.io/docs/dialog"
+        );
+        return;
+      }
 
-      // Click inside
-      if (!element || element.contains(target)) return;
+      // Click inside dialog
+      if (container.contains(target)) return;
 
       // Click on disclosure
       if (
@@ -60,7 +63,7 @@ export function useEventListenerOutside(
       document.removeEventListener(event, handleEvent, true);
     };
   }, [
-    targetRef,
+    containerRef,
     disclosuresRef,
     nestedDialogs,
     event,

--- a/packages/reakit/src/Dialog/__utils/useHideOnClickOutside.ts
+++ b/packages/reakit/src/Dialog/__utils/useHideOnClickOutside.ts
@@ -8,20 +8,15 @@ export function useHideOnClickOutside(
   nestedDialogs: Array<React.RefObject<HTMLElement>>,
   options: DialogOptions
 ) {
-  useEventListenerOutside(
-    dialogRef,
-    disclosuresRef,
-    nestedDialogs,
-    "click",
-    options.hide,
-    options.visible && options.hideOnClickOutside
-  );
-  useEventListenerOutside(
-    dialogRef,
-    disclosuresRef,
-    nestedDialogs,
-    "focus",
-    options.hide,
-    options.visible && options.hideOnClickOutside
-  );
+  const useEvent = (eventType: string) =>
+    useEventListenerOutside(
+      dialogRef,
+      disclosuresRef,
+      nestedDialogs,
+      eventType,
+      options.hide,
+      options.visible && options.hideOnClickOutside
+    );
+  useEvent("click");
+  useEvent("focus");
 }

--- a/packages/reakit/src/Dialog/__utils/usePortal.tsx
+++ b/packages/reakit/src/Dialog/__utils/usePortal.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { closest } from "reakit-utils/closest";
+import { Portal, PortalContext } from "../../Portal/Portal";
+import { DialogOptions } from "../Dialog";
+
+export function usePortal(
+  dialogRef: React.RefObject<HTMLElement>,
+  options: DialogOptions
+) {
+  const context = React.useContext(PortalContext);
+
+  const wrap = React.useCallback(
+    (children: React.ReactNode) => {
+      if (options.unstable_portal) {
+        // Internally, Portal wraps children within a PortalContext.Provider
+        // where the value is the portal itself, which means that nested
+        // portals will be children of the parent portal and siblings of the
+        // parent modal. This doesn't work out with VoiceOver, which seems to
+        // require nested modals to be children of their parent modals.
+        // So we overwrite the portal context for the children with the current
+        // modal so nested modals will be children of it.
+        children = (
+          <Portal>
+            <PortalContext.Provider value={dialogRef.current}>
+              {children}
+            </PortalContext.Provider>
+          </Portal>
+        );
+      }
+
+      if (options.unstable_orphan && context) {
+        const value = closest(context, Portal.__selector) as HTMLElement;
+        children = (
+          <PortalContext.Provider value={value}>
+            {children}
+          </PortalContext.Provider>
+        );
+      }
+
+      return children;
+    },
+    [dialogRef, context, options.unstable_portal, options.unstable_orphan]
+  );
+
+  return wrap;
+}

--- a/packages/reakit/src/Menu/__tests__/Menu-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/Menu-test.tsx
@@ -26,7 +26,6 @@ test("render", () => {
       <div>
         <div
           aria-label="menu"
-          aria-modal="false"
           class="hidden"
           data-dialog="true"
           hidden=""

--- a/packages/reakit/src/Popover/__tests__/Popover-test.tsx
+++ b/packages/reakit/src/Popover/__tests__/Popover-test.tsx
@@ -14,7 +14,6 @@ test("render", () => {
       <div>
         <div
           aria-label="popover"
-          aria-modal="false"
           class="hidden"
           data-dialog="true"
           hidden=""
@@ -41,7 +40,6 @@ test("render visible", () => {
       <div>
         <div
           aria-label="popover"
-          aria-modal="false"
           data-dialog="true"
           id="popover"
           role="dialog"

--- a/packages/reakit/src/Portal/Portal.tsx
+++ b/packages/reakit/src/Portal/Portal.tsx
@@ -16,30 +16,30 @@ export function Portal({ children }: PortalProps) {
   // if it's a nested portal, context is the parent portal
   // otherwise it's document.body
   const context = React.useContext(PortalContext);
-  const [container] = React.useState(() => {
+  const [portal] = React.useState(() => {
     if (typeof document !== "undefined") {
-      const portal = document.createElement("div");
-      portal.className = Portal.__className;
-      return portal;
+      const element = document.createElement("div");
+      element.className = Portal.__className;
+      return element;
     }
     // ssr
     return null;
   });
 
   React.useEffect(() => {
-    if (!container || !context) return undefined;
-    context.appendChild(container);
+    if (!portal || !context) return undefined;
+    context.appendChild(portal);
     return () => {
-      context.removeChild(container);
+      context.removeChild(portal);
     };
-  }, [container, context]);
+  }, [portal, context]);
 
-  if (container) {
-    const portal = ReactDOM.createPortal(children, container);
-    return (
-      <PortalContext.Provider value={container}>
-        {portal}
-      </PortalContext.Provider>
+  if (portal) {
+    return ReactDOM.createPortal(
+      <PortalContext.Provider value={portal}>
+        {children}
+      </PortalContext.Provider>,
+      portal
     );
   }
 

--- a/packages/reakit/src/Portal/README.md
+++ b/packages/reakit/src/Portal/README.md
@@ -35,28 +35,3 @@ function Example() {
 ## Props
 
 <!-- Automatically generated -->
-
-### `Portal`
-
-- **`unstable_ignoresCustomContext`** <span title="Experimental">⚠️</span>
-  <code>boolean | undefined</code>
-
-  Ignores custom `childContext` passed to parent portals.
-  ```jsx
-  import { Portal } from "reakit/Portal";
-
-  function Example() {
-    const ref = React.useRef();
-    const [lol, setLol] = React.useState(0);
-    React.useEffect(() => setLol(1), [])
-    return (
-      <Portal unstable_childContext={ref.current}>
-        <div ref={ref}>
-          <p>portal 0</p>
-          <Portal unstable_ignoresCustomContext>portal 1</Portal>
-          <Portal>portal 2</Portal>
-        </div>
-      </Portal>
-    );
-  }
-  ```

--- a/packages/reakit/src/Portal/README.md
+++ b/packages/reakit/src/Portal/README.md
@@ -31,3 +31,32 @@ function Example() {
   );
 }
 ```
+
+## Props
+
+<!-- Automatically generated -->
+
+### `Portal`
+
+- **`unstable_ignoresCustomContext`** <span title="Experimental">⚠️</span>
+  <code>boolean | undefined</code>
+
+  Ignores custom `childContext` passed to parent portals.
+  ```jsx
+  import { Portal } from "reakit/Portal";
+
+  function Example() {
+    const ref = React.useRef();
+    const [lol, setLol] = React.useState(0);
+    React.useEffect(() => setLol(1), [])
+    return (
+      <Portal unstable_childContext={ref.current}>
+        <div ref={ref}>
+          <p>portal 0</p>
+          <Portal unstable_ignoresCustomContext>portal 1</Portal>
+          <Portal>portal 2</Portal>
+        </div>
+      </Portal>
+    );
+  }
+  ```

--- a/packages/reakit/src/Portal/README.md
+++ b/packages/reakit/src/Portal/README.md
@@ -31,7 +31,3 @@ function Example() {
   );
 }
 ```
-
-## Props
-
-<!-- Automatically generated -->


### PR DESCRIPTION
VoiceOver requires nested modals to be children of their parent modals. In our current implementation, they're siblings. This PR changes this so nested dialogs will be appended as children to the parent dialog instead of the portal.