### PR TITLE
fix: Standardize precedence when `options` and `htmlProps` conflict

### DIFF
--- a/packages/reakit/src/Checkbox/Checkbox.ts
+++ b/packages/reakit/src/Checkbox/Checkbox.ts
@@ -55,9 +55,9 @@ export const useCheckbox = createHook<CheckboxOptions, CheckboxHTMLProps>({
   ) {
     return {
       unstable_clickOnEnter,
-      ...options,
-      value: typeof value !== "undefined" ? value : options.value,
-      checked: typeof checked !== "undefined" ? checked : options.checked
+      value,
+      checked,
+      ...options
     };
   },
 

--- a/packages/reakit/src/Form/FormCheckbox.ts
+++ b/packages/reakit/src/Form/FormCheckbox.ts
@@ -54,10 +54,13 @@ export const unstable_useFormCheckbox = createHook<
   useState: unstable_useFormState,
   keys: ["name", "value"],
 
-  useOptions(options) {
-    const state = unstable_getIn(options.values, options.name);
-    const setState = (value: any) => options.update(options.name, value);
-    return { ...options, state, setState };
+  useOptions(options, htmlProps) {
+    const name = options.name || htmlProps.name;
+    const value =
+      typeof options.value !== "undefined" ? options.value : htmlProps.value;
+    const state = unstable_getIn(options.values, name);
+    const setState = (val: any) => options.update(name, val);
+    return { ...options, state, setState, name, value };
   },
 
   useProps(options, { onBlur: htmlOnBlur, ...htmlProps }) {

--- a/packages/reakit/src/Form/FormGroup.ts
+++ b/packages/reakit/src/Form/FormGroup.ts
@@ -38,6 +38,10 @@ export const unstable_useFormGroup = createHook<
   useState: unstable_useFormState,
   keys: ["name"],
 
+  useOptions(options, { id }) {
+    return { id, ...options };
+  },
+
   useProps(options, htmlProps) {
     return {
       id: getInputId(options.name, options.baseId),

--- a/packages/reakit/src/Form/FormGroup.ts
+++ b/packages/reakit/src/Form/FormGroup.ts
@@ -38,10 +38,6 @@ export const unstable_useFormGroup = createHook<
   useState: unstable_useFormState,
   keys: ["name"],
 
-  useOptions(options, { id }) {
-    return { id, ...options };
-  },
-
   useProps(options, htmlProps) {
     return {
       id: getInputId(options.name, options.baseId),

--- a/packages/reakit/src/Form/FormInput.ts
+++ b/packages/reakit/src/Form/FormInput.ts
@@ -48,8 +48,9 @@ export const unstable_useFormInput = createHook<
   useState: unstable_useFormState,
   keys: ["name"],
 
-  useOptions(options) {
+  useOptions(options, { name }) {
     return {
+      name,
       ...options,
       unstable_clickOnEnter: false,
       unstable_clickOnSpace: false

--- a/packages/reakit/src/Form/FormPushButton.ts
+++ b/packages/reakit/src/Form/FormPushButton.ts
@@ -42,6 +42,10 @@ export const unstable_useFormPushButton = createHook<
   useState: unstable_useFormState,
   keys: ["name", "value"],
 
+  useOptions(options, { name, value }) {
+    return { name, value, ...options };
+  },
+
   useProps(options, { onClick: htmlOnClick, ...htmlProps }) {
     const onClick = React.useCallback(() => {
       options.push(options.name, options.value);

--- a/packages/reakit/src/Form/FormRadio.ts
+++ b/packages/reakit/src/Form/FormRadio.ts
@@ -42,17 +42,20 @@ export const unstable_useFormRadio = createHook<
   useState: unstable_useFormState,
   keys: ["name", "value"],
 
-  useOptions(options) {
+  useOptions(options, htmlProps) {
+    const name = options.name || htmlProps.name;
+    const value =
+      typeof options.value !== "undefined" ? options.value : htmlProps.value;
     const rover = React.useContext(FormRadioGroupContext);
-    const currentChecked = unstable_getIn(options.values, options.name);
-    const checked = currentChecked === options.value;
+    const currentChecked = unstable_getIn(options.values, name);
+    const checked = currentChecked === value;
 
     if (!rover) {
       // TODO: Better error
       throw new Error("Missing FormRadioGroup");
     }
 
-    return { ...rover, ...options, checked };
+    return { ...options, ...rover, checked, name, value };
   },
 
   useProps(

--- a/packages/reakit/src/Form/FormRadioGroup.tsx
+++ b/packages/reakit/src/Form/FormRadioGroup.tsx
@@ -11,6 +11,7 @@ import {
 } from "./FormGroup";
 import { unstable_useFormState } from "./FormState";
 import { DeepPath } from "./__utils/types";
+import { getInputId } from "./__utils/getInputId";
 
 export type unstable_FormRadioGroupOptions<
   V,
@@ -43,8 +44,13 @@ export const unstable_useFormRadioGroup = createHook<
   useState: unstable_useFormState,
   keys: ["name"],
 
-  useProps(_, { unstable_wrap: htmlWrap, ...htmlProps }) {
-    const rover = useRoverState({ loop: true });
+  useOptions(options, { name }) {
+    return { name, ...options };
+  },
+
+  useProps(options, { unstable_wrap: htmlWrap, ...htmlProps }) {
+    const id = getInputId(options.name, options.baseId);
+    const rover = useRoverState({ baseId: id, loop: true });
     const providerValue = React.useMemo(() => rover, [
       rover.stops,
       rover.currentId,

--- a/packages/reakit/src/Form/FormRemoveButton.ts
+++ b/packages/reakit/src/Form/FormRemoveButton.ts
@@ -40,6 +40,10 @@ export const unstable_useFormRemoveButton = createHook<
   useState: unstable_useFormState,
   keys: ["name", "index"],
 
+  useOptions(options, { name }) {
+    return { name, ...options };
+  },
+
   useProps(options, { onClick: htmlOnClick, ...htmlProps }) {
     const onClick = React.useCallback(() => {
       options.remove(options.name, options.index);

--- a/packages/reakit/src/Form/FormSubmitButton.ts
+++ b/packages/reakit/src/Form/FormSubmitButton.ts
@@ -24,10 +24,7 @@ export const unstable_useFormSubmitButton = createHook<
   useState: unstable_useFormState,
 
   useOptions(options) {
-    return {
-      disabled: options.submitting,
-      ...options
-    };
+    return { disabled: options.submitting, ...options };
   },
 
   useProps(options, { onClick: htmlOnClick, ...htmlProps }) {

--- a/packages/reakit/src/Form/FormSubmitButton.ts
+++ b/packages/reakit/src/Form/FormSubmitButton.ts
@@ -23,11 +23,8 @@ export const unstable_useFormSubmitButton = createHook<
   compose: useButton,
   useState: unstable_useFormState,
 
-  useOptions(options, { disabled }) {
-    return {
-      disabled: typeof disabled !== "undefined" ? disabled : options.submitting,
-      ...options
-    };
+  useOptions(options) {
+    return { disabled: options.submitting, ...options };
   },
 
   useProps(options, { onClick: htmlOnClick, ...htmlProps }) {

--- a/packages/reakit/src/Form/FormSubmitButton.ts
+++ b/packages/reakit/src/Form/FormSubmitButton.ts
@@ -23,8 +23,11 @@ export const unstable_useFormSubmitButton = createHook<
   compose: useButton,
   useState: unstable_useFormState,
 
-  useOptions(options) {
-    return { disabled: options.submitting, ...options };
+  useOptions(options, { disabled }) {
+    return {
+      disabled: typeof disabled !== "undefined" ? disabled : options.submitting,
+      ...options
+    };
   },
 
   useProps(options, { onClick: htmlOnClick, ...htmlProps }) {

--- a/packages/reakit/src/Id/Id.tsx
+++ b/packages/reakit/src/Id/Id.tsx
@@ -24,6 +24,7 @@ export const unstable_useId = createHook<
   name: "Id",
   compose: useBox,
   useState: unstable_useIdState,
+  keys: ["id"],
 
   useOptions(options, htmlProps) {
     const generateId = React.useContext(unstable_IdContext);
@@ -51,13 +52,13 @@ export const unstable_useId = createHook<
       generateId
     ]);
 
-    const id = htmlProps.id || options.id || `${baseId}${suffix}`;
+    const id = options.id || htmlProps.id || `${baseId}${suffix}`;
 
     return { ...options, id };
   },
 
-  useProps(options, { id, ...htmlProps }) {
-    return { id: id || options.id, ...htmlProps };
+  useProps(options, htmlProps) {
+    return { id: options.id, ...htmlProps };
   }
 });
 

--- a/packages/reakit/src/Id/IdGroup.tsx
+++ b/packages/reakit/src/Id/IdGroup.tsx
@@ -28,11 +28,12 @@ export const unstable_useIdGroup = createHook<
   name: "IdGroup",
   compose: useBox,
   useState: unstable_useIdState,
+  keys: ["id"],
 
   useOptions(options, htmlProps) {
     const generateId = React.useContext(unstable_IdContext);
     const [baseId] = React.useState(
-      () => htmlProps.id || options.id || options.baseId || generateId()
+      () => options.id || htmlProps.id || options.baseId || generateId()
     );
 
     // If there's useIdState and IdGroup has received a different id, then set
@@ -42,6 +43,10 @@ export const unstable_useIdGroup = createHook<
     }
 
     return { ...options, baseId };
+  },
+
+  useProps(options, htmlProps) {
+    return { id: options.id, ...htmlProps };
   }
 });
 

--- a/packages/reakit/src/Radio/Radio.ts
+++ b/packages/reakit/src/Radio/Radio.ts
@@ -27,11 +27,11 @@ export const useRadio = createHook<RadioOptions, RadioHTMLProps>({
   useState: useRadioState,
   keys: ["value", "checked"],
 
-  useOptions({ unstable_clickOnEnter = false, ...options }) {
-    return {
-      unstable_clickOnEnter,
-      ...options
-    };
+  useOptions(
+    { unstable_clickOnEnter = false, ...options },
+    { value, checked }
+  ) {
+    return { value, checked, unstable_clickOnEnter, ...options };
   },
 
   useProps(

--- a/packages/reakit/src/Radio/RadioGroup.tsx
+++ b/packages/reakit/src/Radio/RadioGroup.tsx
@@ -3,19 +3,23 @@ import { createComponent } from "reakit-system/createComponent";
 import { useCreateElement } from "reakit-system/useCreateElement";
 import { createHook } from "reakit-system/createHook";
 import { warning } from "reakit-utils/warning";
-import { BoxOptions, BoxHTMLProps, useBox } from "../Box/Box";
+import {
+  unstable_IdGroupOptions,
+  unstable_IdGroupHTMLProps,
+  unstable_useIdGroup
+} from "../Id/IdGroup";
 import { useRadioState } from "./RadioState";
 
-export type RadioGroupOptions = BoxOptions;
+export type RadioGroupOptions = unstable_IdGroupOptions;
 
-export type RadioGroupHTMLProps = BoxHTMLProps &
+export type RadioGroupHTMLProps = unstable_IdGroupHTMLProps &
   React.FieldsetHTMLAttributes<any>;
 
 export type RadioGroupProps = RadioGroupOptions & RadioGroupHTMLProps;
 
 const useRadioGroup = createHook<RadioGroupOptions, RadioGroupHTMLProps>({
   name: "RadioGroup",
-  compose: useBox,
+  compose: unstable_useIdGroup,
   useState: useRadioState,
 
   useProps(_, htmlProps) {

--- a/packages/reakit/src/Radio/__tests__/index-test.tsx
+++ b/packages/reakit/src/Radio/__tests__/index-test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { render, fireEvent } from "@testing-library/react";
-import { Radio, useRadioState } from "..";
+import { Radio, RadioGroup, useRadioState } from "..";
 
 test("click on radio", () => {
   const Test = () => {
@@ -78,4 +78,67 @@ test("onChange non-native radio", () => {
   expect(radio.checked).toBe(false);
   fireEvent.click(radio);
   expect(radio.checked).toBe(true);
+});
+
+test("group", () => {
+  const Test = () => {
+    const radio = useRadioState();
+    return (
+      <RadioGroup {...radio} aria-label="radiogroup" id="base">
+        <label>
+          <Radio {...radio} value="a" />a
+        </label>
+        <label>
+          <Radio {...radio} value="b" />b
+        </label>
+        <label>
+          <Radio {...radio} value="c" />c
+        </label>
+      </RadioGroup>
+    );
+  };
+  const { container } = render(<Test />);
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <fieldset
+        aria-label="radiogroup"
+        id="base"
+        role="radiogroup"
+      >
+        <label>
+          <input
+            aria-checked="false"
+            id="base-1"
+            role="radio"
+            tabindex="0"
+            type="radio"
+            value="a"
+          />
+          a
+        </label>
+        <label>
+          <input
+            aria-checked="false"
+            id="base-2"
+            role="radio"
+            tabindex="-1"
+            type="radio"
+            value="b"
+          />
+          b
+        </label>
+        <label>
+          <input
+            aria-checked="false"
+            id="base-3"
+            role="radio"
+            tabindex="-1"
+            type="radio"
+            value="c"
+          />
+          c
+        </label>
+      </fieldset>
+    </div>
+  `);
 });

--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -78,10 +78,10 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
 
   useOptions(
     { unstable_clickOnEnter = true, unstable_clickOnSpace = true, ...options },
-    htmlProps
+    { disabled }
   ) {
     return {
-      disabled: htmlProps.disabled,
+      disabled,
       unstable_clickOnEnter,
       unstable_clickOnSpace,
       ...options


### PR DESCRIPTION
This PR standardizes the precedence when `options` and `htmlProps` have conflicts. This is only an issue when using props hooks instead of components.

**Does this PR introduce a breaking change?**

No