### PR TITLE
Make `Menu` run without menu state props

### DIFF
--- a/packages/reakit/src/Menu/Menu.tsx
+++ b/packages/reakit/src/Menu/Menu.tsx
@@ -54,7 +54,7 @@ export const useMenu = createHook<MenuOptions, MenuHTMLProps>({
 
     const { next, previous, orientation } = ancestorMenuBar || {};
     const ancestorIsHorizontal = orientation === "horizontal";
-    const [dir] = options.placement.split("-");
+    const [dir] = (options.placement || "").split("-");
 
     const rovingBindings = React.useMemo(
       () =>

--- a/packages/reakit/src/Menu/__tests__/Menu-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/Menu-test.tsx
@@ -38,3 +38,22 @@ test("render", () => {
     </body>
   `);
 });
+
+test("render without state props", () => {
+  // @ts-ignore
+  const { baseElement } = render(<Menu />);
+  expect(baseElement).toMatchInlineSnapshot(`
+    <body>
+      <div>
+        <div
+          class="hidden"
+          data-dialog="true"
+          hidden=""
+          role="menu"
+          style="display: none;"
+          tabindex="-1"
+        />
+      </div>
+    </body>
+  `);
+});

--- a/packages/reakit/src/Rover/Rover.ts
+++ b/packages/reakit/src/Rover/Rover.ts
@@ -59,13 +59,13 @@ export const useRover = createHook<RoverOptions, RoverHTMLProps>({
     const trulyDisabled = options.disabled && !options.focusable;
     const noFocused = options.currentId == null;
     const focused = options.currentId === stopId;
-    const isFirst = options.stops[0] && options.stops[0].id === stopId;
+    const isFirst = (options.stops || [])[0] && options.stops[0].id === stopId;
     const shouldTabIndex = focused || (isFirst && noFocused);
 
     React.useEffect(() => {
       if (trulyDisabled) return undefined;
-      options.register(stopId, ref);
-      return () => options.unregister(stopId);
+      options.register && options.register(stopId, ref);
+      return () => options.unregister && options.unregister(stopId);
     }, [stopId, trulyDisabled, options.register, options.unregister]);
 
     React.useEffect(() => {

--- a/packages/reakit/src/Rover/__tests__/Rover-test.tsx
+++ b/packages/reakit/src/Rover/__tests__/Rover-test.tsx
@@ -2,6 +2,12 @@ import * as React from "react";
 import { render } from "@testing-library/react";
 import { Rover } from "../Rover";
 
+jest.mock("reakit-utils/useId", () => {
+  return {
+    useId: jest.fn(() => "rover")
+  };
+});
+
 const props: Parameters<typeof Rover>[0] = {
   stopId: "rover",
   stops: [],
@@ -17,6 +23,23 @@ const props: Parameters<typeof Rover>[0] = {
 
 test("render", () => {
   const { baseElement } = render(<Rover {...props}>rover</Rover>);
+  expect(baseElement).toMatchInlineSnapshot(`
+    <body>
+      <div>
+        <button
+          id="rover"
+          tabindex="-1"
+        >
+          rover
+        </button>
+      </div>
+    </body>
+  `);
+});
+
+test("render without state props", () => {
+  // @ts-ignore
+  const { baseElement } = render(<Rover>rover</Rover>);
   expect(baseElement).toMatchInlineSnapshot(`
     <body>
       <div>


### PR DESCRIPTION
Should a component break when not all required props are provided? 
Other components like `Dialog` do not break when you don't spread its state-props.