### PR TITLE
feat: Add `baseId` option to `useRoverState` and derivative hooks

### DIFF
--- a/packages/reakit/src/Id/IdState.ts
+++ b/packages/reakit/src/Id/IdState.ts
@@ -7,7 +7,7 @@ import { unstable_IdContext } from "./IdProvider";
 
 export type unstable_IdState = {
   /**
-   * @private
+   * ID that will serve as a base for all the items IDs.
    */
   baseId: string;
   /**

--- a/packages/reakit/src/Provider.tsx
+++ b/packages/reakit/src/Provider.tsx
@@ -4,6 +4,7 @@ import {
   SystemProviderProps,
   SystemProvider
 } from "reakit-system/SystemProvider";
+import { unstable_IdProvider as NewIdProvider } from "./Id/IdProvider";
 
 export type ProviderProps = IdProviderProps & Partial<SystemProviderProps>;
 
@@ -14,7 +15,9 @@ export function Provider({
 }: ProviderProps) {
   return (
     <IdProvider unstable_prefix={prefix}>
-      <SystemProvider unstable_system={system}>{children}</SystemProvider>
+      <NewIdProvider prefix={prefix}>
+        <SystemProvider unstable_system={system}>{children}</SystemProvider>
+      </NewIdProvider>
     </IdProvider>
   );
 }

--- a/packages/reakit/src/Radio/__tests__/RadioState-test.ts
+++ b/packages/reakit/src/Radio/__tests__/RadioState-test.ts
@@ -5,14 +5,18 @@ import { useRadioState } from "../RadioState";
 expect.addSnapshotSerializer(jestSerializerStripFunctions);
 
 test("initial state", () => {
-  const { result } = renderHook(() => useRadioState());
+  const { result } = renderHook(() => useRadioState({ baseId: "base" }));
   expect(result.current).toMatchInlineSnapshot(`
     Object {
+      "baseId": "base",
       "currentId": null,
       "loop": true,
       "orientation": undefined,
       "state": undefined,
       "stops": Array [],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 0,
       "unstable_pastId": null,
     }

--- a/packages/reakit/src/Rover/__tests__/Rover-test.tsx
+++ b/packages/reakit/src/Rover/__tests__/Rover-test.tsx
@@ -2,12 +2,6 @@ import * as React from "react";
 import { render } from "@testing-library/react";
 import { Rover } from "../Rover";
 
-jest.mock("reakit-utils/useId", () => {
-  return {
-    useId: jest.fn(() => "rover")
-  };
-});
-
 const props: Parameters<typeof Rover>[0] = {
   stopId: "rover",
   stops: [],
@@ -39,7 +33,7 @@ test("render", () => {
 
 test("render without state props", () => {
   // @ts-ignore
-  const { baseElement } = render(<Rover>rover</Rover>);
+  const { baseElement } = render(<Rover id="rover">rover</Rover>);
   expect(baseElement).toMatchInlineSnapshot(`
     <body>
       <div>

--- a/packages/reakit/src/Rover/__tests__/RoverState-test.ts
+++ b/packages/reakit/src/Rover/__tests__/RoverState-test.ts
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { renderHook, act } from "@testing-library/react-hooks";
 import { jestSerializerStripFunctions } from "reakit-utils/jestSerializerStripFunctions";
-import { useRoverState } from "../RoverState";
+import { useRoverState, RoverInitialState } from "../RoverState";
 
 expect.addSnapshotSerializer(jestSerializerStripFunctions);
 
-function render(...args: Parameters<typeof useRoverState>) {
-  return renderHook(() => useRoverState(...args)).result;
+function render({ baseId = "base", ...initialState }: RoverInitialState = {}) {
+  return renderHook(() => useRoverState({ baseId, ...initialState })).result;
 }
 
 function createRef(id: string) {
@@ -20,10 +20,14 @@ test("initial state", () => {
   const result = render();
   expect(result.current).toMatchInlineSnapshot(`
     Object {
+      "baseId": "base",
       "currentId": null,
       "loop": false,
       "orientation": undefined,
       "stops": Array [],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 0,
       "unstable_pastId": null,
     }
@@ -36,10 +40,14 @@ test("initial state activeRef", () => {
     { currentId: "a" },
     `
     Object {
+      "baseId": "base",
       "currentId": "a",
       "loop": false,
       "orientation": undefined,
       "stops": Array [],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 0,
       "unstable_pastId": null,
     }
@@ -53,10 +61,14 @@ test("initial state loop", () => {
     { loop: true },
     `
     Object {
+      "baseId": "base",
       "currentId": null,
       "loop": true,
       "orientation": undefined,
       "stops": Array [],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 0,
       "unstable_pastId": null,
     }
@@ -69,15 +81,19 @@ test("initial state orientation", () => {
   expect(result.current).toMatchInlineSnapshot(
     { orientation: "vertical" },
     `
-            Object {
-              "currentId": null,
-              "loop": false,
-              "orientation": "vertical",
-              "stops": Array [],
-              "unstable_moves": 0,
-              "unstable_pastId": null,
-            }
-      `
+    Object {
+      "baseId": "base",
+      "currentId": null,
+      "loop": false,
+      "orientation": "vertical",
+      "stops": Array [],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
+      "unstable_moves": 0,
+      "unstable_pastId": null,
+    }
+  `
   );
 });
 
@@ -86,6 +102,7 @@ test("register", () => {
   act(() => result.current.register("a", createRef("a")));
   expect(result.current).toMatchInlineSnapshot(`
     Object {
+      "baseId": "base",
       "currentId": null,
       "loop": false,
       "orientation": undefined,
@@ -99,6 +116,9 @@ test("register", () => {
           },
         },
       ],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 0,
       "unstable_pastId": null,
     }
@@ -112,6 +132,7 @@ test("register already registered", () => {
   act(() => result.current.register("a", ref));
   expect(result.current).toMatchInlineSnapshot(`
     Object {
+      "baseId": "base",
       "currentId": null,
       "loop": false,
       "orientation": undefined,
@@ -125,6 +146,9 @@ test("register already registered", () => {
           },
         },
       ],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 0,
       "unstable_pastId": null,
     }
@@ -136,6 +160,7 @@ test("register currentId", () => {
   act(() => result.current.register("a", createRef("a")));
   expect(result.current).toMatchInlineSnapshot(`
     Object {
+      "baseId": "base",
       "currentId": "a",
       "loop": false,
       "orientation": undefined,
@@ -149,6 +174,9 @@ test("register currentId", () => {
           },
         },
       ],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 0,
       "unstable_pastId": null,
     }
@@ -161,10 +189,14 @@ test("unregister", () => {
   act(() => result.current.unregister("a"));
   expect(result.current).toMatchInlineSnapshot(`
     Object {
+      "baseId": "base",
       "currentId": null,
       "loop": false,
       "orientation": undefined,
       "stops": Array [],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 0,
       "unstable_pastId": null,
     }
@@ -176,10 +208,14 @@ test("unregister inexistent", () => {
   act(() => result.current.unregister("a"));
   expect(result.current).toMatchInlineSnapshot(`
     Object {
+      "baseId": "base",
       "currentId": null,
       "loop": false,
       "orientation": undefined,
       "stops": Array [],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 0,
       "unstable_pastId": null,
     }
@@ -197,10 +233,14 @@ test("unregister currentId", () => {
     },
     `
     Object {
+      "baseId": "base",
       "currentId": null,
       "loop": false,
       "orientation": undefined,
       "stops": Array [],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 0,
       "unstable_pastId": null,
     }
@@ -221,6 +261,7 @@ test("unregister pastId", () => {
     },
     `
     Object {
+      "baseId": "base",
       "currentId": "b",
       "loop": false,
       "orientation": undefined,
@@ -234,6 +275,9 @@ test("unregister pastId", () => {
           },
         },
       ],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 1,
       "unstable_pastId": null,
     }
@@ -251,6 +295,7 @@ test("move", () => {
     },
     `
     Object {
+      "baseId": "base",
       "currentId": "a",
       "loop": false,
       "orientation": undefined,
@@ -264,6 +309,9 @@ test("move", () => {
           },
         },
       ],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 1,
       "unstable_pastId": null,
     }
@@ -284,6 +332,7 @@ test("move twice", () => {
     },
     `
     Object {
+      "baseId": "base",
       "currentId": "b",
       "loop": false,
       "orientation": undefined,
@@ -305,6 +354,9 @@ test("move twice", () => {
           },
         },
       ],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 2,
       "unstable_pastId": "a",
     }
@@ -325,6 +377,7 @@ test("move to the same ref", () => {
     },
     `
     Object {
+      "baseId": "base",
       "currentId": "b",
       "loop": false,
       "orientation": undefined,
@@ -346,6 +399,9 @@ test("move to the same ref", () => {
           },
         },
       ],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 2,
       "unstable_pastId": null,
     }
@@ -366,6 +422,7 @@ test("move to null", () => {
     },
     `
     Object {
+      "baseId": "base",
       "currentId": null,
       "loop": false,
       "orientation": undefined,
@@ -387,6 +444,9 @@ test("move to null", () => {
           },
         },
       ],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 2,
       "unstable_pastId": "b",
     }
@@ -406,6 +466,7 @@ test("move silently", () => {
     },
     `
     Object {
+      "baseId": "base",
       "currentId": "b",
       "loop": false,
       "orientation": undefined,
@@ -427,6 +488,9 @@ test("move silently", () => {
           },
         },
       ],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 1,
       "unstable_pastId": null,
     }
@@ -448,6 +512,7 @@ test("next", () => {
     },
     `
     Object {
+      "baseId": "base",
       "currentId": "b",
       "loop": false,
       "orientation": undefined,
@@ -477,6 +542,9 @@ test("next", () => {
           },
         },
       ],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 2,
       "unstable_pastId": "a",
     }
@@ -500,6 +568,7 @@ test("next thrice", () => {
     },
     `
     Object {
+      "baseId": "base",
       "currentId": "c",
       "loop": false,
       "orientation": undefined,
@@ -529,6 +598,9 @@ test("next thrice", () => {
           },
         },
       ],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 3,
       "unstable_pastId": "b",
     }
@@ -552,6 +624,7 @@ test("next thrice loop", () => {
     },
     `
     Object {
+      "baseId": "base",
       "currentId": "a",
       "loop": true,
       "orientation": undefined,
@@ -581,6 +654,9 @@ test("next thrice loop", () => {
           },
         },
       ],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 4,
       "unstable_pastId": "c",
     }
@@ -602,6 +678,7 @@ test("previous", () => {
     },
     `
     Object {
+      "baseId": "base",
       "currentId": "a",
       "loop": false,
       "orientation": undefined,
@@ -631,6 +708,9 @@ test("previous", () => {
           },
         },
       ],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 2,
       "unstable_pastId": "b",
     }
@@ -652,6 +732,7 @@ test("previous loop", () => {
     },
     `
     Object {
+      "baseId": "base",
       "currentId": "c",
       "loop": true,
       "orientation": undefined,
@@ -681,6 +762,9 @@ test("previous loop", () => {
           },
         },
       ],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 2,
       "unstable_pastId": "a",
     }
@@ -700,6 +784,7 @@ test("first", () => {
     },
     `
     Object {
+      "baseId": "base",
       "currentId": "a",
       "loop": false,
       "orientation": undefined,
@@ -721,6 +806,9 @@ test("first", () => {
           },
         },
       ],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 1,
       "unstable_pastId": null,
     }
@@ -740,6 +828,7 @@ test("last", () => {
     },
     `
     Object {
+      "baseId": "base",
       "currentId": "b",
       "loop": false,
       "orientation": undefined,
@@ -761,6 +850,9 @@ test("last", () => {
           },
         },
       ],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 1,
       "unstable_pastId": null,
     }
@@ -776,14 +868,18 @@ test("orientate", () => {
       orientation: "horizontal"
     },
     `
-            Object {
-              "currentId": null,
-              "loop": false,
-              "orientation": "horizontal",
-              "stops": Array [],
-              "unstable_moves": 0,
-              "unstable_pastId": null,
-            }
-      `
+    Object {
+      "baseId": "base",
+      "currentId": null,
+      "loop": false,
+      "orientation": "horizontal",
+      "stops": Array [],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
+      "unstable_moves": 0,
+      "unstable_pastId": null,
+    }
+  `
   );
 });

--- a/packages/reakit/src/Tab/Tab.ts
+++ b/packages/reakit/src/Tab/Tab.ts
@@ -9,7 +9,7 @@ import { useTabState, TabStateReturn } from "./TabState";
 export type TabOptions = RoverOptions &
   Pick<Required<RoverOptions>, "stopId"> &
   Pick<Partial<TabStateReturn>, "manual"> &
-  Pick<TabStateReturn, "unstable_baseId" | "selectedId" | "select">;
+  Pick<TabStateReturn, "baseId" | "selectedId" | "select">;
 
 export type TabHTMLProps = RoverHTMLProps;
 
@@ -50,9 +50,9 @@ export const useTab = createHook<TabOptions, TabHTMLProps>({
 
     return {
       role: "tab",
-      id: getTabId(options.stopId, options.unstable_baseId),
+      id: getTabId(options.stopId, options.baseId),
       "aria-selected": selected,
-      "aria-controls": getTabPanelId(options.stopId, options.unstable_baseId),
+      "aria-controls": getTabPanelId(options.stopId, options.baseId),
       onClick: useAllCallbacks(onClick, htmlOnClick),
       onFocus: useAllCallbacks(onFocus, htmlOnFocus),
       ...htmlProps

--- a/packages/reakit/src/Tab/TabList.tsx
+++ b/packages/reakit/src/Tab/TabList.tsx
@@ -2,19 +2,23 @@ import { warning } from "reakit-utils/warning";
 import { createComponent } from "reakit-system/createComponent";
 import { useCreateElement } from "reakit-system/useCreateElement";
 import { createHook } from "reakit-system/createHook";
-import { BoxOptions, BoxHTMLProps, useBox } from "../Box/Box";
+import {
+  unstable_IdGroupOptions,
+  unstable_IdGroupHTMLProps,
+  unstable_useIdGroup
+} from "../Id/IdGroup";
 import { useTabState, TabStateReturn } from "./TabState";
 
-export type TabListOptions = BoxOptions &
+export type TabListOptions = unstable_IdGroupOptions &
   Pick<Partial<TabStateReturn>, "orientation">;
 
-export type TabListHTMLProps = BoxHTMLProps;
+export type TabListHTMLProps = unstable_IdGroupHTMLProps;
 
 export type TabListProps = TabListOptions & TabListHTMLProps;
 
 export const useTabList = createHook<TabListOptions, TabListHTMLProps>({
   name: "TabList",
-  compose: useBox,
+  compose: unstable_useIdGroup,
   useState: useTabState,
 
   useProps(options, htmlProps) {

--- a/packages/reakit/src/Tab/TabPanel.ts
+++ b/packages/reakit/src/Tab/TabPanel.ts
@@ -5,7 +5,7 @@ import { getTabPanelId, getTabId } from "./__utils";
 import { useTabState, TabStateReturn } from "./TabState";
 
 export type TabPanelOptions = HiddenOptions &
-  Pick<TabStateReturn, "unstable_baseId" | "selectedId"> & {
+  Pick<TabStateReturn, "baseId" | "selectedId"> & {
     /**
      * Tab's `stopId`.
      */
@@ -33,8 +33,8 @@ export const useTabPanel = createHook<TabPanelOptions, TabPanelHTMLProps>({
     return {
       role: "tabpanel",
       tabIndex: 0,
-      id: getTabPanelId(options.stopId, options.unstable_baseId),
-      "aria-labelledby": getTabId(options.stopId, options.unstable_baseId),
+      id: getTabPanelId(options.stopId, options.baseId),
+      "aria-labelledby": getTabId(options.stopId, options.baseId),
       ...htmlProps
     };
   }

--- a/packages/reakit/src/Tab/TabState.ts
+++ b/packages/reakit/src/Tab/TabState.ts
@@ -3,15 +3,9 @@ import {
   SealedInitialState,
   useSealedState
 } from "reakit-utils/useSealedState";
-import { useId } from "reakit-utils/useId";
 import { useRoverState, RoverState, RoverActions } from "../Rover/RoverState";
 
 export type TabState = RoverState & {
-  /**
-   * An ID that will serve as a base for the tab elements.
-   * @private
-   */
-  unstable_baseId: string;
   /**
    * The current selected tab's `stopId`.
    */
@@ -36,9 +30,7 @@ export type TabStateReturn = TabState & TabActions;
 export function useTabState(
   initialState: SealedInitialState<TabInitialState> = {}
 ): TabStateReturn {
-  const defaultId = useId("tab-");
   const {
-    unstable_baseId: baseId = defaultId,
     selectedId: sealedSelectedId = null,
     loop = true,
     manual = false,
@@ -54,7 +46,6 @@ export function useTabState(
 
   return {
     ...rover,
-    unstable_baseId: baseId,
     selectedId,
     manual,
     select
@@ -63,7 +54,6 @@ export function useTabState(
 
 const keys: Array<keyof TabStateReturn> = [
   ...useRoverState.__keys,
-  "unstable_baseId",
   "selectedId",
   "select",
   "manual"

--- a/packages/reakit/src/Tab/__tests__/Tab-test.tsx
+++ b/packages/reakit/src/Tab/__tests__/Tab-test.tsx
@@ -3,7 +3,7 @@ import { render } from "@testing-library/react";
 import { Tab } from "../Tab";
 
 const props: Parameters<typeof Tab>[0] = {
-  unstable_baseId: "base",
+  baseId: "base",
   stopId: "tab",
   stops: [],
   currentId: null,

--- a/packages/reakit/src/Tab/__tests__/TabPanel-test.tsx
+++ b/packages/reakit/src/Tab/__tests__/TabPanel-test.tsx
@@ -3,7 +3,7 @@ import { render } from "@testing-library/react";
 import { TabPanel } from "../TabPanel";
 
 const props: Parameters<typeof TabPanel>[0] = {
-  unstable_baseId: "base",
+  baseId: "base",
   stopId: "tab",
   selectedId: null
 };

--- a/packages/reakit/src/Tab/__tests__/TabState-test.ts
+++ b/packages/reakit/src/Tab/__tests__/TabState-test.ts
@@ -1,24 +1,27 @@
 import { renderHook } from "@testing-library/react-hooks";
 import { jestSerializerStripFunctions } from "reakit-utils/jestSerializerStripFunctions";
-import { useTabState } from "../TabState";
+import { useTabState, TabInitialState } from "../TabState";
 
 expect.addSnapshotSerializer(jestSerializerStripFunctions);
 
-function render(...args: Parameters<typeof useTabState>) {
-  return renderHook(() => useTabState(...args)).result;
+function render({ baseId = "base", ...initialState }: TabInitialState = {}) {
+  return renderHook(() => useTabState({ baseId, ...initialState })).result;
 }
 
 test("initial state", () => {
-  const result = render({ unstable_baseId: "base" });
+  const result = render();
   expect(result.current).toMatchInlineSnapshot(`
     Object {
+      "baseId": "base",
       "currentId": null,
       "loop": true,
       "manual": false,
       "orientation": undefined,
       "selectedId": null,
       "stops": Array [],
-      "unstable_baseId": "base",
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 0,
       "unstable_pastId": null,
     }
@@ -26,7 +29,7 @@ test("initial state", () => {
 });
 
 test("initial state selectedId", () => {
-  const result = render({ unstable_baseId: "base", selectedId: "a" });
+  const result = render({ selectedId: "a" });
   expect(result.current).toMatchInlineSnapshot(
     {
       currentId: "a",
@@ -34,13 +37,16 @@ test("initial state selectedId", () => {
     },
     `
     Object {
+      "baseId": "base",
       "currentId": "a",
       "loop": true,
       "manual": false,
       "orientation": undefined,
       "selectedId": "a",
       "stops": Array [],
-      "unstable_baseId": "base",
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 0,
       "unstable_pastId": null,
     }

--- a/packages/reakit/src/Tab/__tests__/index-test.tsx
+++ b/packages/reakit/src/Tab/__tests__/index-test.tsx
@@ -70,3 +70,76 @@ test("clicking on tab reveals the panel", () => {
   fireEvent.click(tab3);
   expect(tabpanel3).toBeVisible();
 });
+
+test("markup", () => {
+  const { container } = render(<SimpleTest baseId="base" />);
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <div
+        aria-label="tablist"
+        role="tablist"
+      >
+        <button
+          aria-controls="base-tab1-panel"
+          aria-selected="false"
+          id="base-tab1"
+          role="tab"
+          tabindex="0"
+        >
+          tab1
+        </button>
+        <button
+          aria-controls="base-tab2-panel"
+          aria-selected="false"
+          id="base-tab2"
+          role="tab"
+          tabindex="-1"
+        >
+          tab2
+        </button>
+        <button
+          aria-controls="base-tab3-panel"
+          aria-selected="false"
+          id="base-tab3"
+          role="tab"
+          tabindex="-1"
+        >
+          tab3
+        </button>
+      </div>
+      <div
+        aria-labelledby="base-tab1"
+        class="hidden"
+        hidden=""
+        id="base-tab1-panel"
+        role="tabpanel"
+        style="display: none;"
+        tabindex="0"
+      >
+        tabpanel1
+      </div>
+      <div
+        aria-labelledby="base-tab2"
+        class="hidden"
+        hidden=""
+        id="base-tab2-panel"
+        role="tabpanel"
+        style="display: none;"
+        tabindex="0"
+      >
+        tabpanel2
+      </div>
+      <div
+        aria-labelledby="base-tab3"
+        class="hidden"
+        hidden=""
+        id="base-tab3-panel"
+        role="tabpanel"
+        style="display: none;"
+        tabindex="0"
+      >
+        tabpanel3
+      </div>
+    </div>
+  `);
+});

--- a/packages/reakit/src/Toolbar/Toolbar.tsx
+++ b/packages/reakit/src/Toolbar/Toolbar.tsx
@@ -2,19 +2,23 @@ import { warning } from "reakit-utils/warning";
 import { createComponent } from "reakit-system/createComponent";
 import { useCreateElement } from "reakit-system/useCreateElement";
 import { createHook } from "reakit-system/createHook";
-import { BoxOptions, BoxHTMLProps, useBox } from "../Box/Box";
+import {
+  unstable_IdGroupOptions,
+  unstable_IdGroupHTMLProps,
+  unstable_useIdGroup
+} from "../Id/IdGroup";
 import { ToolbarStateReturn, useToolbarState } from "./ToolbarState";
 
-export type ToolbarOptions = BoxOptions &
+export type ToolbarOptions = unstable_IdGroupOptions &
   Pick<Partial<ToolbarStateReturn>, "orientation">;
 
-export type ToolbarHTMLProps = BoxHTMLProps;
+export type ToolbarHTMLProps = unstable_IdGroupHTMLProps;
 
 export type ToolbarProps = ToolbarOptions & ToolbarHTMLProps;
 
 export const useToolbar = createHook<ToolbarOptions, ToolbarHTMLProps>({
   name: "Toolbar",
-  compose: useBox,
+  compose: unstable_useIdGroup,
   useState: useToolbarState,
 
   useProps(options, htmlProps) {

--- a/packages/reakit/src/Toolbar/__tests__/ToolbarState-test.ts
+++ b/packages/reakit/src/Toolbar/__tests__/ToolbarState-test.ts
@@ -1,21 +1,28 @@
 import { renderHook } from "@testing-library/react-hooks";
 import { jestSerializerStripFunctions } from "reakit-utils/jestSerializerStripFunctions";
-import { useToolbarState } from "../ToolbarState";
+import { useToolbarState, ToolbarInitialState } from "../ToolbarState";
 
 expect.addSnapshotSerializer(jestSerializerStripFunctions);
 
-function render(...args: Parameters<typeof useToolbarState>) {
-  return renderHook(() => useToolbarState(...args)).result;
+function render({
+  baseId = "base",
+  ...initialState
+}: ToolbarInitialState = {}) {
+  return renderHook(() => useToolbarState({ baseId, ...initialState })).result;
 }
 
 test("initial state", () => {
   const result = render();
   expect(result.current).toMatchInlineSnapshot(`
     Object {
+      "baseId": "base",
       "currentId": null,
       "loop": false,
       "orientation": "horizontal",
       "stops": Array [],
+      "unstable_idCountRef": Object {
+        "current": 0,
+      },
       "unstable_moves": 0,
       "unstable_pastId": null,
     }

--- a/packages/reakit/src/Toolbar/__tests__/index-test.tsx
+++ b/packages/reakit/src/Toolbar/__tests__/index-test.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { render } from "@testing-library/react";
+import { useToolbarState, Toolbar, ToolbarItem } from "..";
+
+test("markup", () => {
+  const Test = () => {
+    const toolbar = useToolbarState();
+    return (
+      <Toolbar {...toolbar} id="base">
+        <ToolbarItem {...toolbar}>Item 1</ToolbarItem>
+        <ToolbarItem {...toolbar}>Item 2</ToolbarItem>
+        <ToolbarItem {...toolbar}>Item 3</ToolbarItem>
+      </Toolbar>
+    );
+  };
+  const { container } = render(<Test />);
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <div
+        aria-orientation="horizontal"
+        id="base"
+        role="toolbar"
+      >
+        <button
+          id="base-1"
+          tabindex="0"
+        >
+          Item 1
+        </button>
+        <button
+          id="base-2"
+          tabindex="-1"
+        >
+          Item 2
+        </button>
+        <button
+          id="base-3"
+          tabindex="-1"
+        >
+          Item 3
+        </button>
+      </div>
+    </div>
+  `);
+});


### PR DESCRIPTION
This PR is a follow-up to #492.

- Compose `useIdState` into `useRoverState` and, therefore, its derivative hooks, such as `useTabState`, `useToolbarState` and `useRadioState`.
- Compose `Id` into `Rover` and its derivative components.
- Compose `IdGroup` into `TabList` and `Toolbar`

Now it's possible to pass a `baseId` option to `useRoverState`, `useTabState`, `useToolbarState` and `useRadioState` so their rover items will have a predictable `id` attribute.

Since they compose now from `IdGroup`, it's also possible to pass an `id` prop to `TabList` and `Toolbar` to achieve the same result:

```jsx
// we can now pass `baseId` to the state hook or `id` to the `IdGroup` (`Toolbar`) component
const toolbar = useToolbarState({ baseId: "toolbar" });
<Toolbar {...toolbar} id="toolbar">
  <ToolbarItem {...toolbar} />
  <ToolbarItem {...toolbar} />
  <ToolbarItem {...toolbar} />
  <ToolbarItem {...toolbar} />
</Toolbar>
```

**Does this PR introduce a breaking change?**

No