### PR TITLE
Remove hardcoded "[reakit]" string from warning()

### DIFF
--- a/packages/reakit-utils/src/__tests__/warning-test.ts
+++ b/packages/reakit-utils/src/__tests__/warning-test.ts
@@ -15,7 +15,7 @@ describe("warning", () => {
       warning(true, "warn", "ing");
     });
 
-    expect(warnSpy).toHaveBeenCalledWith("warn\n\ning");
+    expect(warnSpy).toHaveBeenCalledWith("warn\ning");
   });
   it('does not log to console.warn if NODE_ENV is "production"', () => {
     process.env.NODE_ENV = "production";

--- a/packages/reakit-utils/src/__tests__/warning-test.ts
+++ b/packages/reakit-utils/src/__tests__/warning-test.ts
@@ -1,0 +1,30 @@
+describe("warning", () => {
+  const initialNodeEnv = process.env.NODE_ENV;
+  const warnSpy = jest.spyOn(global.console, "warn").mockImplementation();
+
+  afterEach(() => {
+    process.env.NODE_ENV = initialNodeEnv;
+    warnSpy.mockRestore();
+  });
+
+  it('logs to console.warn when NODE_ENV is not "production"', () => {
+    process.env.NODE_ENV = "development";
+
+    jest.isolateModules(() => {
+      const { warning } = require("../warning");
+      warning(true, "warn", "ing");
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith("warn\n\ning");
+  });
+  it('does not log to console.warn if NODE_ENV is "production"', () => {
+    process.env.NODE_ENV = "production";
+
+    jest.isolateModules(() => {
+      const { warning } = require("../warning");
+      warning(true, "warn", "ing");
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/reakit-utils/src/warning.ts
+++ b/packages/reakit-utils/src/warning.ts
@@ -1,15 +1,10 @@
 const isProduction = process.env.NODE_ENV === "production";
 
-export function warning(
-  condition: boolean,
-  label?: string,
-  ...messages: string[]
-) {
+export function warning(condition: boolean, ...messages: string[]) {
   if (!isProduction) {
     if (!condition) return;
 
-    const finalLabel = label ? `[reakit/${label}]\n` : "[reakit]\n";
-    const text = `${finalLabel}${messages.join("\n\n")}`;
+    const text = messages.join("\n\n");
 
     // eslint-disable-next-line no-console
     console.warn(text);

--- a/packages/reakit-utils/src/warning.ts
+++ b/packages/reakit-utils/src/warning.ts
@@ -4,7 +4,7 @@ export function warning(condition: boolean, ...messages: string[]) {
   if (!isProduction) {
     if (!condition) return;
 
-    const text = messages.join("\n\n");
+    const text = messages.join("\n");
 
     // eslint-disable-next-line no-console
     console.warn(text);

--- a/packages/reakit/src/Checkbox/__utils/useIndeterminateState.ts
+++ b/packages/reakit/src/Checkbox/__utils/useIndeterminateState.ts
@@ -10,7 +10,7 @@ export function useIndeterminateState(
     if (!checkboxRef.current) {
       warning(
         options.state === "indeterminate",
-        "Checkbox",
+        "[reakit/Checkbox]",
         "Can't set indeterminate state because `ref` wasn't passed to component.",
         "See https://reakit.io/docs/checkbox/#indeterminate-state"
       );

--- a/packages/reakit/src/Dialog/Dialog.tsx
+++ b/packages/reakit/src/Dialog/Dialog.tsx
@@ -148,7 +148,7 @@ export const useDialog = createHook<DialogOptions, DialogHTMLProps>({
           if (!options.hide) {
             warning(
               true,
-              "Dialog",
+              "[reakit/Dialog]",
               "`hideOnEsc` prop is truthy, but `hide` prop wasn't provided.",
               "See https://reakit.io/docs/dialog"
             );
@@ -180,7 +180,7 @@ export const Dialog = createComponent({
   useCreateElement: (type, props, children) => {
     warning(
       !props["aria-label"] && !props["aria-labelledby"],
-      "Dialog",
+      "[reakit/Dialog]",
       "You should provide either `aria-label` or `aria-labelledby` props.",
       "See https://reakit.io/docs/dialog"
     );

--- a/packages/reakit/src/Dialog/__utils/useEventListenerOutside.ts
+++ b/packages/reakit/src/Dialog/__utils/useEventListenerOutside.ts
@@ -26,7 +26,7 @@ export function useEventListenerOutside(
       if (!container) {
         warning(
           true,
-          "Dialog",
+          "[reakit/Dialog]",
           "Can't detect events outside dialog because `ref` wasn't passed to component.",
           "See https://reakit.io/docs/dialog"
         );

--- a/packages/reakit/src/Dialog/__utils/useFocusOnHide.ts
+++ b/packages/reakit/src/Dialog/__utils/useFocusOnHide.ts
@@ -37,7 +37,7 @@ export function useFocusOnHide(
     } else {
       warning(
         true,
-        "Dialog",
+        "[reakit/Dialog]",
         "Can't return focus after closing dialog. Either render a disclosure component or provide a `unstable_finalFocusRef` prop.",
         "See https://reakit.io/docs/dialog"
       );

--- a/packages/reakit/src/Dialog/__utils/useFocusOnShow.ts
+++ b/packages/reakit/src/Dialog/__utils/useFocusOnShow.ts
@@ -17,7 +17,7 @@ export function useFocusOnShow(
 
     warning(
       Boolean(shouldFocus && !dialog),
-      "Dialog",
+      "[reakit/Dialog]",
       "Can't set initial focus on dialog because `ref` wasn't passed to component.",
       "See https://reakit.io/docs/dialog"
     );
@@ -44,7 +44,7 @@ export function useFocusOnShow(
         ensureFocus(dialog, { preventScroll: true, isActive });
         warning(
           dialog.tabIndex === undefined || dialog.tabIndex < 0,
-          "Dialog",
+          "[reakit/Dialog]",
           "It's recommended to have at least one tabbable element inside dialog. The dialog element has been automatically focused.",
           "If this is the intended behavior, pass `tabIndex={0}` to the dialog element to disable this warning.",
           "See https://reakit.io/docs/dialog/#initial-focus"

--- a/packages/reakit/src/Dialog/__utils/useFocusTrap.ts
+++ b/packages/reakit/src/Dialog/__utils/useFocusTrap.ts
@@ -46,7 +46,7 @@ export function useFocusTrap(
     if (!portal) {
       warning(
         true,
-        "Dialog",
+        "[reakit/Dialog]",
         "Can't trap focus within modal dialog because either `ref` wasn't passed to component or the component wasn't rendered within a portal",
         "See https://reakit.io/docs/dialog"
       );

--- a/packages/reakit/src/Hidden/HiddenState.ts
+++ b/packages/reakit/src/Hidden/HiddenState.ts
@@ -110,7 +110,7 @@ export function useHiddenState(
   const show = React.useCallback(() => {
     warning(
       !isMounted,
-      "Hidden",
+      "[reakit/Hidden]",
       "You're trying to show a hidden element that hasn't been mounted yet.",
       "You shouldn't conditionally render a `Hidden` component (or any of its derivatives) as this will make some features not work.",
       "If this is intentional, you can omit this warning by passing `unstable_isMounted: true` to `useHiddenState` or just ignore it.",
@@ -124,7 +124,7 @@ export function useHiddenState(
   const toggle = React.useCallback(() => {
     warning(
       !isMounted,
-      "Hidden",
+      "[reakit/Hidden]",
       "You're trying to toggle a hidden element that hasn't been mounted yet.",
       "You shouldn't conditionally render a `Hidden` component (or any of its derivatives) as this will make some features not work.",
       "If this is intentional, you can omit this warning by passing `unstable_isMounted: true` to `useHiddenState` or just ignore it.",

--- a/packages/reakit/src/Hidden/__utils/useWarningIfMultiple.ts
+++ b/packages/reakit/src/Hidden/__utils/useWarningIfMultiple.ts
@@ -10,7 +10,7 @@ export function useWarningIfMultiple(options: HiddenOptions) {
 
     warning(
       document.querySelectorAll(`#${options.unstable_hiddenId}`).length > 1,
-      "Hidden",
+      "[reakit/Hidden]",
       "You're reusing the same `useModuleState` for multiple components (Hidden, Dialog, Popover, Menu etc.).",
       "This is not allowed! If you want to use multiple components, make sure you're using different states.",
       "See https://reakit.io/docs/hidden/#multiple-components"

--- a/packages/reakit/src/Menu/Menu.tsx
+++ b/packages/reakit/src/Menu/Menu.tsx
@@ -137,7 +137,7 @@ export const Menu = createComponent({
   useCreateElement: (type, props, children) => {
     warning(
       !props["aria-label"] && !props["aria-labelledby"],
-      "Menu",
+      "[reakit/Menu]",
       "You should provide either `aria-label` or `aria-labelledby` props.",
       "See https://reakit.io/docs/menu"
     );

--- a/packages/reakit/src/Menu/MenuBar.tsx
+++ b/packages/reakit/src/Menu/MenuBar.tsx
@@ -50,7 +50,7 @@ export const MenuBar = createComponent({
       !props["aria-label"] &&
         !props["aria-labelledby"] &&
         props.role !== "menubar",
-      "Menu",
+      "[reakit/Menu]",
       "You should provide either `aria-label` or `aria-labelledby` props.",
       "See https://reakit.io/docs/menu"
     );

--- a/packages/reakit/src/Popover/Popover.ts
+++ b/packages/reakit/src/Popover/Popover.ts
@@ -40,7 +40,7 @@ export const Popover = createComponent({
   useCreateElement: (type, props, children) => {
     warning(
       !props["aria-label"] && !props["aria-labelledby"],
-      "Popover",
+      "[reakit/Popover]",
       "You should provide either `aria-label` or `aria-labelledby` props.",
       "See https://reakit.io/docs/popover"
     );

--- a/packages/reakit/src/Radio/RadioGroup.tsx
+++ b/packages/reakit/src/Radio/RadioGroup.tsx
@@ -29,7 +29,7 @@ export const RadioGroup = createComponent({
   useCreateElement: (type, props, children) => {
     warning(
       !props["aria-label"] && !props["aria-labelledby"],
-      "RadioGroup",
+      "[reakit/RadioGroup]",
       "You should provide either `aria-label` or `aria-labelledby` props.",
       "See https://reakit.io/docs/radio"
     );

--- a/packages/reakit/src/Rover/Rover.ts
+++ b/packages/reakit/src/Rover/Rover.ts
@@ -72,7 +72,7 @@ export const useRover = createHook<RoverOptions, RoverHTMLProps>({
       if (!ref.current) {
         warning(
           true,
-          "Rover",
+          "[reakit/Rover]",
           "Can't focus rover component because `ref` wasn't passed to component.",
           "See https://reakit.io/docs/rover"
         );

--- a/packages/reakit/src/Rover/RoverState.ts
+++ b/packages/reakit/src/Rover/RoverState.ts
@@ -155,7 +155,7 @@ function reducer(state: RoverState, action: RoverAction): RoverState {
       const { id } = action;
       const nextStops = stops.filter(stop => stop.id !== id);
       if (nextStops.length === stops.length) {
-        warning(true, "RoverState", `${id} stop is not registered`);
+        warning(true, "[reakit/RoverState]", `${id} stop is not registered`);
         return state;
       }
 

--- a/packages/reakit/src/Tab/TabList.tsx
+++ b/packages/reakit/src/Tab/TabList.tsx
@@ -32,7 +32,7 @@ export const TabList = createComponent({
   useCreateElement: (type, props, children) => {
     warning(
       !props["aria-label"] && !props["aria-labelledby"],
-      "TabList",
+      "[reakit/TabList]",
       "You should provide either `aria-label` or `aria-labelledby` props.",
       "See https://reakit.io/docs/tab"
     );

--- a/packages/reakit/src/Toolbar/Toolbar.tsx
+++ b/packages/reakit/src/Toolbar/Toolbar.tsx
@@ -32,7 +32,7 @@ export const Toolbar = createComponent({
   useCreateElement: (type, props, children) => {
     warning(
       !props["aria-label"] && !props["aria-labelledby"],
-      "Toolbar",
+      "[reakit/Toolbar]",
       "You should provide either `aria-label` or `aria-labelledby` props.",
       "See https://reakit.io/docs/toolbar"
     );

--- a/packages/reakit/src/utils/Provider.ts
+++ b/packages/reakit/src/utils/Provider.ts
@@ -2,7 +2,7 @@ import { warning } from "reakit-utils/warning";
 
 warning(
   false,
-  undefined,
+  "[reakit]",
   "Importing `Provider` from `reakit/utils` or `reakit/utils/Provider` is deprecated.",
   "Please, import `Provider` from `reakit` or `reakit/Provider` instead"
 );


### PR DESCRIPTION
Enable third-party callsites to use `warning()` for their specific warnings without tagging them as `"[reakit]"`.

Closes #475

**Does this PR introduce a breaking change?**

Yes

- `warning()`'s label argument has been turned into a regular message. Existing callsites should update the first message after the condition to include a label, if required.

  **Before:**
  ```js
  warning(!!condition, 'Button', 'warning message');
  ```
  **After:**
  ```js
  warning(!!condition, '[reakit/Button]', 'warning message');
  ```
