### PR TITLE
do not close dialog on esc if an input is focused

### DIFF
--- a/packages/reakit/src/Dialog/Dialog.tsx
+++ b/packages/reakit/src/Dialog/Dialog.tsx
@@ -142,7 +142,19 @@ export const useDialog = createHook<DialogOptions, DialogHTMLProps>({
 
     const onKeyDown = React.useCallback(
       (event: React.KeyboardEvent) => {
-        if (event.key === "Escape" && options.hideOnEsc) {
+        const target = event.target as HTMLElement;
+        const targetIsControl = ["INPUT", "SELECT", "BUTTON"].includes(
+          target.tagName.toUpperCase()
+        );
+        const targetIsFocusable =
+          targetIsControl || Number(target.tabIndex) > -1;
+        if (
+          event.key === "Escape" &&
+          options.hideOnEsc &&
+          target &&
+          !targetIsControl &&
+          !targetIsFocusable
+        ) {
           if (!options.hide) {
             warning(
               true,

--- a/packages/reakit/src/Dialog/__tests__/index-test.tsx
+++ b/packages/reakit/src/Dialog/__tests__/index-test.tsx
@@ -436,6 +436,35 @@ test("esc does not close the dialog when hideOnEsc is falsy", () => {
   expect(dialog).toBeVisible();
 });
 
+test("esc does not close the dialog when hideOnEsc is true but focus is in input", () => {
+  const Test = () => {
+    const dialog = useDialogState({ visible: true });
+    return (
+      <Dialog {...dialog} aria-label="dialog" hideOnEsc>
+        <input />
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+        <div tabIndex={0} aria-label="div" />
+      </Dialog>
+    );
+  };
+  const { getByLabelText, getByRole } = render(<Test />);
+  const dialog = getByLabelText("dialog");
+  const input = getByRole("textbox");
+  const div = getByLabelText("div");
+  expect(dialog).toBeVisible();
+  focus(input);
+  press.Escape(input);
+  expect(dialog).toBeVisible();
+
+  focus(div);
+  press.Escape(div);
+  expect(dialog).toBeVisible();
+
+  press.Escape(dialog);
+  expect(dialog).not.toBeVisible();
+  expect(console).toHaveWarned();
+});
+
 test("clicking outside closes the dialog", () => {
   const Test = () => {
     const dialog = useDialogState({ visible: true });


### PR DESCRIPTION
Closes #536 
Checks if the target of Esc event is a form control or an element with tabIndex > -1.
