### PR TITLE
Add and enable `eslint-plugin-react-hooks`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,8 @@ module.exports = {
     "react/jsx-filename-extension": "off",
     "react/destructuring-assignment": "off",
     "react/button-has-type": "off",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
     "import/order": [
       "error",
       {
@@ -74,7 +76,7 @@ module.exports = {
       parserOptions: {
         project: "./tsconfig.json"
       },
-      plugins: ["@typescript-eslint"],
+      plugins: ["@typescript-eslint", "react-hooks"],
       rules: {
         "no-undef": "off",
         "no-unused-vars": "off",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-markdown": "1.0.0",
     "eslint-plugin-prettier": "3.1.0",
     "eslint-plugin-react": "7.14.2",
-    "eslint-plugin-react-hooks": "1.6.1",
+    "eslint-plugin-react-hooks": "2.2.0",
     "fs-extra": "8.0.1",
     "husky": "2.4.1",
     "jest": "24.8.0",

--- a/packages/website/src/components/DocsInnerNavigation.tsx
+++ b/packages/website/src/components/DocsInnerNavigation.tsx
@@ -1,4 +1,5 @@
 // TODO: Refactor this mess
+/* eslint-disable react-hooks/rules-of-hooks, react-hooks/exhaustive-deps */
 import * as React from "react";
 import RehypeReact from "rehype-react";
 import { useId } from "reakit-utils";

--- a/packages/website/src/templates/Docs.tsx
+++ b/packages/website/src/templates/Docs.tsx
@@ -1,4 +1,5 @@
 // TODO: Refactor this mess
+/* eslint-disable react-hooks/rules-of-hooks, react-hooks/exhaustive-deps */
 import * as React from "react";
 import { graphql } from "gatsby";
 import RehypeReact from "rehype-react";

--- a/yarn.lock
+++ b/yarn.lock
@@ -7434,10 +7434,10 @@ eslint-plugin-prettier@3.1.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react-hooks@1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.1.tgz#3c66a5515ea3e0a221ffc5d4e75c971c217b1a4c"
-  integrity sha512-wHhmGJyVuijnYIJXZJHDUF2WM+rJYTjulUTqF9k61d3BTk8etydz+M4dXUVH7M76ZRS85rqBTCx0Es/lLsrjnA==
+eslint-plugin-react-hooks@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.2.0.tgz#078264e9e388da6929ace09d6abe92c85963aff4"
+  integrity sha512-jSlnBjV2cmyIeL555H/FbvuSbQ1AtpHjLMHuPrQnt1eVA6lX8yufdygh7AArI2m8ct7ChHGx2uOaCuxq2MUn6g==
 
 eslint-plugin-react@7.14.2, eslint-plugin-react@^7.8.2:
   version "7.14.2"


### PR DESCRIPTION
A mentioned here: https://github.com/reakit/reakit/pull/481#issue-338186966

There are currently lots of warnings which I'm hoping to go through and fix. I have reached out on the React repo (facebook/react#17312) to see if I can get some clarification on passing object properties in the dependency array. I couldn't find any info through Googling!

**Does this PR introduce a breaking change?**

No