### PR TITLE
importing directly body-scroll-lock from es modules to fix rollup build

### DIFF
--- a/packages/reakit-system-palette/jest.config.js
+++ b/packages/reakit-system-palette/jest.config.js
@@ -5,5 +5,6 @@ const pkg = require("./package.json");
 module.exports = {
   ...baseConfig,
   displayName: pkg.name,
-  testMatch: [join(__dirname, "src/**/*-test.{js,ts,tsx}")]
+  testMatch: [join(__dirname, "src/**/*-test.{js,ts,tsx}")],
+  transformIgnorePatterns: ["/node_modules/(?!body-scroll-lock).+\\.es6$"]
 };

--- a/packages/reakit/jest.config.js
+++ b/packages/reakit/jest.config.js
@@ -5,5 +5,6 @@ const pkg = require("./package.json");
 module.exports = {
   ...baseConfig,
   displayName: pkg.name,
-  testMatch: [join(__dirname, "src/**/*-test.{js,ts,tsx}")]
+  testMatch: [join(__dirname, "src/**/*-test.{js,ts,tsx}")],
+  transformIgnorePatterns: ["/node_modules/(?!body-scroll-lock).+\\.es6$"]
 };

--- a/packages/reakit/src/Dialog/__utils/usePreventBodyScroll.ts
+++ b/packages/reakit/src/Dialog/__utils/usePreventBodyScroll.ts
@@ -1,5 +1,8 @@
 import * as React from "react";
-import { disableBodyScroll, enableBodyScroll } from "body-scroll-lock";
+import {
+  disableBodyScroll,
+  enableBodyScroll
+} from "body-scroll-lock/lib/bodyScrollLock.es6";
 import { DialogOptions } from "../Dialog";
 
 export function usePreventBodyScroll(


### PR DESCRIPTION
This PR closes #505

**Does this PR introduce a breaking change?**
 - No

After applying the fix found by @diegohaz on the `body-scroll-lock` issues, it should fix the rollup build

![image](https://user-images.githubusercontent.com/13686332/69765118-73243f80-1151-11ea-9498-360cb491896f.png)
