### PR TITLE
fix: Fix `MenuItemCheckbox` and `MenuItemRadio` not working

### DIFF
--- a/packages/reakit/src/Menu/MenuBarState.ts
+++ b/packages/reakit/src/Menu/MenuBarState.ts
@@ -21,7 +21,7 @@ export type MenuBarActions = RoverActions & {
   /**
    * Updates checkboxes and radios values within the menu.
    */
-  unstable_update: (name: string, value?: any) => void;
+  unstable_setValue: (name: string, value?: any) => void;
 };
 
 export type MenuBarInitialState = RoverInitialState &
@@ -44,7 +44,7 @@ export function useMenuBarState(
   return {
     ...rover,
     unstable_values: values,
-    unstable_update: React.useCallback((name, value) => {
+    unstable_setValue: React.useCallback((name, value) => {
       setValues(vals => ({
         ...vals,
         [name]: typeof value === "function" ? value(vals) : value
@@ -56,7 +56,7 @@ export function useMenuBarState(
 const keys: Array<keyof MenuBarStateReturn> = [
   ...useRoverState.__keys,
   "unstable_values",
-  "unstable_update"
+  "unstable_setValue"
 ];
 
 useMenuBarState.__keys = keys;

--- a/packages/reakit/src/Menu/MenuItemCheckbox.ts
+++ b/packages/reakit/src/Menu/MenuItemCheckbox.ts
@@ -11,7 +11,7 @@ import { MenuStateReturn, useMenuState } from "./MenuState";
 
 export type MenuItemCheckboxOptions = CheckboxOptions &
   MenuItemOptions &
-  Pick<MenuStateReturn, "unstable_values" | "unstable_update"> & {
+  Pick<MenuStateReturn, "unstable_values" | "unstable_setValue"> & {
     /**
      * MenuItemCheckbox's name as in `menu.values`.
      */
@@ -34,8 +34,8 @@ export const useMenuItemCheckbox = createHook<
 
   useOptions(options) {
     const setState = React.useCallback(
-      value => options.unstable_update(options.name, value),
-      [options.unstable_update, options.name]
+      value => options.unstable_setValue(options.name, value),
+      [options.unstable_setValue, options.name]
     );
 
     return {

--- a/packages/reakit/src/Menu/MenuItemRadio.ts
+++ b/packages/reakit/src/Menu/MenuItemRadio.ts
@@ -7,7 +7,7 @@ import { useMenuItem, MenuItemOptions, MenuItemHTMLProps } from "./MenuItem";
 
 export type MenuItemRadioOptions = RadioOptions &
   MenuItemOptions &
-  Pick<MenuStateReturn, "unstable_values" | "unstable_update"> & {
+  Pick<MenuStateReturn, "unstable_values" | "unstable_setValue"> & {
     /**
      * MenuItemRadio's name as in `menu.values`.
      */
@@ -29,8 +29,8 @@ export const useMenuItemRadio = createHook<
 
   useOptions(options) {
     const setState = React.useCallback(
-      value => options.unstable_update(options.name, value),
-      [options.unstable_update, options.name]
+      value => options.unstable_setValue(options.name, value),
+      [options.unstable_setValue, options.name]
     );
 
     return {

--- a/packages/reakit/src/Menu/__tests__/MenuItemCheckbox-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/MenuItemCheckbox-test.tsx
@@ -15,7 +15,7 @@ const props: Parameters<typeof MenuItemCheckbox>[0] = {
   first: jest.fn(),
   last: jest.fn(),
   unstable_values: {},
-  unstable_update: jest.fn()
+  unstable_setValue: jest.fn()
 };
 
 test("render", () => {

--- a/packages/reakit/src/Menu/__tests__/MenuItemRadio-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/MenuItemRadio-test.tsx
@@ -16,7 +16,7 @@ const props: Parameters<typeof MenuItemRadio>[0] = {
   first: jest.fn(),
   last: jest.fn(),
   unstable_values: {},
-  unstable_update: jest.fn()
+  unstable_setValue: jest.fn()
 };
 
 test("render", () => {

--- a/packages/reakit/src/Menu/__tests__/index-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/index-test.tsx
@@ -1518,3 +1518,41 @@ test("pressing esc on disclosure closes the menu", async () => {
   await wait(expect(menu).not.toBeVisible);
   expect(disclosure).toHaveFocus();
 });
+
+test("clicking on menu item checkbox/radio checks it", async () => {
+  const Test = () => {
+    const menu = useMenuState();
+    return (
+      <MenuBar {...menu} aria-label="menu">
+        <MenuItemCheckbox {...menu} name="accept">
+          accept
+        </MenuItemCheckbox>
+        <MenuGroup>
+          <MenuItemRadio {...menu} name="fruit" value="apple">
+            apple
+          </MenuItemRadio>
+          <MenuItemRadio {...menu} name="fruit" value="orange">
+            orange
+          </MenuItemRadio>
+        </MenuGroup>
+      </MenuBar>
+    );
+  };
+  const { getByText } = render(<Test />);
+  const accept = getByText("accept") as HTMLInputElement;
+  const apple = getByText("apple") as HTMLInputElement;
+  const orange = getByText("orange") as HTMLInputElement;
+
+  expect(accept.checked).toBe(false);
+  fireEvent.click(accept);
+  expect(accept.checked).toBe(true);
+
+  expect(apple.checked).toBe(false);
+  fireEvent.click(apple);
+  expect(apple.checked).toBe(true);
+
+  expect(orange.checked).toBe(false);
+  fireEvent.click(orange);
+  expect(orange.checked).toBe(true);
+  expect(apple.checked).toBe(false);
+});


### PR DESCRIPTION
This fixes a regression introduced in #463 where both `PopoverState` and `MenuState` got conflicting property `unstable_update`. I'm updating the name of the function on `MenuState`, but I think both names should be revisited later.

Closes #472

**Does this PR introduce a breaking change?**

No breaking changes, but `menuState.unstable_update` has been replaced by `menuState.unstable_setValues`.