### PR TITLE
fix: Fix `Rover` trying to focus itself again when it receives focus

### DIFF
--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -649,7 +649,7 @@ It's called after given milliseconds if `animated` is a number.
   A list of element refs and IDs of the roving items.
 
 - **`move`**
-  <code>(id: string | null) =&#62; void</code>
+  <code title="(id: string | null, unstable_silent?: boolean | undefined) =&#62; void">(id: string | null, unstable_silent?: boolean |...</code>
 
   Moves focus to a given element ID.
 
@@ -700,7 +700,7 @@ It's called after given milliseconds if `animated` is a number.
   A list of element refs and IDs of the roving items.
 
 - **`move`**
-  <code>(id: string | null) =&#62; void</code>
+  <code title="(id: string | null, unstable_silent?: boolean | undefined) =&#62; void">(id: string | null, unstable_silent?: boolean |...</code>
 
   Moves focus to a given element ID.
 
@@ -835,7 +835,7 @@ similarly to `readOnly` on form elements. In this case, only
   A list of element refs and IDs of the roving items.
 
 - **`move`**
-  <code>(id: string | null) =&#62; void</code>
+  <code title="(id: string | null, unstable_silent?: boolean | undefined) =&#62; void">(id: string | null, unstable_silent?: boolean |...</code>
 
   Moves focus to a given element ID.
 
@@ -912,7 +912,7 @@ array.
 
   MenuItemCheckbox's name as in `menu.values`.
 
-<details><summary>17 state props</summary>
+<details><summary>18 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 
@@ -960,7 +960,7 @@ going to be an array.
   A list of element refs and IDs of the roving items.
 
 - **`move`**
-  <code>(id: string | null) =&#62; void</code>
+  <code title="(id: string | null, unstable_silent?: boolean | undefined) =&#62; void">(id: string | null, unstable_silent?: boolean |...</code>
 
   Moves focus to a given element ID.
 
@@ -1004,6 +1004,11 @@ going to be an array.
 
   Stores the values of radios and checkboxes within the menu.
 
+- **`unstable_setValue`** <span title="Experimental">⚠️</span>
+  <code>(name: string, value?: any) =&#62; void</code>
+
+  Updates checkboxes and radios values within the menu.
+
 </details>
 
 ### `MenuItemRadio`
@@ -1040,7 +1045,7 @@ similarly to `readOnly` on form elements. In this case, only
 
   MenuItemRadio's name as in `menu.values`.
 
-<details><summary>17 state props</summary>
+<details><summary>18 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 
@@ -1048,6 +1053,12 @@ similarly to `readOnly` on form elements. In this case, only
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
   Defines the orientation of the rover list.
+
+- **`unstable_moves`** <span title="Experimental">⚠️</span>
+  <code>number</code>
+
+  Stores the number of moves that have been made by calling `move`, `next`,
+`previous`, `first` or `last`.
 
 - **`currentId`**
   <code>string | null</code>
@@ -1070,7 +1081,7 @@ similarly to `readOnly` on form elements. In this case, only
   A list of element refs and IDs of the roving items.
 
 - **`move`**
-  <code>(id: string | null) =&#62; void</code>
+  <code title="(id: string | null, unstable_silent?: boolean | undefined) =&#62; void">(id: string | null, unstable_silent?: boolean |...</code>
 
   Moves focus to a given element ID.
 
@@ -1083,12 +1094,6 @@ similarly to `readOnly` on form elements. In this case, only
   <code>() =&#62; void</code>
 
   Moves focus to the previous element.
-
-- **`unstable_moves`** <span title="Experimental">⚠️</span>
-  <code>number</code>
-
-  Stores the number of moves that have been made by calling `move`, `next`,
-`previous`, `first` or `last`.
 
 - **`register`**
   <code>(id: string, ref: RefObject&#60;HTMLElement&#62;) =&#62; void</code>
@@ -1129,6 +1134,11 @@ similarly to `readOnly` on form elements. In this case, only
   <code>{ [x: string]: any; }</code>
 
   Stores the values of radios and checkboxes within the menu.
+
+- **`unstable_setValue`** <span title="Experimental">⚠️</span>
+  <code>(name: string, value?: any) =&#62; void</code>
+
+  Updates checkboxes and radios values within the menu.
 
 </details>
 

--- a/packages/reakit/src/Radio/README.md
+++ b/packages/reakit/src/Radio/README.md
@@ -120,16 +120,16 @@ similarly to `readOnly` on form elements. In this case, only
 
   Defines the orientation of the rover list.
 
-- **`currentId`**
-  <code>string | null</code>
-
-  The current focused element ID.
-
 - **`unstable_moves`** <span title="Experimental">⚠️</span>
   <code>number</code>
 
   Stores the number of moves that have been made by calling `move`, `next`,
 `previous`, `first` or `last`.
+
+- **`currentId`**
+  <code>string | null</code>
+
+  The current focused element ID.
 
 - **`stops`**
   <code>Stop[]</code>
@@ -147,7 +147,7 @@ similarly to `readOnly` on form elements. In this case, only
   Unregisters the roving item.
 
 - **`move`**
-  <code>(id: string | null) =&#62; void</code>
+  <code title="(id: string | null, unstable_silent?: boolean | undefined) =&#62; void">(id: string | null, unstable_silent?: boolean |...</code>
 
   Moves focus to a given element ID.
 

--- a/packages/reakit/src/Rover/README.md
+++ b/packages/reakit/src/Rover/README.md
@@ -172,7 +172,7 @@ similarly to `readOnly` on form elements. In this case, only
   Unregisters the roving item.
 
 - **`move`**
-  <code>(id: string | null) =&#62; void</code>
+  <code title="(id: string | null, unstable_silent?: boolean | undefined) =&#62; void">(id: string | null, unstable_silent?: boolean |...</code>
 
   Moves focus to a given element ID.
 

--- a/packages/reakit/src/Rover/Rover.ts
+++ b/packages/reakit/src/Rover/Rover.ts
@@ -86,7 +86,8 @@ export const useRover = createHook<RoverOptions, RoverHTMLProps>({
     React.useEffect(() => {
       if (!ref.current) return undefined;
 
-      const onFocus = () => options.move(stopId);
+      // this is already focused, so we move silently
+      const onFocus = () => options.move(stopId, true);
 
       // https://github.com/facebook/react/issues/11387#issuecomment-524113945
       ref.current.addEventListener("focus", onFocus, true);

--- a/packages/reakit/src/Rover/__tests__/RoverState-test.ts
+++ b/packages/reakit/src/Rover/__tests__/RoverState-test.ts
@@ -394,6 +394,46 @@ test("move to null", () => {
   );
 });
 
+test("move silently", () => {
+  const result = render();
+  act(() => result.current.register("a", createRef("a")));
+  act(() => result.current.register("b", createRef("b")));
+  act(() => result.current.move("b"));
+  act(() => result.current.move("b", true));
+  expect(result.current).toMatchInlineSnapshot(
+    {
+      unstable_moves: 1
+    },
+    `
+    Object {
+      "currentId": "b",
+      "loop": false,
+      "orientation": undefined,
+      "stops": Array [
+        Object {
+          "id": "a",
+          "ref": Object {
+            "current": <div
+              id="a"
+            />,
+          },
+        },
+        Object {
+          "id": "b",
+          "ref": Object {
+            "current": <div
+              id="b"
+            />,
+          },
+        },
+      ],
+      "unstable_moves": 1,
+      "unstable_pastId": null,
+    }
+  `
+  );
+});
+
 test("next", () => {
   const result = render();
   act(() => result.current.register("a", createRef("a")));

--- a/packages/reakit/src/Rover/__tests__/index-test.tsx
+++ b/packages/reakit/src/Rover/__tests__/index-test.tsx
@@ -283,3 +283,27 @@ test("keep rover DOM order", () => {
   keyDown("ArrowLeft");
   expect(rover2).toHaveFocus();
 });
+
+test("focus another component right after focusing rover", () => {
+  const Test = () => {
+    const rover = useRoverState();
+    return (
+      <>
+        <Rover {...rover}>rover1</Rover>
+        <Rover {...rover}>rover2</Rover>
+        <Rover {...rover}>rover3</Rover>
+        <button>button</button>
+      </>
+    );
+  };
+  const { getByText } = render(<Test />);
+  const rover1 = getByText("rover1");
+  const button = getByText("button");
+  act(() => {
+    // Puting both in the same act so rover focus effects will run only after
+    // receives focus
+    rover1.focus();
+    button.focus();
+  });
+  expect(button).toHaveFocus();
+});

--- a/packages/reakit/src/Tab/README.md
+++ b/packages/reakit/src/Tab/README.md
@@ -337,7 +337,7 @@ similarly to `readOnly` on form elements. In this case, only
   Unregisters the roving item.
 
 - **`move`**
-  <code>(id: string | null) =&#62; void</code>
+  <code title="(id: string | null, unstable_silent?: boolean | undefined) =&#62; void">(id: string | null, unstable_silent?: boolean |...</code>
 
   Moves focus to a given element ID.
 

--- a/packages/reakit/src/Toolbar/README.md
+++ b/packages/reakit/src/Toolbar/README.md
@@ -196,7 +196,7 @@ similarly to `readOnly` on form elements. In this case, only
   Unregisters the roving item.
 
 - **`move`**
-  <code>(id: string | null) =&#62; void</code>
+  <code title="(id: string | null, unstable_silent?: boolean | undefined) =&#62; void">(id: string | null, unstable_silent?: boolean |...</code>
 
   Moves focus to a given element ID.
 


### PR DESCRIPTION
When `Rover` received focus it was incrementing the `unstable_moves` prop, triggering another effect that would try to focus it again.

**Does this PR introduce a breaking change?**

No