### PR TITLE
fix: Stop adding `type="button"` on `Button` by default

### DIFF
--- a/packages/reakit/src/Button/Button.ts
+++ b/packages/reakit/src/Button/Button.ts
@@ -28,7 +28,6 @@ export const useButton = createHook<ButtonOptions, ButtonHTMLProps>({
       if (
         ref.current &&
         (ref.current instanceof HTMLButtonElement ||
-          ref.current instanceof HTMLAnchorElement ||
           ref.current instanceof HTMLInputElement)
       ) {
         setType("button");

--- a/packages/reakit/src/Button/Button.ts
+++ b/packages/reakit/src/Button/Button.ts
@@ -22,6 +22,7 @@ export const useButton = createHook<ButtonOptions, ButtonHTMLProps>({
   useProps(_, { ref: htmlRef, ...htmlProps }) {
     const ref = React.useRef<HTMLElement>(null);
     const [role, setRole] = React.useState<"button" | undefined>(undefined);
+    const [type, setType] = React.useState<"button" | undefined>(undefined);
 
     React.useEffect(() => {
       if (
@@ -30,6 +31,7 @@ export const useButton = createHook<ButtonOptions, ButtonHTMLProps>({
           ref.current instanceof HTMLAnchorElement ||
           ref.current instanceof HTMLInputElement)
       ) {
+        setType("button");
         return;
       }
       setRole("button");
@@ -38,7 +40,7 @@ export const useButton = createHook<ButtonOptions, ButtonHTMLProps>({
     return {
       ref: mergeRefs(ref, htmlRef),
       role,
-      type: "button",
+      type,
       ...htmlProps
     };
   }

--- a/packages/reakit/src/Button/Button.ts
+++ b/packages/reakit/src/Button/Button.ts
@@ -25,16 +25,19 @@ export const useButton = createHook<ButtonOptions, ButtonHTMLProps>({
     const [type, setType] = React.useState<"button" | undefined>(undefined);
 
     React.useEffect(() => {
+      if (ref.current && ref.current instanceof HTMLAnchorElement) {
+        return;
+      }
+
       if (
         ref.current &&
         (ref.current instanceof HTMLButtonElement ||
-          ref.current instanceof HTMLAnchorElement ||
           ref.current instanceof HTMLInputElement)
       ) {
         setType("button");
-        return;
+      } else {
+        setRole("button");
       }
-      setRole("button");
     }, []);
 
     return {

--- a/packages/reakit/src/Button/Button.ts
+++ b/packages/reakit/src/Button/Button.ts
@@ -28,6 +28,7 @@ export const useButton = createHook<ButtonOptions, ButtonHTMLProps>({
       if (
         ref.current &&
         (ref.current instanceof HTMLButtonElement ||
+          ref.current instanceof HTMLAnchorElement ||
           ref.current instanceof HTMLInputElement)
       ) {
         setType("button");

--- a/packages/reakit/src/Button/__tests__/Button-test.tsx
+++ b/packages/reakit/src/Button/__tests__/Button-test.tsx
@@ -16,9 +16,7 @@ test("render", () => {
 test("render anchor", () => {
   const { getByText } = render(<Button as="a">button</Button>);
   expect(getByText("button")).toMatchInlineSnapshot(`
-    <a
-      role="button"
-    >
+    <a>
       button
     </a>
   `);

--- a/packages/reakit/src/Button/__tests__/Button-test.tsx
+++ b/packages/reakit/src/Button/__tests__/Button-test.tsx
@@ -16,9 +16,7 @@ test("render", () => {
 test("render anchor", () => {
   const { getByText } = render(<Button as="a">button</Button>);
   expect(getByText("button")).toMatchInlineSnapshot(`
-    <a
-      type="button"
-    >
+    <a>
       button
     </a>
   `);

--- a/packages/reakit/src/Button/__tests__/Button-test.tsx
+++ b/packages/reakit/src/Button/__tests__/Button-test.tsx
@@ -16,9 +16,7 @@ test("render", () => {
 test("render anchor", () => {
   const { getByText } = render(<Button as="a">button</Button>);
   expect(getByText("button")).toMatchInlineSnapshot(`
-    <a
-      type="button"
-    >
+    <a>
       button
     </a>
   `);
@@ -30,7 +28,6 @@ test("render div", () => {
     <div
       role="button"
       tabindex="0"
-      type="button"
     >
       button
     </div>

--- a/packages/reakit/src/Button/__tests__/Button-test.tsx
+++ b/packages/reakit/src/Button/__tests__/Button-test.tsx
@@ -16,7 +16,9 @@ test("render", () => {
 test("render anchor", () => {
   const { getByText } = render(<Button as="a">button</Button>);
   expect(getByText("button")).toMatchInlineSnapshot(`
-    <a>
+    <a
+      role="button"
+    >
       button
     </a>
   `);

--- a/packages/reakit/src/Button/__tests__/Button-test.tsx
+++ b/packages/reakit/src/Button/__tests__/Button-test.tsx
@@ -16,7 +16,9 @@ test("render", () => {
 test("render anchor", () => {
   const { getByText } = render(<Button as="a">button</Button>);
   expect(getByText("button")).toMatchInlineSnapshot(`
-    <a>
+    <a
+      type="button"
+    >
       button
     </a>
   `);


### PR DESCRIPTION
Custom elements are receiving the `type` attribute, which is not valid.

About the role, see note on WAI-ARIA 1.1 [link(role)](https://w3.org/TR/wai-aria-1.1/#link):

> "If pressing the link triggers an action but does not change browser focus or page location, authors are advised to consider using the button role instead of the link role."