### PR TITLE
fix: Prevent clicks when pressing Enter/Space with meta key on non-native `Tabbable`

### DIFF
--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -151,7 +151,13 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
           htmlOnKeyDown(event);
         }
 
-        if (options.disabled || isNativeTabbable(event.currentTarget)) return;
+        if (
+          options.disabled ||
+          isNativeTabbable(event.currentTarget) ||
+          event.metaKey
+        ) {
+          return;
+        }
 
         // Per the spec, space only triggers button click on key up.
         // On key down, it triggers the :active state.

--- a/packages/reakit/src/Tabbable/__tests__/Tabbable-test.tsx
+++ b/packages/reakit/src/Tabbable/__tests__/Tabbable-test.tsx
@@ -208,6 +208,19 @@ test("non-native button space/enter disabled", () => {
   expect(fn).toHaveBeenCalledTimes(0);
 });
 
+test("non-native button space/enter metaKey", () => {
+  const fn = jest.fn();
+  const { getByText } = render(
+    <Tabbable as="div" onClick={fn}>
+      tabbable
+    </Tabbable>
+  );
+  const tabbable = getByText("tabbable");
+  press.Enter(tabbable, { metaKey: true });
+  press.Space(tabbable, { metaKey: true });
+  expect(fn).toHaveBeenCalledTimes(0);
+});
+
 test("non-native button space/enter disabled focusable", () => {
   const fn = jest.fn();
   const { getByText } = render(


### PR DESCRIPTION
When clicking on a non-native `Tabbable` component (e.g. `<Tabbable as="div" />`) by pressing <kbd>Enter</kbd> or <kbd>Space</kbd> in conjunction with the meta key (e.g. <kbd>⌘</kbd>), the button should not be activated.

**Does this PR introduce a breaking change?**

No