### PR TITLE
Add support for the popper.js `inner` modifier to Popover

### DIFF
--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -538,6 +538,11 @@ element.
 
   Shift popover on the start or end of its reference element.
 
+- **`unstable_inner`** <span title="Experimental">⚠️</span>
+  <code>boolean | undefined</code>
+
+  Position the popover inside the reference element.
+
 - **`gutter`**
   <code>number | undefined</code>
 

--- a/packages/reakit/src/Popover/PopoverState.ts
+++ b/packages/reakit/src/Popover/PopoverState.ts
@@ -96,6 +96,10 @@ export type PopoverInitialState = DialogInitialState &
      */
     unstable_shift?: boolean;
     /**
+     * Position the popover inside the reference element.
+     */
+    unstable_inner?: boolean;
+    /**
      * Offset between the reference and the popover.
      */
     gutter?: number;
@@ -119,6 +123,7 @@ export function usePopoverState(
     placement: sealedPlacement = "bottom",
     unstable_flip: flip = true,
     unstable_shift: shift = true,
+    unstable_inner: inner = false,
     unstable_preventOverflow: preventOverflow = true,
     unstable_boundariesElement: boundariesElement = "scrollParent",
     unstable_fixed: fixed = false,
@@ -164,6 +169,7 @@ export function usePopoverState(
         modifiers: {
           applyStyle: { enabled: false },
           flip: { enabled: flip, padding: 16 },
+          inner: { enabled: inner },
           shift: { enabled: shift },
           offset: { enabled: shift, offset: `0, ${gutter}` },
           preventOverflow: { enabled: preventOverflow, boundariesElement },
@@ -203,6 +209,7 @@ export function usePopoverState(
     dialog.visible,
     originalPlacement,
     flip,
+    inner,
     shift,
     gutter,
     preventOverflow,

--- a/packages/reakit/src/Popover/README.md
+++ b/packages/reakit/src/Popover/README.md
@@ -246,6 +246,11 @@ element.
 
   Shift popover on the start or end of its reference element.
 
+- **`unstable_inner`** <span title="Experimental">⚠️</span>
+  <code>boolean | undefined</code>
+
+  Position the popover inside the reference element.
+
 - **`gutter`**
   <code>number | undefined</code>
 

--- a/packages/reakit/src/Tooltip/README.md
+++ b/packages/reakit/src/Tooltip/README.md
@@ -180,6 +180,11 @@ element.
 
   Shift popover on the start or end of its reference element.
 
+- **`unstable_inner`** <span title="Experimental">⚠️</span>
+  <code>boolean | undefined</code>
+
+  Position the popover inside the reference element.
+
 - **`gutter`**
   <code>number | undefined</code>
 


### PR DESCRIPTION
Closes #516 

**Does this PR introduce a breaking change?**

No

- - -

Aside - It didn't look like there were tests for other modifier flags like `unstable_shift`. If you have a way you prefer this to be tested, lmk and I'll update the PR.