### PR TITLE
fix: Fix `Tabbable` preventing click after enabling it

### DIFF
--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -124,7 +124,7 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
           htmlOnClick(event);
         }
       },
-      [htmlOnClick]
+      [options.disabled, htmlOnClick]
     );
 
     const onMouseDown = React.useCallback(
@@ -155,7 +155,7 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
           htmlOnMouseDown(event);
         }
       },
-      [htmlOnMouseDown]
+      [options.disabled, htmlOnMouseDown]
     );
 
     const onKeyDown = React.useCallback(

--- a/packages/reakit/src/Tabbable/__tests__/Tabbable-test.tsx
+++ b/packages/reakit/src/Tabbable/__tests__/Tabbable-test.tsx
@@ -59,6 +59,19 @@ test("click disabled", () => {
   expect(fn).toHaveBeenCalledTimes(0);
 });
 
+test("click enabled after disabled", () => {
+  const fn = jest.fn();
+  const { getByText, rerender } = render(
+    <Tabbable onClick={fn} disabled>
+      tabbable
+    </Tabbable>
+  );
+  const tabbable = getByText("tabbable");
+  rerender(<Tabbable onClick={fn}>tabbable</Tabbable>);
+  fireEvent.click(tabbable);
+  expect(fn).toHaveBeenCalledTimes(1);
+});
+
 test("click disabled focusable", () => {
   const fn = jest.fn();
   const { getByText } = render(


### PR DESCRIPTION
Closes #480

By the way, something like `eslint-plugin-react-hooks` would catch this.