### PR TITLE
Add troubleshooting session on docs

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,13 @@
+---
+path: /docs/troubleshooting/
+redirect_from:
+  - /guide/troubleshooting/
+---
+
+# Troubleshooting
+
+<carbon-ad></carbon-ad>
+
+## Randomly generated IDs
+
+For components that generate random id's internally, like tooltips and popovers, you'll likely run into the problem when trying to test them with with snapshots due to the internal use of randomly generated IDs. There's two solutions to this problem, you can either mock `Math.random` for the specific test or you can wrap your tests on a Provider for SSR, which is a more adequate solution.

--- a/packages/website/src/data/docs.yml
+++ b/packages/website/src/data/docs.yml
@@ -7,6 +7,7 @@
     - /docs/styling/
     - /docs/managing-state/
     - /docs/bundle-size/
+    - /docs/troubleshooting/
 - section: Components
   paths:
     - /docs/button/


### PR DESCRIPTION
Closes #384

- Adds troubleshooting session
- Adds a topic about ramdonly generated IDs and tests