### PR TITLE
Add a `useIsomorphicEffect` hook to allow proper SSR rendering

### DIFF
--- a/packages/reakit-playground/src/__deps/reakit-utils.ts
+++ b/packages/reakit-playground/src/__deps/reakit-utils.ts
@@ -7,6 +7,7 @@ export default {
   "reakit-utils/useSealedState": require("reakit-utils/useSealedState"),
   "reakit-utils/usePipe": require("reakit-utils/usePipe"),
   "reakit-utils/useLiveRef": require("reakit-utils/useLiveRef"),
+  "reakit-utils/useIsomorphicEffect": require("reakit-utils/useIsomorphicEffect"),
   "reakit-utils/useId": require("reakit-utils/useId"),
   "reakit-utils/useAllCallbacks": require("reakit-utils/useAllCallbacks"),
   "reakit-utils/types": require("reakit-utils/types"),

--- a/packages/reakit-utils/.gitignore
+++ b/packages/reakit-utils/.gitignore
@@ -8,6 +8,7 @@
 /useSealedState
 /usePipe
 /useLiveRef
+/useIsomorphicEffect
 /useId
 /useAllCallbacks
 /types

--- a/packages/reakit-utils/src/useIsomorphicEffect.ts
+++ b/packages/reakit-utils/src/useIsomorphicEffect.ts
@@ -1,0 +1,4 @@
+import * as React from "react";
+
+export const useIsomorphicEffect =
+  typeof window === "undefined" ? React.useEffect : React.useLayoutEffect;

--- a/packages/reakit/src/Dialog/__utils/useDisclosuresRef.ts
+++ b/packages/reakit/src/Dialog/__utils/useDisclosuresRef.ts
@@ -1,11 +1,12 @@
 import * as React from "react";
+import { useIsomorphicEffect } from "reakit-utils/useIsomorphicEffect";
 import { DialogOptions } from "../Dialog";
 
 export function useDisclosuresRef(options: DialogOptions) {
   const disclosuresRef = React.useRef<HTMLElement[]>([]);
   const lastActiveElement = React.useRef<Element | null>(null);
 
-  React.useLayoutEffect(() => {
+  useIsomorphicEffect(() => {
     if (options.visible) return undefined;
     const onFocus = () => {
       lastActiveElement.current = document.activeElement;

--- a/packages/reakit/src/Hidden/HiddenState.ts
+++ b/packages/reakit/src/Hidden/HiddenState.ts
@@ -4,6 +4,7 @@ import {
   SealedInitialState
 } from "reakit-utils/useSealedState";
 import { useId } from "reakit-utils/useId";
+import { useIsomorphicEffect } from "reakit-utils/useIsomorphicEffect";
 import { warning } from "reakit-utils/warning";
 
 export type HiddenState = {
@@ -67,7 +68,7 @@ export type HiddenStateReturn = HiddenState & HiddenActions;
 
 function useLastValue<T>(value: T) {
   const lastValue = React.useRef<T | null>(null);
-  React.useLayoutEffect(() => {
+  useIsomorphicEffect(() => {
     lastValue.current = value;
   }, [value]);
   return lastValue;
@@ -99,7 +100,7 @@ export function useHiddenState(
     setAnimating(true);
   }
 
-  React.useLayoutEffect(() => {
+  useIsomorphicEffect(() => {
     if (typeof animated !== "number") return undefined;
     // Stops animation after an interval defined by animated
     const id = setTimeout(() => setAnimating(false), animated);

--- a/packages/reakit/src/Popover/PopoverState.ts
+++ b/packages/reakit/src/Popover/PopoverState.ts
@@ -4,6 +4,7 @@ import {
   SealedInitialState,
   useSealedState
 } from "reakit-utils/useSealedState";
+import { useIsomorphicEffect } from "reakit-utils/useIsomorphicEffect";
 import {
   DialogState,
   DialogActions,
@@ -142,7 +143,7 @@ export function usePopoverState(
     return false;
   }, []);
 
-  React.useLayoutEffect(() => {
+  useIsomorphicEffect(() => {
     if (referenceRef.current && popoverRef.current) {
       popper.current = new Popper(referenceRef.current, popoverRef.current, {
         placement: originalPlacement,

--- a/packages/website/src/hooks/useScrolled.ts
+++ b/packages/website/src/hooks/useScrolled.ts
@@ -1,9 +1,10 @@
 import * as React from "react";
+import { useIsomorphicEffect } from "reakit-utils/useIsomorphicEffect";
 
 export default function useScrolled(offset = 0) {
   const [scrolled, setScrolled] = React.useState(false);
 
-  React.useLayoutEffect(() => {
+  useIsomorphicEffect(() => {
     const handleScroll = () => {
       setScrolled(window.scrollY > offset);
     };

--- a/packages/website/src/hooks/useViewportWidthGreaterThan.ts
+++ b/packages/website/src/hooks/useViewportWidthGreaterThan.ts
@@ -1,9 +1,10 @@
 import * as React from "react";
+import { useIsomorphicEffect } from "reakit-utils/useIsomorphicEffect";
 
 function useViewportWidthGreaterThan(width: number) {
   const [greater, setGreater] = React.useState(false);
 
-  React.useLayoutEffect(() => {
+  useIsomorphicEffect(() => {
     const handleResize = () => {
       if (window.innerWidth > width) {
         setGreater(true);


### PR DESCRIPTION
As mentioned in #438 the currently using Reakit triggers a lot of React warning messages when used with server side rendering. Using `useEffect` when window is undefined resolves this behaviour.

Fixes #438 