### PR TITLE
Support popper.js' `offset` modifier with `unstable_offset`

### DIFF
--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -543,10 +543,15 @@ element.
 
   Position the popover inside the reference element.
 
+- **`unstable_offset`** <span title="Experimental">⚠️</span>
+  <code>[string | number, string | number] | undefined</code>
+
+  Offset between the reference and the popover: [main axis, alt axis]. Should not be combined with `gutter`.
+
 - **`gutter`**
   <code>number | undefined</code>
 
-  Offset between the reference and the popover.
+  Offset between the reference and the popover on the main axis. Should not be combined with `unstable_offset`.
 
 - **`unstable_preventOverflow`** <span title="Experimental">⚠️</span>
   <code>boolean | undefined</code>

--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -544,7 +544,7 @@ element.
   Position the popover inside the reference element.
 
 - **`unstable_offset`** <span title="Experimental">⚠️</span>
-  <code>[string | number, string | number] | undefined</code>
+  <code title="readonly [string | number, string | number] | undefined">readonly [string | number, string | number] | u...</code>
 
   Offset between the reference and the popover: [main axis, alt axis]. Should not be combined with `gutter`.
 

--- a/packages/reakit/src/Popover/PopoverState.ts
+++ b/packages/reakit/src/Popover/PopoverState.ts
@@ -100,7 +100,11 @@ export type PopoverInitialState = DialogInitialState &
      */
     unstable_inner?: boolean;
     /**
-     * Offset between the reference and the popover.
+     * Offset between the reference and the popover: [main axis, alt axis]. Should not be combined with `gutter`.
+     */
+    unstable_offset?: [number | string, number | string];
+    /**
+     * Offset between the reference and the popover on the main axis. Should not be combined with `unstable_offset`.
      */
     gutter?: number;
     /**
@@ -124,11 +128,12 @@ export function usePopoverState(
     unstable_flip: flip = true,
     unstable_shift: shift = true,
     unstable_inner: inner = false,
+    unstable_offset: offset = [0, gutter],
     unstable_preventOverflow: preventOverflow = true,
     unstable_boundariesElement: boundariesElement = "scrollParent",
     unstable_fixed: fixed = false,
     ...sealed
-  } = useSealedState(initialState);
+  }: PopoverInitialState = useSealedState(initialState);
 
   const popper = React.useRef<Popper | null>(null);
   const referenceRef = React.useRef<HTMLElement>(null);
@@ -171,7 +176,7 @@ export function usePopoverState(
           flip: { enabled: flip, padding: 16 },
           inner: { enabled: inner },
           shift: { enabled: shift },
-          offset: { enabled: shift, offset: `0, ${gutter}` },
+          offset: { enabled: shift, offset: `${offset[0]}, ${offset[1]}` },
           preventOverflow: { enabled: preventOverflow, boundariesElement },
           arrow: arrowRef.current
             ? { enabled: true, element: arrowRef.current }

--- a/packages/reakit/src/Popover/PopoverState.ts
+++ b/packages/reakit/src/Popover/PopoverState.ts
@@ -102,7 +102,7 @@ export type PopoverInitialState = DialogInitialState &
     /**
      * Offset between the reference and the popover: [main axis, alt axis]. Should not be combined with `gutter`.
      */
-    unstable_offset?: [number | string, number | string];
+    unstable_offset?: readonly [number | string, number | string];
     /**
      * Offset between the reference and the popover on the main axis. Should not be combined with `unstable_offset`.
      */
@@ -128,12 +128,14 @@ export function usePopoverState(
     unstable_flip: flip = true,
     unstable_shift: shift = true,
     unstable_inner: inner = false,
-    unstable_offset: offset = [0, gutter],
+    unstable_offset: offset = [0, gutter] as NonNullable<
+      PopoverInitialState["unstable_offset"]
+    >,
     unstable_preventOverflow: preventOverflow = true,
     unstable_boundariesElement: boundariesElement = "scrollParent",
     unstable_fixed: fixed = false,
     ...sealed
-  }: PopoverInitialState = useSealedState(initialState);
+  } = useSealedState(initialState);
 
   const popper = React.useRef<Popper | null>(null);
   const referenceRef = React.useRef<HTMLElement>(null);

--- a/packages/reakit/src/Popover/README.md
+++ b/packages/reakit/src/Popover/README.md
@@ -252,7 +252,7 @@ element.
   Position the popover inside the reference element.
 
 - **`unstable_offset`** <span title="Experimental">⚠️</span>
-  <code>[string | number, string | number] | undefined</code>
+  <code title="readonly [string | number, string | number] | undefined">readonly [string | number, string | number] | u...</code>
 
   Offset between the reference and the popover: [main axis, alt axis]. Should not be combined with `gutter`.
 

--- a/packages/reakit/src/Popover/README.md
+++ b/packages/reakit/src/Popover/README.md
@@ -251,10 +251,15 @@ element.
 
   Position the popover inside the reference element.
 
+- **`unstable_offset`** <span title="Experimental">⚠️</span>
+  <code>[string | number, string | number] | undefined</code>
+
+  Offset between the reference and the popover: [main axis, alt axis]. Should not be combined with `gutter`.
+
 - **`gutter`**
   <code>number | undefined</code>
 
-  Offset between the reference and the popover.
+  Offset between the reference and the popover on the main axis. Should not be combined with `unstable_offset`.
 
 - **`unstable_preventOverflow`** <span title="Experimental">⚠️</span>
   <code>boolean | undefined</code>

--- a/packages/reakit/src/Tooltip/README.md
+++ b/packages/reakit/src/Tooltip/README.md
@@ -185,10 +185,15 @@ element.
 
   Position the popover inside the reference element.
 
+- **`unstable_offset`** <span title="Experimental">⚠️</span>
+  <code>[string | number, string | number] | undefined</code>
+
+  Offset between the reference and the popover: [main axis, alt axis]. Should not be combined with `gutter`.
+
 - **`gutter`**
   <code>number | undefined</code>
 
-  Offset between the reference and the popover.
+  Offset between the reference and the popover on the main axis. Should not be combined with `unstable_offset`.
 
 - **`unstable_preventOverflow`** <span title="Experimental">⚠️</span>
   <code>boolean | undefined</code>

--- a/packages/reakit/src/Tooltip/README.md
+++ b/packages/reakit/src/Tooltip/README.md
@@ -186,7 +186,7 @@ element.
   Position the popover inside the reference element.
 
 - **`unstable_offset`** <span title="Experimental">⚠️</span>
-  <code>[string | number, string | number] | undefined</code>
+  <code title="readonly [string | number, string | number] | undefined">readonly [string | number, string | number] | u...</code>
 
   Offset between the reference and the popover: [main axis, alt axis]. Should not be combined with `gutter`.
 


### PR DESCRIPTION
Adds support for two-axis offset positioning via an `unstable_offset` prop. Turns existing single-axis offset positioning (`gutter`) into a special case of `unstable_offset`.

Closes #511 

**Does this PR introduce a breaking change?**

No