### PR TITLE
Expose a `unstable_update()` call to update the popover positioning

### DIFF
--- a/packages/reakit/src/Popover/PopoverState.ts
+++ b/packages/reakit/src/Popover/PopoverState.ts
@@ -64,6 +64,10 @@ export type PopoverState = DialogState & {
    */
   unstable_scheduleUpdate: () => boolean;
   /**
+   * @private
+   */
+  unstable_update: () => boolean;
+  /**
    * Actual `placement`.
    */
   placement: Placement;
@@ -138,6 +142,14 @@ export function usePopoverState(
   const scheduleUpdate = React.useCallback(() => {
     if (popper.current) {
       popper.current.scheduleUpdate();
+      return true;
+    }
+    return false;
+  }, []);
+
+  const update = React.useCallback(() => {
+    if (popper.current) {
+      popper.current.update();
       return true;
     }
     return false;
@@ -221,6 +233,7 @@ export function usePopoverState(
     unstable_popoverStyles: popoverStyles,
     unstable_arrowStyles: arrowStyles,
     unstable_scheduleUpdate: scheduleUpdate,
+    unstable_update: update,
     unstable_originalPlacement: originalPlacement,
     placement,
     place: React.useCallback(place, [])
@@ -235,6 +248,7 @@ const keys: Array<keyof PopoverStateReturn> = [
   "unstable_popoverStyles",
   "unstable_arrowStyles",
   "unstable_scheduleUpdate",
+  "unstable_update",
   "unstable_originalPlacement",
   "placement",
   "place"


### PR DESCRIPTION
As discussed in #462 only exposes the `unsafe_update()` method in this version.

By the way, in the current project I'm working on I've wrapped the Popover state to automatically update whenever the content of the popover change. This might also be a good solution? I'm not really sure what the whole philosophy of reakit is, if this should be included or if this is something that should be left up to the user.

```ts
  useIsomorphicEffect(() => {
    const observer = new ResizeObserver(() => {
      if (popperRef.current) popperRef.current.update();
    });

    observer.observe(elementRef.current);
    return () => observer.disconnect();
  }, []);
```