### PR TITLE
fix: Fix parent `Dialog` closing when clicking on nested `DialogBackdrop`

### DIFF
--- a/packages/reakit/src/Dialog/__utils/useHideOnClickOutside.ts
+++ b/packages/reakit/src/Dialog/__utils/useHideOnClickOutside.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { getDocument } from "reakit-utils/getDocument";
 import { DialogOptions } from "../Dialog";
 import { useEventListenerOutside } from "./useEventListenerOutside";
 
@@ -10,16 +11,22 @@ export function useHideOnClickOutside(
 ) {
   const mouseDownRef = React.useRef<EventTarget | null>();
 
-  useEventListenerOutside(
-    dialogRef,
-    disclosuresRef,
-    nestedDialogs,
-    "mousedown",
-    event => {
+  React.useEffect(() => {
+    if (!options.visible || !options.hideOnClickOutside) {
+      return undefined;
+    }
+
+    const document = getDocument(dialogRef.current);
+    const onMouseDown = (event: MouseEvent) => {
       mouseDownRef.current = event.target;
-    },
-    options.visible && options.hideOnClickOutside
-  );
+    };
+
+    document.addEventListener("mousedown", onMouseDown);
+
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+    };
+  }, [options.visible, options.hideOnClickOutside, dialogRef]);
 
   useEventListenerOutside(
     dialogRef,

--- a/packages/reakit/src/Dialog/__utils/useHideOnClickOutside.ts
+++ b/packages/reakit/src/Dialog/__utils/useHideOnClickOutside.ts
@@ -3,10 +3,8 @@ import { getDocument } from "reakit-utils/getDocument";
 import { DialogOptions } from "../Dialog";
 import { useEventListenerOutside } from "./useEventListenerOutside";
 
-export function useHideOnClickOutside(
+function useMouseDownRef(
   dialogRef: React.RefObject<HTMLElement>,
-  disclosuresRef: React.RefObject<HTMLElement[]>,
-  nestedDialogs: Array<React.RefObject<HTMLElement>>,
   options: DialogOptions
 ) {
   const mouseDownRef = React.useRef<EventTarget | null>();
@@ -28,12 +26,27 @@ export function useHideOnClickOutside(
     };
   }, [options.visible, options.hideOnClickOutside, dialogRef]);
 
+  return mouseDownRef;
+}
+
+export function useHideOnClickOutside(
+  dialogRef: React.RefObject<HTMLElement>,
+  disclosuresRef: React.RefObject<HTMLElement[]>,
+  nestedDialogs: Array<React.RefObject<HTMLElement>>,
+  options: DialogOptions
+) {
+  const mouseDownRef = useMouseDownRef(dialogRef, options);
+
   useEventListenerOutside(
     dialogRef,
     disclosuresRef,
     nestedDialogs,
     "click",
     event => {
+      // Make sure the element that has been clicked is the same that last
+      // triggered the mousedown event. This prevents the dialog from closing
+      // by dragging the cursor (for example, selecting some text inside the
+      // dialog and releasing the mouse outside of it).
       if (mouseDownRef.current === event.target && options.hide) {
         options.hide();
       }


### PR DESCRIPTION
Closes #529

**Does this PR introduce a breaking change?**

No