### PR TITLE
Add default PortalContext if it's undefined

### DIFF
--- a/packages/reakit/src/Portal/Portal.tsx
+++ b/packages/reakit/src/Portal/Portal.tsx
@@ -8,9 +8,12 @@ export type PortalProps = {
   children: React.ReactNode;
 };
 
-const getBodyElement = () => typeof document !== "undefined" ? document.body : null
+const getBodyElement = () =>
+  typeof document !== "undefined" ? document.body : null;
 
-export const PortalContext = React.createContext<HTMLElement | null>(getBodyElement());
+export const PortalContext = React.createContext<HTMLElement | null>(
+  getBodyElement()
+);
 
 export function Portal({ children }: PortalProps) {
   // if it's a nested portal, context is the parent portal

--- a/packages/reakit/src/Portal/Portal.tsx
+++ b/packages/reakit/src/Portal/Portal.tsx
@@ -8,8 +8,9 @@ export type PortalProps = {
   children: React.ReactNode;
 };
 
-const getBodyElement = () =>
-  typeof document !== "undefined" ? document.body : null;
+function getBodyElement() {
+  return typeof document !== "undefined" ? document.body : null;
+}
 
 export const PortalContext = React.createContext<HTMLElement | null>(
   getBodyElement()

--- a/packages/reakit/src/Portal/Portal.tsx
+++ b/packages/reakit/src/Portal/Portal.tsx
@@ -15,7 +15,7 @@ export const PortalContext = React.createContext<HTMLElement | null>(
 export function Portal({ children }: PortalProps) {
   // if it's a nested portal, context is the parent portal
   // otherwise it's document.body
-  const context = React.useContext(PortalContext);
+  const context = React.useContext(PortalContext) || document.body;
   const [portal] = React.useState(() => {
     if (typeof document !== "undefined") {
       const element = document.createElement("div");

--- a/packages/reakit/src/Portal/Portal.tsx
+++ b/packages/reakit/src/Portal/Portal.tsx
@@ -8,14 +8,15 @@ export type PortalProps = {
   children: React.ReactNode;
 };
 
-export const PortalContext = React.createContext<HTMLElement | null>(
-  typeof document !== "undefined" ? document.body : null
-);
+const getBodyElement = () => typeof document !== "undefined" ? document.body : null
+
+export const PortalContext = React.createContext<HTMLElement | null>(getBodyElement());
 
 export function Portal({ children }: PortalProps) {
   // if it's a nested portal, context is the parent portal
   // otherwise it's document.body
-  const context = React.useContext(PortalContext) || document.body;
+  // https://github.com/reakit/reakit/issues/513
+  const context = React.useContext(PortalContext) || getBodyElement();
   const [portal] = React.useState(() => {
     if (typeof document !== "undefined") {
       const element = document.createElement("div");


### PR DESCRIPTION
Should fix below issue, when PortalContext is undefined. See the commit message for good description.

Closes https://github.com/reakit/reakit/issues/513

**Does this PR introduce a breaking change?**

Unfortunately, not sure.
I couldn't figure out when `document` would ever be undefined. But in that case, the outcome is different now.