### PR TITLE
feat: Replace `unstable_wrap` by `wrapElement`

### DIFF
--- a/docs/BASIC_CONCEPTS.md
+++ b/docs/BASIC_CONCEPTS.md
@@ -94,7 +94,7 @@ Learn more in [Managing state](/docs/managing-state/).
 Finally, as the **lowest level API**, Reakit exposes props hooks. These hooks hold most of the logic behind components and are heavily used within Reakit's source code as a means to compose behaviors without the hassle of polluting the tree with multiple components. For example, [Dialog](/docs/dialog/) uses [Hidden](/docs/hidden/), which in turn uses [Box](/docs/box/).
 
 ```jsx
-import { useHiddenState, useHidden, useHiddenDisclosure } from "reakit";
+import { Box, useHiddenState, useHidden, useHiddenDisclosure } from "reakit";
 
 function Example() {
   const state = useHiddenState({ visible: true });
@@ -102,8 +102,10 @@ function Example() {
   const disclosureProps = useHiddenDisclosure(state);
   return (
     <>
-      <button {...disclosureProps}>Disclosure</button>
-      <div {...props}>Hidden</div>
+      <Box as="button" {...disclosureProps}>
+        Disclosure
+      </Box>
+      <Box {...props}>Hidden</Box>
     </>
   );
 }

--- a/docs/COMPOSITION.md
+++ b/docs/COMPOSITION.md
@@ -61,14 +61,16 @@ Props hooks receive two arguments: `options` and `htmlProps`; and return new `ht
 Props will be merged automatically. If there's any conflict between props, the topmost hook (in the case below, `useButton`) will take precedence.
 
 ```jsx
-import { useCheckboxState, useCheckbox, useButton } from "reakit";
+import { Box, useCheckboxState, useCheckbox, useButton } from "reakit";
 
 function Example() {
   const options = useCheckboxState();
   // Composing Checkbox and Button together
   const htmlProps = useCheckbox(options, useButton());
   return (
-    <button {...htmlProps}>{options.state ? "😄 Happy" : "😞 Sad"}</button>
+    <Box as="button" {...htmlProps}>
+      {options.state ? "😄 Happy" : "😞 Sad"}
+    </Box>
   );
 }
 ```

--- a/packages/reakit-system/src/__tests__/createComponent-test.tsx
+++ b/packages/reakit-system/src/__tests__/createComponent-test.tsx
@@ -81,8 +81,8 @@ test("as other component created with createComponent", () => {
 
 test("wrap", () => {
   const useA = (_: any, h: any) => ({
-    wrapElement: (children: React.ReactNode) => (
-      <div id="wrapper">{children}</div>
+    wrapElement: (element: React.ReactNode) => (
+      <div id="wrapper">{element}</div>
     ),
     ...h
   });

--- a/packages/reakit-system/src/__tests__/createComponent-test.tsx
+++ b/packages/reakit-system/src/__tests__/createComponent-test.tsx
@@ -81,7 +81,7 @@ test("as other component created with createComponent", () => {
 
 test("wrap", () => {
   const useA = (_: any, h: any) => ({
-    unstable_wrap: (children: React.ReactNode) => (
+    wrapElement: (children: React.ReactNode) => (
       <div id="wrapper">{children}</div>
     ),
     ...h

--- a/packages/reakit-system/src/createComponent.ts
+++ b/packages/reakit-system/src/createComponent.ts
@@ -8,7 +8,7 @@ import { useCreateElement as defaultUseCreateElement } from "./useCreateElement"
 
 type BoxHTMLProps = React.HTMLAttributes<any> &
   React.RefAttributes<any> & {
-    unstable_wrap?: (children: React.ReactNode) => React.ReactNode;
+    wrapElement?: (element: React.ReactNode) => React.ReactNode;
   };
 
 type Hook<O> = {
@@ -59,7 +59,7 @@ export function createComponent<T extends As, O>({
   ) => {
     if (useHook) {
       const [options, htmlProps] = splitProps(props, keys);
-      const { unstable_wrap, ...elementProps } = useHook(options, {
+      const { wrapElement, ...elementProps } = useHook(options, {
         ref,
         ...htmlProps
       });
@@ -67,8 +67,8 @@ export function createComponent<T extends As, O>({
       const asKeys = as.render ? as.render.__keys : as.__keys;
       const asOptions = asKeys ? splitProps(props, asKeys)[0] : {};
       const element = useCreateElement(as, { ...elementProps, ...asOptions });
-      if (unstable_wrap) {
-        return unstable_wrap(element);
+      if (wrapElement) {
+        return wrapElement(element);
       }
       return element;
     }

--- a/packages/reakit/src/Box/Box.ts
+++ b/packages/reakit/src/Box/Box.ts
@@ -13,9 +13,10 @@ export type BoxOptions = {
 export type BoxHTMLProps = React.HTMLAttributes<any> &
   React.RefAttributes<any> & {
     /**
-     * Function returned by hook to wrap children.
+     * Function returned by the hook to wrap the element to which html props
+     * will be passed.
      */
-    unstable_wrap?: (children: React.ReactNode) => React.ReactNode;
+    wrapElement?: (children: React.ReactNode) => React.ReactNode;
   };
 
 export type BoxProps = BoxOptions & BoxHTMLProps;

--- a/packages/reakit/src/Box/Box.ts
+++ b/packages/reakit/src/Box/Box.ts
@@ -16,7 +16,7 @@ export type BoxHTMLProps = React.HTMLAttributes<any> &
      * Function returned by the hook to wrap the element to which html props
      * will be passed.
      */
-    wrapElement?: (children: React.ReactNode) => React.ReactNode;
+    wrapElement?: (element: React.ReactNode) => React.ReactNode;
   };
 
 export type BoxProps = BoxOptions & BoxHTMLProps;

--- a/packages/reakit/src/Dialog/Dialog.tsx
+++ b/packages/reakit/src/Dialog/Dialog.tsx
@@ -124,7 +124,7 @@ export const useDialog = createHook<DialogOptions, DialogHTMLProps>({
     {
       ref: htmlRef,
       onKeyDown: htmlOnKeyDown,
-      unstable_wrap: htmlWrap,
+      wrapElement: htmlWrapElement,
       ...htmlProps
     }
   ) {
@@ -159,7 +159,7 @@ export const useDialog = createHook<DialogOptions, DialogHTMLProps>({
       [options.hideOnEsc, options.hide]
     );
 
-    const wrapChildren = React.useCallback(
+    const wrapElement = React.useCallback(
       (children: React.ReactNode) => {
         if (options.modal && !backdrop) {
           return <Portal>{wrap(children)}</Portal>;
@@ -174,7 +174,7 @@ export const useDialog = createHook<DialogOptions, DialogHTMLProps>({
       role: "dialog",
       tabIndex: -1,
       onKeyDown: useAllCallbacks(onKeyDown, htmlOnKeyDown),
-      unstable_wrap: usePipe(wrapChildren, htmlWrap),
+      wrapElement: usePipe(wrapElement, htmlWrapElement),
       "aria-modal": options.modal ? true : undefined,
       "data-dialog": true,
       ...htmlProps

--- a/packages/reakit/src/Dialog/Dialog.tsx
+++ b/packages/reakit/src/Dialog/Dialog.tsx
@@ -160,11 +160,11 @@ export const useDialog = createHook<DialogOptions, DialogHTMLProps>({
     );
 
     const wrapElement = React.useCallback(
-      (children: React.ReactNode) => {
+      (element: React.ReactNode) => {
         if (options.modal && !backdrop) {
-          return <Portal>{wrap(children)}</Portal>;
+          return <Portal>{wrap(element)}</Portal>;
         }
-        return wrap(children);
+        return wrap(element);
       },
       [options.modal, backdrop, wrap]
     );

--- a/packages/reakit/src/Dialog/DialogBackdrop.tsx
+++ b/packages/reakit/src/Dialog/DialogBackdrop.tsx
@@ -29,17 +29,17 @@ export const useDialogBackdrop = createHook<
 
   useProps(options, { wrapElement: htmlWrapElement, ...htmlProps }) {
     const wrapElement = React.useCallback(
-      (children: React.ReactNode) => {
+      (element: React.ReactNode) => {
         if (options.modal) {
           return (
             <Portal>
               <DialogBackdropContext.Provider value>
-                {children}
+                {element}
               </DialogBackdropContext.Provider>
             </Portal>
           );
         }
-        return children;
+        return element;
       },
       [options.modal]
     );

--- a/packages/reakit/src/Dialog/DialogBackdrop.tsx
+++ b/packages/reakit/src/Dialog/DialogBackdrop.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { createComponent } from "reakit-system/createComponent";
 import { createHook } from "reakit-system/createHook";
+import { usePipe } from "reakit-utils/usePipe";
 import { HiddenOptions, HiddenHTMLProps, useHidden } from "../Hidden/Hidden";
 import { Portal } from "../Portal/Portal";
 import { useDialogState, DialogStateReturn } from "./DialogState";
@@ -26,8 +27,8 @@ export const useDialogBackdrop = createHook<
     return { modal, ...options };
   },
 
-  useProps(options, htmlProps) {
-    const wrapChildren = React.useCallback(
+  useProps(options, { wrapElement: htmlWrapElement, ...htmlProps }) {
+    const wrapElement = React.useCallback(
       (children: React.ReactNode) => {
         if (options.modal) {
           return (
@@ -46,7 +47,7 @@ export const useDialogBackdrop = createHook<
     return {
       id: undefined,
       role: undefined,
-      unstable_wrap: wrapChildren,
+      wrapElement: usePipe(wrapElement, htmlWrapElement),
       "data-dialog-ref": options.baseId,
       ...htmlProps
     };

--- a/packages/reakit/src/Dialog/__utils/useNestedDialogs.tsx
+++ b/packages/reakit/src/Dialog/__utils/useNestedDialogs.tsx
@@ -77,9 +77,9 @@ export function useNestedDialogs(
   );
 
   const wrap = React.useCallback(
-    (children: React.ReactNode) => (
+    (element: React.ReactNode) => (
       <DialogContext.Provider value={providerValue}>
-        {children}
+        {element}
       </DialogContext.Provider>
     ),
     [providerValue]

--- a/packages/reakit/src/Form/FormRadioGroup.tsx
+++ b/packages/reakit/src/Form/FormRadioGroup.tsx
@@ -48,7 +48,7 @@ export const unstable_useFormRadioGroup = createHook<
     return { name, ...options };
   },
 
-  useProps(options, { unstable_wrap: htmlWrap, ...htmlProps }) {
+  useProps(options, { wrapElement: htmlWrapElement, ...htmlProps }) {
     const id = getInputId(options.name, options.baseId);
     const rover = useRoverState({ baseId: id, loop: true });
     const providerValue = React.useMemo(() => rover, [
@@ -57,7 +57,7 @@ export const unstable_useFormRadioGroup = createHook<
       rover.unstable_pastId
     ]);
 
-    const wrap = React.useCallback(
+    const wrapElement = React.useCallback(
       (children: React.ReactNode) => (
         <FormRadioGroupContext.Provider value={providerValue}>
           {children}
@@ -68,7 +68,7 @@ export const unstable_useFormRadioGroup = createHook<
 
     return {
       role: "radiogroup",
-      unstable_wrap: usePipe(wrap, htmlWrap),
+      wrapElement: usePipe(wrapElement, htmlWrapElement),
       ...htmlProps
     };
   }

--- a/packages/reakit/src/Form/FormRadioGroup.tsx
+++ b/packages/reakit/src/Form/FormRadioGroup.tsx
@@ -58,9 +58,9 @@ export const unstable_useFormRadioGroup = createHook<
     ]);
 
     const wrapElement = React.useCallback(
-      (children: React.ReactNode) => (
+      (element: React.ReactNode) => (
         <FormRadioGroupContext.Provider value={providerValue}>
-          {children}
+          {element}
         </FormRadioGroupContext.Provider>
       ),
       [providerValue]

--- a/packages/reakit/src/Form/__tests__/index-test.tsx
+++ b/packages/reakit/src/Form/__tests__/index-test.tsx
@@ -871,12 +871,12 @@ test("useFormRadio and useFormRadioGroup passing name and value as htmlProps", a
       }
     });
     // @ts-ignore
-    const { unstable_wrap: wrap, ...radioGroup } = useFormRadioGroup(form, {
+    const { wrapElement, ...radioGroup } = useFormRadioGroup(form, {
       name: "input"
     });
     return (
       <Form {...form}>
-        {wrap(
+        {wrapElement(
           <fieldset {...radioGroup}>
             <CustomFormRadio {...form} value="a" />
             <CustomFormRadio {...form} value="b" />

--- a/packages/reakit/src/Menu/MenuBar.tsx
+++ b/packages/reakit/src/Menu/MenuBar.tsx
@@ -25,10 +25,15 @@ export const useMenuBar = createHook<MenuBarOptions, MenuBarHTMLProps>({
 
   useProps(
     options,
-    { ref: htmlRef, unstable_wrap: htmlWrap, role = "menubar", ...htmlProps }
+    {
+      ref: htmlRef,
+      wrapElement: htmlWrapElement,
+      role = "menubar",
+      ...htmlProps
+    }
   ) {
     const ref = React.useRef<HTMLElement>(null);
-    const wrap = useMenuContext(ref, role, options);
+    const wrapElement = useMenuContext(ref, role, options);
 
     useShortcuts(ref, options);
 
@@ -36,7 +41,7 @@ export const useMenuBar = createHook<MenuBarOptions, MenuBarHTMLProps>({
       ref: mergeRefs(ref, htmlRef),
       role,
       "aria-orientation": options.orientation,
-      unstable_wrap: usePipe(wrap, htmlWrap),
+      wrapElement: usePipe(wrapElement, htmlWrapElement),
       ...htmlProps
     };
   }

--- a/packages/reakit/src/Menu/__utils/MenuContext.tsx
+++ b/packages/reakit/src/Menu/__utils/MenuContext.tsx
@@ -75,12 +75,12 @@ export function useMenuContext(
     ]
   );
 
-  const wrap = React.useCallback(
+  const wrapElement = React.useCallback(
     (c: React.ReactNode) => (
       <MenuContext.Provider value={providerValue}>{c}</MenuContext.Provider>
     ),
     [providerValue]
   );
 
-  return wrap;
+  return wrapElement;
 }

--- a/packages/reakit/src/Tooltip/Tooltip.tsx
+++ b/packages/reakit/src/Tooltip/Tooltip.tsx
@@ -46,11 +46,11 @@ export const useTooltip = createHook<TooltipOptions, TooltipHTMLProps>({
     }
   ) {
     const wrapElement = React.useCallback(
-      (children: React.ReactNode) => {
+      (element: React.ReactNode) => {
         if (options.unstable_portal) {
-          return <Portal>{children}</Portal>;
+          return <Portal>{element}</Portal>;
         }
-        return children;
+        return element;
       },
       [options.unstable_portal]
     );

--- a/packages/reakit/src/Tooltip/Tooltip.tsx
+++ b/packages/reakit/src/Tooltip/Tooltip.tsx
@@ -38,9 +38,14 @@ export const useTooltip = createHook<TooltipOptions, TooltipHTMLProps>({
 
   useProps(
     options,
-    { ref: htmlRef, style: htmlStyle, unstable_wrap: htmlWrap, ...htmlProps }
+    {
+      ref: htmlRef,
+      style: htmlStyle,
+      wrapElement: htmlWrapElement,
+      ...htmlProps
+    }
   ) {
-    const wrap = React.useCallback(
+    const wrapElement = React.useCallback(
       (children: React.ReactNode) => {
         if (options.unstable_portal) {
           return <Portal>{children}</Portal>;
@@ -58,7 +63,7 @@ export const useTooltip = createHook<TooltipOptions, TooltipHTMLProps>({
         pointerEvents: "none",
         ...htmlStyle
       },
-      unstable_wrap: usePipe(wrap, htmlWrap),
+      wrapElement: usePipe(wrapElement, htmlWrapElement),
       ...htmlProps
     };
   }


### PR DESCRIPTION
This PR marks `unstable_wrap` as stable and renames it to `wrapElement`.

This:
```jsx
const { unstable_wrap, ...props } = useDialog();
const element = <div {...props} />;
return unstable_wrap ? unstable_wrap(element) : element;
```

Becomes this:
```jsx
const { wrapElement, ...props } = useDialog();
const element = <div {...props} />;
return wrapElement ? wrapElement(element) : element;
```

**Does this PR introduce a breaking change?**

No (it was an unstable feature).