### PR TITLE
Docs: Remove unnecessary `Portal` from `Dialog` readme

### DIFF
--- a/packages/reakit/src/Dialog/README.md
+++ b/packages/reakit/src/Dialog/README.md
@@ -64,9 +64,7 @@ function Example() {
   return (
     <>
       <DialogDisclosure {...dialog}>Open dialog</DialogDisclosure>
-      <Portal>
-        <DialogBackdrop {...dialog} />
-      </Portal>
+      <DialogBackdrop {...dialog} />
       <Dialog {...dialog} aria-label="Welcome">
         Welcome to Reakit!
       </Dialog>


### PR DESCRIPTION
A `DialogBackdrop` renders by default in a portal.


**Does this PR introduce a breaking change?**

no

