### PR TITLE
fix: Stop ignoring `checked` and `value` props passed as html props to `useCheckbox`

### DIFF
--- a/packages/reakit/src/Checkbox/Checkbox.ts
+++ b/packages/reakit/src/Checkbox/Checkbox.ts
@@ -49,10 +49,15 @@ export const useCheckbox = createHook<CheckboxOptions, CheckboxHTMLProps>({
   useState: useCheckboxState,
   keys: ["value", "checked"],
 
-  useOptions({ unstable_clickOnEnter = false, ...options }) {
+  useOptions(
+    { unstable_clickOnEnter = false, ...options },
+    { value, checked }
+  ) {
     return {
       unstable_clickOnEnter,
-      ...options
+      ...options,
+      value: typeof value !== "undefined" ? value : options.value,
+      checked: typeof checked !== "undefined" ? checked : options.checked
     };
   },
 

--- a/packages/reakit/src/Checkbox/__tests__/index-test.tsx
+++ b/packages/reakit/src/Checkbox/__tests__/index-test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { fireEvent, render } from "@testing-library/react";
-import { Checkbox, useCheckboxState } from "..";
+import { Checkbox, useCheckbox, useCheckboxState } from "..";
 
 test("single checkbox", () => {
   const Test = () => {
@@ -162,4 +162,55 @@ test("non-native checkbox onChange checked value without useCheckboxState", asyn
   fireEvent.click(checkbox);
   expect(checkbox.checked).toBe(false);
   expect(onChange).toBeCalledWith(false);
+});
+
+test("useCheckbox", () => {
+  const Test = () => {
+    const [checked, setChecked] = React.useState(false);
+    const props = useCheckbox(
+      {},
+      {
+        checked,
+        onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
+          setChecked(event.target.checked)
+      }
+    );
+    return (
+      <label>
+        <input {...props} />
+        checkbox
+      </label>
+    );
+  };
+  const { getByLabelText } = render(<Test />);
+  const checkbox = getByLabelText("checkbox") as HTMLInputElement;
+  expect(checkbox.checked).toBe(false);
+  expect(checkbox).toMatchInlineSnapshot(`
+    <input
+      aria-checked="false"
+      role="checkbox"
+      type="checkbox"
+      value=""
+    />
+  `);
+  fireEvent.click(checkbox);
+  expect(checkbox.checked).toBe(true);
+  expect(checkbox).toMatchInlineSnapshot(`
+    <input
+      aria-checked="true"
+      role="checkbox"
+      type="checkbox"
+      value=""
+    />
+  `);
+  fireEvent.click(checkbox);
+  expect(checkbox.checked).toBe(false);
+  expect(checkbox).toMatchInlineSnapshot(`
+    <input
+      aria-checked="false"
+      role="checkbox"
+      type="checkbox"
+      value=""
+    />
+  `);
 });


### PR DESCRIPTION
Closes #465

If `checked` or `value` is passed to the second argument of the `useCheckbox` hook, they will be used instead of `options.checked` and `options.value` (passed to the first argument).

**Does this PR introduce a breaking change?**

No