### PR TITLE
feat: Add `MenuButton` and deprecate `MenuDisclosure`

### DIFF
--- a/packages/reakit-playground/src/__deps/reakit.ts
+++ b/packages/reakit-playground/src/__deps/reakit.ts
@@ -49,6 +49,7 @@ export default {
   "reakit/Menu/MenuItem": require("reakit/Menu/MenuItem"),
   "reakit/Menu/MenuGroup": require("reakit/Menu/MenuGroup"),
   "reakit/Menu/MenuDisclosure": require("reakit/Menu/MenuDisclosure"),
+  "reakit/Menu/MenuButton": require("reakit/Menu/MenuButton"),
   "reakit/Menu/MenuBarState": require("reakit/Menu/MenuBarState"),
   "reakit/Menu/MenuBar": require("reakit/Menu/MenuBar"),
   "reakit/Menu/MenuArrow": require("reakit/Menu/MenuArrow"),

--- a/packages/reakit-system-bootstrap/src/Menu.tsx
+++ b/packages/reakit-system-bootstrap/src/Menu.tsx
@@ -1,10 +1,7 @@
 import * as React from "react";
 import { css, cx } from "emotion";
 import { MenuHTMLProps, MenuOptions } from "reakit/Menu/Menu";
-import {
-  MenuDisclosureHTMLProps,
-  MenuDisclosureOptions
-} from "reakit/Menu/MenuDisclosure";
+import { MenuButtonHTMLProps, MenuButtonOptions } from "reakit/Menu/MenuButton";
 import {
   MenuItemCheckboxHTMLProps,
   MenuItemCheckboxOptions
@@ -120,14 +117,14 @@ export function useMenuProps(
   return { ...htmlProps, className: cx(menu, htmlProps.className) };
 }
 
-export type BootstrapMenuDisclosureOptions = BootstrapBoxOptions &
-  MenuDisclosureOptions &
+export type BootstrapMenuButtonOptions = BootstrapBoxOptions &
+  MenuButtonOptions &
   Pick<Partial<MenuStateReturn>, "unstable_originalPlacement">;
 
-export function useMenuDisclosureProps(
-  options: BootstrapMenuDisclosureOptions,
-  { children, ...htmlProps }: MenuDisclosureHTMLProps = {}
-): MenuDisclosureHTMLProps {
+export function useMenuButtonProps(
+  options: BootstrapMenuButtonOptions,
+  { children, ...htmlProps }: MenuButtonHTMLProps = {}
+): MenuButtonHTMLProps {
   const placement = options.unstable_originalPlacement || options.placement;
   const dir = placement
     ? (placement.split("-")[0] as "top" | "bottom" | "right" | "left")

--- a/packages/reakit/src/Menu/MenuButton.ts
+++ b/packages/reakit/src/Menu/MenuButton.ts
@@ -1,0 +1,172 @@
+import * as React from "react";
+import { createComponent } from "reakit-system/createComponent";
+import { createOnKeyDown } from "reakit-utils/createOnKeyDown";
+import { createHook } from "reakit-system/createHook";
+import { useForkRef } from "reakit-utils/useForkRef";
+import { useAllCallbacks } from "reakit-utils/useAllCallbacks";
+import {
+  PopoverDisclosureOptions,
+  PopoverDisclosureHTMLProps,
+  usePopoverDisclosure
+} from "../Popover/PopoverDisclosure";
+import { useMenuState, MenuStateReturn } from "./MenuState";
+import { MenuContext } from "./__utils/MenuContext";
+
+export type MenuButtonOptions = PopoverDisclosureOptions &
+  Pick<Partial<MenuStateReturn>, "hide"> &
+  Pick<MenuStateReturn, "show" | "placement" | "first" | "last">;
+
+export type MenuButtonHTMLProps = PopoverDisclosureHTMLProps;
+
+export type MenuButtonProps = MenuButtonOptions & MenuButtonHTMLProps;
+
+const noop = () => {};
+
+export const useMenuButton = createHook<MenuButtonOptions, MenuButtonHTMLProps>(
+  {
+    name: "MenuButton",
+    compose: usePopoverDisclosure,
+    useState: useMenuState,
+
+    useProps(
+      options,
+      {
+        ref: htmlRef,
+        onClick: htmlOnClick,
+        onKeyDown: htmlOnKeyDown,
+        onFocus: htmlOnFocus,
+        onMouseOver: htmlOnMouseOver,
+        ...htmlProps
+      }
+    ) {
+      const parent = React.useContext(MenuContext);
+      const ref = React.useRef<HTMLElement>(null);
+      // This avoids race condition between focus and click.
+      // On some browsers, focus is triggered right before click.
+      // So we use it to disable toggling.
+      const [hasShownOnFocus, setHasShownOnFocus] = React.useState(false);
+      const [dir] = options.placement.split("-");
+      const hasParent = Boolean(parent);
+      const parentIsMenuBar = parent && parent.role === "menubar";
+
+      const onKeyDown = React.useMemo(
+        () =>
+          createOnKeyDown({
+            stopPropagation: event => event.key !== "Escape",
+            onKey: options.show,
+            keyMap: () => {
+              // prevents scroll jump
+              const first = () => setTimeout(options.first);
+              return {
+                Escape: options.hide,
+                Enter: hasParent && first,
+                " ": hasParent && first,
+                ArrowUp:
+                  dir === "top" || dir === "bottom" ? options.last : false,
+                ArrowRight: dir === "right" && first,
+                ArrowDown: dir === "bottom" || dir === "top" ? first : false,
+                ArrowLeft: dir === "left" && first
+              };
+            }
+          }),
+        [
+          dir,
+          hasParent,
+          options.show,
+          options.hide,
+          options.first,
+          options.last
+        ]
+      );
+
+      const onFocus = React.useCallback(() => {
+        if (parentIsMenuBar) {
+          setHasShownOnFocus(true);
+          options.show();
+        }
+      }, [parentIsMenuBar, options.show]);
+
+      // Restores hasShownOnFocus
+      React.useEffect(() => {
+        if (!hasShownOnFocus) return undefined;
+        const id = setTimeout(() => setHasShownOnFocus(false), 200);
+        return () => clearTimeout(id);
+      }, [hasShownOnFocus]);
+
+      const onMouseOver = React.useCallback(
+        (event: MouseEvent) => {
+          // MenuButton's don't do anything on mouse over when they aren't
+          // cointained within a Menu/MenuBar
+          if (!parent) return;
+
+          const self = event.currentTarget as HTMLElement;
+
+          if (parentIsMenuBar) {
+            // if MenuButton is an item inside a MenuBar, it'll only open
+            // if there's already another sibling expanded MenuButton
+            const subjacentOpenMenu =
+              parent.ref.current &&
+              parent.ref.current.querySelector("[aria-expanded='true']");
+            if (subjacentOpenMenu) {
+              self.focus();
+            }
+          } else {
+            // If it's in a Menu, open after a short delay
+            // TODO: Make the delay a prop?
+            setTimeout(() => {
+              if (self.contains(document.activeElement)) {
+                options.show();
+                if (document.activeElement !== self) {
+                  self.focus();
+                }
+              }
+            }, 200);
+          }
+        },
+        [parent, parentIsMenuBar, options.show]
+      );
+
+      // If disclosure is rendered as a menu bar item, it's toggable
+      // That is, you can click on the expanded disclosure to close its menu
+      // But, if disclosure has been focused, it may be result of a mouse down
+      // In this case, toggling it would make it close right away on click
+      // Then we check if it has been shown on focus. If so, we don't toggle
+      const onClick = React.useCallback(() => {
+        if (hasParent && (!parentIsMenuBar || hasShownOnFocus)) {
+          options.show();
+        } else {
+          options.toggle();
+        }
+      }, [
+        hasParent,
+        parentIsMenuBar,
+        hasShownOnFocus,
+        options.show,
+        options.toggle
+      ]);
+
+      return {
+        ref: useForkRef(ref, htmlRef),
+        "aria-haspopup": "menu",
+        onClick: useAllCallbacks(onClick, htmlOnClick),
+        onKeyDown: useAllCallbacks(onKeyDown, htmlOnKeyDown),
+        onFocus: useAllCallbacks(onFocus, htmlOnFocus),
+        onMouseOver: useAllCallbacks(onMouseOver, htmlOnMouseOver),
+        ...htmlProps
+      };
+    },
+
+    useComposeOptions(options) {
+      return {
+        ...options,
+        // Toggling is handled by MenuButton
+        toggle: noop
+      };
+    }
+  }
+);
+
+export const MenuButton = createComponent({
+  as: "button",
+  useHook: useMenuButton
+});

--- a/packages/reakit/src/Menu/MenuDisclosure.ts
+++ b/packages/reakit/src/Menu/MenuDisclosure.ts
@@ -1,162 +1,34 @@
-import * as React from "react";
 import { createComponent } from "reakit-system/createComponent";
-import { createOnKeyDown } from "reakit-utils/createOnKeyDown";
 import { createHook } from "reakit-system/createHook";
-import { useForkRef } from "reakit-utils/useForkRef";
-import { useAllCallbacks } from "reakit-utils/useAllCallbacks";
+import { warning } from "reakit-utils/warning";
 import {
-  PopoverDisclosureOptions,
-  PopoverDisclosureHTMLProps,
-  usePopoverDisclosure
-} from "../Popover/PopoverDisclosure";
-import { useMenuState, MenuStateReturn } from "./MenuState";
-import { MenuContext } from "./__utils/MenuContext";
+  useMenuButton,
+  MenuButtonOptions,
+  MenuButtonHTMLProps
+} from "./MenuButton";
 
-export type MenuDisclosureOptions = PopoverDisclosureOptions &
-  Pick<Partial<MenuStateReturn>, "hide"> &
-  Pick<MenuStateReturn, "show" | "placement" | "first" | "last">;
+export type MenuDisclosureOptions = MenuButtonOptions;
 
-export type MenuDisclosureHTMLProps = PopoverDisclosureHTMLProps;
+export type MenuDisclosureHTMLProps = MenuButtonHTMLProps;
 
 export type MenuDisclosureProps = MenuDisclosureOptions &
   MenuDisclosureHTMLProps;
-
-const noop = () => {};
 
 export const useMenuDisclosure = createHook<
   MenuDisclosureOptions,
   MenuDisclosureHTMLProps
 >({
   name: "MenuDisclosure",
-  compose: usePopoverDisclosure,
-  useState: useMenuState,
+  compose: useMenuButton,
 
-  useProps(
-    options,
-    {
-      ref: htmlRef,
-      onClick: htmlOnClick,
-      onKeyDown: htmlOnKeyDown,
-      onFocus: htmlOnFocus,
-      onMouseOver: htmlOnMouseOver,
-      ...htmlProps
-    }
-  ) {
-    const parent = React.useContext(MenuContext);
-    const ref = React.useRef<HTMLElement>(null);
-    // This avoids race condition between focus and click.
-    // On some browsers, focus is triggered right before click.
-    // So we use it to disable toggling.
-    const [hasShownOnFocus, setHasShownOnFocus] = React.useState(false);
-    const [dir] = options.placement.split("-");
-    const hasParent = Boolean(parent);
-    const parentIsMenuBar = parent && parent.role === "menubar";
-
-    const onKeyDown = React.useMemo(
-      () =>
-        createOnKeyDown({
-          stopPropagation: event => event.key !== "Escape",
-          onKey: options.show,
-          keyMap: () => {
-            // prevents scroll jump
-            const first = () => setTimeout(options.first);
-            return {
-              Escape: options.hide,
-              Enter: hasParent && first,
-              " ": hasParent && first,
-              ArrowUp: dir === "top" || dir === "bottom" ? options.last : false,
-              ArrowRight: dir === "right" && first,
-              ArrowDown: dir === "bottom" || dir === "top" ? first : false,
-              ArrowLeft: dir === "left" && first
-            };
-          }
-        }),
-      [dir, hasParent, options.show, options.hide, options.first, options.last]
+  useProps(_, htmlProps) {
+    warning(
+      true,
+      "[reakit/MenuDisclosure]",
+      "`MenuDisclosure` has been renamed to `MenuButton`. Using `<MenuDisclosure />` will no longer work in future versions.",
+      "See https://reakit.io/docs/menu"
     );
-
-    const onFocus = React.useCallback(() => {
-      if (parentIsMenuBar) {
-        setHasShownOnFocus(true);
-        options.show();
-      }
-    }, [parentIsMenuBar, options.show]);
-
-    // Restores hasShownOnFocus
-    React.useEffect(() => {
-      if (!hasShownOnFocus) return undefined;
-      const id = setTimeout(() => setHasShownOnFocus(false), 200);
-      return () => clearTimeout(id);
-    }, [hasShownOnFocus]);
-
-    const onMouseOver = React.useCallback(
-      (event: MouseEvent) => {
-        // MenuDisclosure's don't do anything on mouse over when they aren't
-        // cointained within a Menu/MenuBar
-        if (!parent) return;
-
-        const self = event.currentTarget as HTMLElement;
-
-        if (parentIsMenuBar) {
-          // if MenuDisclosure is an item inside a MenuBar, it'll only open
-          // if there's already another sibling expanded MenuDisclosure
-          const subjacentOpenMenu =
-            parent.ref.current &&
-            parent.ref.current.querySelector("[aria-expanded='true']");
-          if (subjacentOpenMenu) {
-            self.focus();
-          }
-        } else {
-          // If it's in a Menu, open after a short delay
-          // TODO: Make the delay a prop?
-          setTimeout(() => {
-            if (self.contains(document.activeElement)) {
-              options.show();
-              if (document.activeElement !== self) {
-                self.focus();
-              }
-            }
-          }, 200);
-        }
-      },
-      [parent, parentIsMenuBar, options.show]
-    );
-
-    // If disclosure is rendered as a menu bar item, it's toggable
-    // That is, you can click on the expanded disclosure to close its menu
-    // But, if disclosure has been focused, it may be result of a mouse down
-    // In this case, toggling it would make it close right away on click
-    // Then we check if it has been shown on focus. If so, we don't toggle
-    const onClick = React.useCallback(() => {
-      if (hasParent && (!parentIsMenuBar || hasShownOnFocus)) {
-        options.show();
-      } else {
-        options.toggle();
-      }
-    }, [
-      hasParent,
-      parentIsMenuBar,
-      hasShownOnFocus,
-      options.show,
-      options.toggle
-    ]);
-
-    return {
-      ref: useForkRef(ref, htmlRef),
-      "aria-haspopup": "menu",
-      onClick: useAllCallbacks(onClick, htmlOnClick),
-      onKeyDown: useAllCallbacks(onKeyDown, htmlOnKeyDown),
-      onFocus: useAllCallbacks(onFocus, htmlOnFocus),
-      onMouseOver: useAllCallbacks(onMouseOver, htmlOnMouseOver),
-      ...htmlProps
-    };
-  },
-
-  useComposeOptions(options) {
-    return {
-      ...options,
-      // Toggling is handled by MenuDisclosure
-      toggle: noop
-    };
+    return htmlProps;
   }
 });
 

--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -4,7 +4,7 @@ path: /docs/menu/
 
 # Menu
 
-Accessible `Menu` component that follows the [WAI-ARIA Menu or Menu bar Pattern](https://www.w3.org/TR/wai-aria-practices/#menu). It also includes a `MenuDisclosure` component that follows the [WAI-ARIA Menu Button Pattern](https://www.w3.org/TR/wai-aria-practices/#menubutton).
+Accessible `Menu` component that follows the [WAI-ARIA Menu or Menu bar Pattern](https://www.w3.org/TR/wai-aria-practices/#menu). It also includes a `MenuButton` component that follows the [WAI-ARIA Menu Button Pattern](https://www.w3.org/TR/wai-aria-practices/#menubutton).
 
 <carbon-ad></carbon-ad>
 
@@ -23,7 +23,7 @@ import {
   useMenuState,
   Menu,
   MenuItem,
-  MenuDisclosure,
+  MenuButton,
   MenuSeparator
 } from "reakit/Menu";
 
@@ -31,7 +31,7 @@ function Example() {
   const menu = useMenuState();
   return (
     <>
-      <MenuDisclosure {...menu}>Preferences</MenuDisclosure>
+      <MenuButton {...menu}>Preferences</MenuButton>
       <Menu {...menu} aria-label="Preferences">
         <MenuItem {...menu}>Settings</MenuItem>
         <MenuItem {...menu} disabled>
@@ -56,7 +56,7 @@ import {
   useMenuState,
   Menu,
   MenuItem,
-  MenuDisclosure,
+  MenuButton,
   MenuSeparator
 } from "reakit/Menu";
 
@@ -65,7 +65,7 @@ function Example() {
 
   return (
     <>
-      <MenuDisclosure {...menu}>Menu</MenuDisclosure>
+      <MenuButton {...menu}>Menu</MenuButton>
       <Menu {...menu} aria-label="Example">
         <MenuItem
           {...menu}
@@ -90,13 +90,13 @@ function Example() {
 When opening `Menu`, focus is usually set on the first `MenuItem`. You can set the initial focus to be the menu container itself by just passing `tabIndex={0}` to it. This will be ignored if the menu is opened by using arrow keys.
 
 ```jsx
-import { useMenuState, Menu, MenuItem, MenuDisclosure } from "reakit/Menu";
+import { useMenuState, Menu, MenuItem, MenuButton } from "reakit/Menu";
 
 function Example() {
   const menu = useMenuState();
   return (
     <>
-      <MenuDisclosure {...menu}>Preferences</MenuDisclosure>
+      <MenuButton {...menu}>Preferences</MenuButton>
       <Menu {...menu} tabIndex={0} aria-label="Preferences">
         <MenuItem {...menu}>Settings</MenuItem>
         <MenuItem {...menu}>Extensions</MenuItem>
@@ -112,7 +112,7 @@ Alternatively, you can define another element to get the initial focus with Reac
 ```jsx
 import React from "react";
 import { Button } from "reakit/Button";
-import { useMenuState, Menu, MenuItem, MenuDisclosure } from "reakit/Menu";
+import { useMenuState, Menu, MenuItem, MenuButton } from "reakit/Menu";
 
 function Example() {
   const menu = useMenuState();
@@ -126,7 +126,7 @@ function Example() {
 
   return (
     <>
-      <MenuDisclosure {...menu}>Preferences</MenuDisclosure>
+      <MenuButton {...menu}>Preferences</MenuButton>
       <Menu {...menu} aria-label="Preferences">
         <MenuItem {...menu}>Settings</MenuItem>
         <MenuItem {...menu} ref={ref}>
@@ -149,7 +149,7 @@ import {
   useMenuState,
   Menu,
   MenuItem,
-  MenuDisclosure,
+  MenuButton,
   MenuSeparator
 } from "reakit/Menu";
 
@@ -157,9 +157,9 @@ const PreferencesMenu = React.forwardRef((props, ref) => {
   const menu = useMenuState();
   return (
     <>
-      <MenuDisclosure ref={ref} {...menu} {...props}>
+      <MenuButton ref={ref} {...menu} {...props}>
         Preferences
-      </MenuDisclosure>
+      </MenuButton>
       <Menu {...menu} aria-label="Preferences">
         <MenuItem {...menu}>Settings</MenuItem>
         <MenuItem {...menu} disabled>
@@ -176,7 +176,7 @@ function Example() {
   const menu = useMenuState();
   return (
     <>
-      <MenuDisclosure {...menu}>Code</MenuDisclosure>
+      <MenuButton {...menu}>Code</MenuButton>
       <Menu {...menu} aria-label="Code">
         <MenuItem {...menu}>About Visual Studio Code</MenuItem>
         <MenuItem {...menu}>Check for Updates...</MenuItem>
@@ -205,7 +205,7 @@ import {
   useMenuState,
   Menu,
   MenuItem,
-  MenuDisclosure,
+  MenuButton,
   MenuSeparator
 } from "reakit/Menu";
 
@@ -228,7 +228,7 @@ function Example() {
   const menu = useMenuState();
   return (
     <>
-      <MenuDisclosure {...menu}>Code</MenuDisclosure>
+      <MenuButton {...menu}>Code</MenuButton>
       <Menu {...menu} aria-label="Code">
         <MenuItem {...menu}>About Visual Studio Code</MenuItem>
         <MenuItem {...menu} as={UpdatesDialog} />
@@ -250,7 +250,7 @@ import {
   useMenuState,
   useMenuBarState,
   Menu,
-  MenuDisclosure,
+  MenuButton,
   MenuItem,
   MenuSeparator,
   MenuBar,
@@ -264,9 +264,9 @@ const OpenRecentMenu = React.forwardRef((props, ref) => {
   const menu = useMenuState();
   return (
     <>
-      <MenuDisclosure ref={ref} {...menu} {...props}>
+      <MenuButton ref={ref} {...menu} {...props}>
         Open Recent
-      </MenuDisclosure>
+      </MenuButton>
       <Menu {...menu} aria-label="Open Recent">
         <MenuItem {...menu}>Reopen Closed Editor</MenuItem>
         <MenuSeparator {...menu} />
@@ -283,9 +283,9 @@ const FileMenu = React.forwardRef((props, ref) => {
   const menu = useMenuState();
   return (
     <>
-      <MenuDisclosure ref={ref} {...menu} {...props}>
+      <MenuButton ref={ref} {...menu} {...props}>
         File
-      </MenuDisclosure>
+      </MenuButton>
       <Menu {...menu} aria-label="File">
         <MenuItem {...menu}>New File</MenuItem>
         <MenuItem {...menu}>New Window</MenuItem>
@@ -303,9 +303,9 @@ const EditMenu = React.forwardRef((props, ref) => {
   const menu = useMenuState();
   return (
     <>
-      <MenuDisclosure ref={ref} {...menu} {...props}>
+      <MenuButton ref={ref} {...menu} {...props}>
         Edit
-      </MenuDisclosure>
+      </MenuButton>
       <Menu {...menu} aria-label="Edit">
         <MenuItem {...menu}>Undo</MenuItem>
         <MenuItem {...menu}>Redo</MenuItem>
@@ -323,9 +323,9 @@ const ViewMenu = React.forwardRef((props, ref) => {
   const menu = useMenuState();
   return (
     <>
-      <MenuDisclosure ref={ref} {...menu} {...props}>
+      <MenuButton ref={ref} {...menu} {...props}>
         View
-      </MenuDisclosure>
+      </MenuButton>
       <Menu {...menu} aria-label="View">
         <MenuGroup {...menu}>
           <MenuItemRadio {...menu} name="windows" value="explorer">
@@ -378,16 +378,16 @@ import {
   useMenuState,
   Menu as BaseMenu,
   MenuItem,
-  MenuDisclosure
+  MenuButton
 } from "reakit/Menu";
 
 function Menu({ disclosure, items, ...props }) {
   const menu = useMenuState();
   return (
     <>
-      <MenuDisclosure {...menu} {...disclosure.props}>
+      <MenuButton {...menu} {...disclosure.props}>
         {disclosureProps => React.cloneElement(disclosure, disclosureProps)}
-      </MenuDisclosure>
+      </MenuButton>
       <BaseMenu {...menu} {...props}>
         {items.map((item, i) => (
           <MenuItem {...menu} {...item.props} key={i}>
@@ -417,12 +417,12 @@ function Example() {
 ## Accessibility
 
 - `MenuBar` and `Menu` have either role `menu` or `menubar` depending on the value of the `orientation` option (when it's `horizontal` it becomes `menubar`).
-- `MenuDisclosure` extends the accessibility features of [PopoverDisclosure](/docs/popover/#accessibility), which means it sets `aria-haspopup` and `aria-expanded` attributes accordingly.
+- `MenuButton` extends the accessibility features of [PopoverDisclosure](/docs/popover/#accessibility), which means it sets `aria-haspopup` and `aria-expanded` attributes accordingly.
 - `MenuItem` has role `menuitem`.
 - `MenuItem` extends the accessibility features of [Rover](/docs/rover/), which means it uses the [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_roving_tabindex) method to manage focus.
 - `MenuItemCheckbox` has role `menuitemcheckbox`.
 - `MenuItemRadio` has role `menuitemradio`.
-- Pressing <kbd>Enter</kbd> on `MenuDisclosure` opens its menu (or submenu) and places focus on its first item.
+- Pressing <kbd>Enter</kbd> on `MenuButton` opens its menu (or submenu) and places focus on its first item.
 - Pressing <kbd>Space</kbd> on `MenuItemCheckbox` changes the state without closing `Menu`.
 - Pressing <kbd>Space</kbd> on a `MenuItemRadio` that is not checked, without closing `Menu`, checks the focused `MenuItemRadio` and unchecks any other checked `MenuItemRadio` in the same group.
 - Pressing any key that corresponds to a printable character moves focus to the next `MenuItem` in the current `Menu` or `MenuBar` whose label begins with that printable character.
@@ -432,7 +432,7 @@ Learn more in [Accessibility](/docs/accessibility/).
 ## Composition
 
 - `Menu` uses `MenuBar` and [Popover](/docs/popover/).
-- `MenuDisclosure` uses [PopoverDisclosure](/docs/popover/).
+- `MenuButton` uses [PopoverDisclosure](/docs/popover/).
 - `MenuGroup` uses [Box](/docs/box/).
 - `MenuItem` uses [Rover](/docs/rover/).
 - `MenuItemCheckbox` uses [Checkbox](/docs/checkbox/).
@@ -747,6 +747,71 @@ It's called after given milliseconds if `animated` is a number.
   <code>() =&#62; void</code>
 
   Moves focus to the previous element.
+
+</details>
+
+### `MenuButton`
+
+- **`disabled`**
+  <code>boolean | undefined</code>
+
+  Same as the HTML attribute.
+
+- **`focusable`**
+  <code>boolean | undefined</code>
+
+  When an element is `disabled`, it may still be `focusable`. It works
+similarly to `readOnly` on form elements. In this case, only
+`aria-disabled` will be set.
+
+<details><summary>9 state props</summary>
+
+> These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
+
+- **`visible`**
+  <code>boolean</code>
+
+  Whether it's visible or not.
+
+- **`baseId`**
+  <code>string</code>
+
+  ID that will serve as a base for all the items IDs.
+
+- **`toggle`**
+  <code>() =&#62; void</code>
+
+  Toggles the `visible` state
+
+- **`unstable_referenceRef`** <span title="Experimental">⚠️</span>
+  <code>RefObject&#60;HTMLElement | null&#62;</code>
+
+  The reference element.
+
+- **`hide`**
+  <code>() =&#62; void</code>
+
+  Changes the `visible` state to `false`
+
+- **`placement`**
+  <code title="&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start&#34; | &#34;top&#34; | &#34;top-end&#34; | &#34;right-start&#34; | &#34;right&#34; | &#34;right-end&#34; | &#34;bottom-end&#34; | &#34;bottom&#34; | &#34;bottom-start&#34; | &#34;left-end&#34; | &#34;left&#34; | &#34;left-start&#34;">&#34;auto-start&#34; | &#34;auto&#34; | &#34;auto-end&#34; | &#34;top-start...</code>
+
+  Actual `placement`.
+
+- **`first`**
+  <code>() =&#62; void</code>
+
+  Moves focus to the first element.
+
+- **`last`**
+  <code>() =&#62; void</code>
+
+  Moves focus to the last element.
+
+- **`show`**
+  <code>() =&#62; void</code>
+
+  Changes the `visible` state to `true`
 
 </details>
 

--- a/packages/reakit/src/Menu/__tests__/MenuButton-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/MenuButton-test.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { render } from "reakit-test-utils";
-import { MenuDisclosure } from "../MenuDisclosure";
+import { MenuButton } from "../MenuButton";
 
-const props: Parameters<typeof MenuDisclosure>[0] = {
+const props: Parameters<typeof MenuButton>[0] = {
   baseId: "base",
   toggle: jest.fn(),
   placement: "bottom",
@@ -13,9 +13,8 @@ const props: Parameters<typeof MenuDisclosure>[0] = {
 
 test("render", () => {
   const { baseElement } = render(
-    <MenuDisclosure {...props}>disclosure</MenuDisclosure>
+    <MenuButton {...props}>disclosure</MenuButton>
   );
-  expect(console).toHaveWarned();
   expect(baseElement).toMatchInlineSnapshot(`
     <body>
       <div>

--- a/packages/reakit/src/Menu/__tests__/MenuDisclosure-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/MenuDisclosure-test.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { render } from "reakit-test-utils";
-import { MenuDisclosure } from "../MenuDisclosure";
+import { MenuButton } from "../MenuButton";
 
-const props: Parameters<typeof MenuDisclosure>[0] = {
+const props: Parameters<typeof MenuButton>[0] = {
   baseId: "base",
   toggle: jest.fn(),
   placement: "bottom",
@@ -13,7 +13,7 @@ const props: Parameters<typeof MenuDisclosure>[0] = {
 
 test("render", () => {
   const { baseElement } = render(
-    <MenuDisclosure {...props}>disclosure</MenuDisclosure>
+    <MenuButton {...props}>disclosure</MenuButton>
   );
   expect(baseElement).toMatchInlineSnapshot(`
     <body>

--- a/packages/reakit/src/Menu/__tests__/index-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/index-test.tsx
@@ -11,13 +11,13 @@ import {
 import {
   useMenuState,
   Menu,
-  MenuDisclosure,
+  MenuButton,
   MenuItem,
   MenuGroup,
   MenuBar,
   MenuItemRadio,
   MenuItemCheckbox,
-  MenuDisclosureHTMLProps
+  MenuButtonHTMLProps
 } from "..";
 
 test("menu bar is always visible", async () => {
@@ -35,7 +35,7 @@ test("clicking on disclosure opens menu and focus the first menu item", async ()
     const menu = useMenuState();
     return (
       <>
-        <MenuDisclosure {...menu}>disclosure</MenuDisclosure>
+        <MenuButton {...menu}>disclosure</MenuButton>
         <Menu {...menu} aria-label="menu">
           <MenuItem {...menu}>item1</MenuItem>
           <MenuItem {...menu}>item2</MenuItem>
@@ -78,13 +78,13 @@ test("hovering menu item moves focus to it", async () => {
 
 test("hovering out expanded menu item disclosure does not moves focus", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState();
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -125,13 +125,13 @@ test("hovering out expanded menu item disclosure does not moves focus", async ()
 
 test("clicking on menu item disclosure opens submenu without moving focus", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState();
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -162,13 +162,13 @@ test("clicking on menu item disclosure opens submenu without moving focus", asyn
 
 test("focusing menu item disclosure does not open submenu", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState();
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -198,13 +198,13 @@ test("focusing menu item disclosure does not open submenu", async () => {
 
 test("pressing enter on menu item disclosure opens submenu and focus the first item", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState();
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -238,13 +238,13 @@ test("pressing enter on menu item disclosure opens submenu and focus the first i
 
 test("pressing space on menu item disclosure opens submenu and focus the first item", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState();
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -278,13 +278,13 @@ test("pressing space on menu item disclosure opens submenu and focus the first i
 
 test("hovering menu item disclosure moves focus into it and opens submenu after a short delay without moving focus", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState();
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -298,7 +298,7 @@ test("hovering menu item disclosure moves focus into it and opens submenu after 
     const menu = useMenuState();
     return (
       <>
-        <MenuDisclosure {...menu}>disclosure</MenuDisclosure>
+        <MenuButton {...menu}>disclosure</MenuButton>
         <Menu {...menu} aria-label="menu">
           <MenuItem {...menu}>item1</MenuItem>
           <MenuItem {...menu}>{props => <Submenu {...props} />}</MenuItem>
@@ -326,7 +326,7 @@ test("arrow down on disclosure opens bottom menu and focus first item", async ()
     const menu = useMenuState({ placement: "bottom-end" });
     return (
       <>
-        <MenuDisclosure {...menu}>disclosure</MenuDisclosure>
+        <MenuButton {...menu}>disclosure</MenuButton>
         <Menu {...menu} aria-label="menu">
           <MenuItem {...menu}>item1</MenuItem>
           <MenuItem {...menu}>item2</MenuItem>
@@ -357,7 +357,7 @@ test("arrow down on disclosure opens top menu and focus first item", async () =>
     const menu = useMenuState({ placement: "top" });
     return (
       <>
-        <MenuDisclosure {...menu}>disclosure</MenuDisclosure>
+        <MenuButton {...menu}>disclosure</MenuButton>
         <Menu {...menu} aria-label="menu">
           <MenuItem {...menu}>item1</MenuItem>
           <MenuItem {...menu}>item2</MenuItem>
@@ -388,7 +388,7 @@ test("arrow up on disclosure opens bottom menu and focus last item", async () =>
     const menu = useMenuState({ placement: "bottom" });
     return (
       <>
-        <MenuDisclosure {...menu}>disclosure</MenuDisclosure>
+        <MenuButton {...menu}>disclosure</MenuButton>
         <Menu {...menu} aria-label="menu">
           <MenuItem {...menu}>item1</MenuItem>
           <MenuItem {...menu}>item2</MenuItem>
@@ -419,7 +419,7 @@ test("arrow up on disclosure opens top menu and focus last item", async () => {
     const menu = useMenuState({ placement: "top-start" });
     return (
       <>
-        <MenuDisclosure {...menu}>disclosure</MenuDisclosure>
+        <MenuButton {...menu}>disclosure</MenuButton>
         <Menu {...menu} aria-label="menu">
           <MenuItem {...menu}>item1</MenuItem>
           <MenuItem {...menu}>item2</MenuItem>
@@ -450,7 +450,7 @@ test("arrow right on disclosure opens right menu and focus first item", async ()
     const menu = useMenuState({ placement: "right" });
     return (
       <>
-        <MenuDisclosure {...menu}>disclosure</MenuDisclosure>
+        <MenuButton {...menu}>disclosure</MenuButton>
         <Menu {...menu} aria-label="menu">
           <MenuItem {...menu}>item1</MenuItem>
           <MenuItem {...menu}>item2</MenuItem>
@@ -481,7 +481,7 @@ test("arrow left on disclosure opens left menu and focus first item", async () =
     const menu = useMenuState({ placement: "left" });
     return (
       <>
-        <MenuDisclosure {...menu}>disclosure</MenuDisclosure>
+        <MenuButton {...menu}>disclosure</MenuButton>
         <Menu {...menu} aria-label="menu">
           <MenuItem {...menu}>item1</MenuItem>
           <MenuItem {...menu}>item2</MenuItem>
@@ -509,13 +509,13 @@ test("arrow left on disclosure opens left menu and focus first item", async () =
 
 test("arrow right on menu item disclosure opens right submenu and focus first item", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState();
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -529,7 +529,7 @@ test("arrow right on menu item disclosure opens right submenu and focus first it
     const menu = useMenuState();
     return (
       <>
-        <MenuDisclosure {...menu}>disclosure</MenuDisclosure>
+        <MenuButton {...menu}>disclosure</MenuButton>
         <Menu {...menu} aria-label="menu">
           <MenuItem {...menu}>item1</MenuItem>
           <MenuItem {...menu}>{props => <Submenu {...props} />}</MenuItem>
@@ -558,13 +558,13 @@ test("arrow right on menu item disclosure opens right submenu and focus first it
 
 test("arrow left on menu item disclosure opens left submenu and focus first item", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState({ placement: "left" });
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -648,13 +648,13 @@ test("arrow down on menu focus first item", async () => {
 
 test("focusing menubar item disclosure opens the submenu without moving focus", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState();
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -685,13 +685,13 @@ test("focusing menubar item disclosure opens the submenu without moving focus", 
 
 test("clicking on menubar item disclosure opens the submenu without moving focus", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState();
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -731,13 +731,13 @@ test("clicking on menubar item disclosure opens the submenu without moving focus
 
 test("hovering menubar item disclosure does not move focus into it", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState();
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -768,15 +768,15 @@ test("hovering menubar item disclosure does not move focus into it", async () =>
 test("hovering menubar item disclosure moves focus into it if there is another submenu opened", async () => {
   const Submenu = React.forwardRef(
     (
-      { index, ...props }: { index: number } & MenuDisclosureHTMLProps,
+      { index, ...props }: { index: number } & MenuButtonHTMLProps,
       ref: React.RefObject<any>
     ) => {
       const menu = useMenuState();
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure{index}
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label={`submenu${index}`}>
             <MenuItem {...menu}>submenu{index}item1</MenuItem>
             <MenuItem {...menu}>submenu{index}item2</MenuItem>
@@ -815,13 +815,13 @@ test("hovering menubar item disclosure moves focus into it if there is another s
 
 test("pressing enter on menubar item disclosure focus submenu first item", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState();
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -855,13 +855,13 @@ test("pressing enter on menubar item disclosure focus submenu first item", async
 
 test("pressing space on menubar item disclosure focus submenu first item", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState();
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -941,13 +941,13 @@ test("move focus within menu with arrow keys", async () => {
 
 test("move focus within submenu with arrow keys", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState();
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -961,7 +961,7 @@ test("move focus within submenu with arrow keys", async () => {
     const menu = useMenuState();
     return (
       <>
-        <MenuDisclosure {...menu}>disclosure</MenuDisclosure>
+        <MenuButton {...menu}>disclosure</MenuButton>
         <Menu {...menu} aria-label="menu">
           <MenuItem {...menu}>item1</MenuItem>
           <MenuItem {...menu}>{props => <Submenu {...props} />}</MenuItem>
@@ -1053,9 +1053,9 @@ test("move focus within submenu with ascii keys", async () => {
         <MenuItem {...menu1}>Def</MenuItem>
         <MenuItem {...menu1}>
           {props => (
-            <MenuDisclosure {...props} {...menu2}>
+            <MenuButton {...props} {...menu2}>
               Ghi
-            </MenuDisclosure>
+            </MenuButton>
           )}
         </MenuItem>
         <Menu aria-label="menu2" {...menu2}>
@@ -1129,15 +1129,15 @@ test("move focus within menubar with ascii keys", async () => {
 test("arrow right/left in a submenu moves focus between disclosures in menubar", async () => {
   const Submenu = React.forwardRef(
     (
-      { index, ...props }: { index: number } & MenuDisclosureHTMLProps,
+      { index, ...props }: { index: number } & MenuButtonHTMLProps,
       ref: React.RefObject<any>
     ) => {
       const menu = useMenuState();
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             item{index}
-          </MenuDisclosure>
+          </MenuButton>
           <Menu aria-label={`submenu${index}`} {...menu}>
             <MenuItem {...menu}>submenu{index}item1</MenuItem>
             <MenuItem {...menu}>submenu{index}item2</MenuItem>
@@ -1196,7 +1196,7 @@ test("clicking on menu disclorure closes the menu", async () => {
     const menu = useMenuState({ visible: true });
     return (
       <>
-        <MenuDisclosure {...menu}>disclosure</MenuDisclosure>
+        <MenuButton {...menu}>disclosure</MenuButton>
         <Menu {...menu} aria-label="menu">
           <MenuItem {...menu}>item1</MenuItem>
           <MenuItem {...menu}>item2</MenuItem>
@@ -1216,13 +1216,13 @@ test("clicking on menu disclorure closes the menu", async () => {
 
 test("clicking outside the menu closes it", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState({ visible: true });
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -1236,7 +1236,7 @@ test("clicking outside the menu closes it", async () => {
     const menu = useMenuState({ visible: true });
     return (
       <>
-        <MenuDisclosure {...menu}>disclosure</MenuDisclosure>
+        <MenuButton {...menu}>disclosure</MenuButton>
         <Menu {...menu} aria-label="menu">
           <MenuItem {...menu}>item1</MenuItem>
           <MenuItem {...menu}>{props => <Submenu {...props} />}</MenuItem>
@@ -1257,13 +1257,13 @@ test("clicking outside the menu closes it", async () => {
 
 test("focusing outside the menu closes it", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState({ visible: true });
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -1278,7 +1278,7 @@ test("focusing outside the menu closes it", async () => {
     return (
       <>
         <button>button</button>
-        <MenuDisclosure {...menu}>disclosure</MenuDisclosure>
+        <MenuButton {...menu}>disclosure</MenuButton>
         <Menu {...menu} aria-label="menu">
           <MenuItem {...menu}>item1</MenuItem>
           <MenuItem {...menu}>{props => <Submenu {...props} />}</MenuItem>
@@ -1301,13 +1301,13 @@ test("focusing outside the menu closes it", async () => {
 
 test("focusing outside the submenu closes it", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState({ visible: true });
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -1321,7 +1321,7 @@ test("focusing outside the submenu closes it", async () => {
     const menu = useMenuState({ visible: true });
     return (
       <>
-        <MenuDisclosure {...menu}>disclosure</MenuDisclosure>
+        <MenuButton {...menu}>disclosure</MenuButton>
         <Menu {...menu} aria-label="menu">
           <MenuItem {...menu}>item1</MenuItem>
           <MenuItem {...menu}>{props => <Submenu {...props} />}</MenuItem>
@@ -1343,13 +1343,13 @@ test("focusing outside the submenu closes it", async () => {
 
 test("pressing esc closes all menus", async () => {
   const Submenu = React.forwardRef(
-    (props: MenuDisclosureHTMLProps, ref: React.RefObject<any>) => {
+    (props: MenuButtonHTMLProps, ref: React.RefObject<any>) => {
       const menu = useMenuState({ visible: true });
       return (
         <>
-          <MenuDisclosure {...menu} {...props} ref={ref}>
+          <MenuButton {...menu} {...props} ref={ref}>
             subdisclosure
-          </MenuDisclosure>
+          </MenuButton>
           <Menu {...menu} aria-label="submenu">
             <MenuItem {...menu}>subitem1</MenuItem>
             <MenuItem {...menu}>subitem2</MenuItem>
@@ -1363,7 +1363,7 @@ test("pressing esc closes all menus", async () => {
     const menu = useMenuState({ visible: true });
     return (
       <>
-        <MenuDisclosure {...menu}>disclosure</MenuDisclosure>
+        <MenuButton {...menu}>disclosure</MenuButton>
         <Menu {...menu} aria-label="menu">
           <MenuItem {...menu}>item1</MenuItem>
           <MenuItem {...menu}>{props => <Submenu {...props} />}</MenuItem>
@@ -1391,7 +1391,7 @@ test("pressing esc on disclosure closes the menu", async () => {
     const menu = useMenuState({ visible: true });
     return (
       <>
-        <MenuDisclosure {...menu}>disclosure</MenuDisclosure>
+        <MenuButton {...menu}>disclosure</MenuButton>
         <Menu {...menu} aria-label="menu">
           <MenuItem {...menu}>item1</MenuItem>
           <MenuItem {...menu}>item2</MenuItem>

--- a/packages/reakit/src/Menu/index.ts
+++ b/packages/reakit/src/Menu/index.ts
@@ -2,6 +2,7 @@ export * from "./Menu";
 export * from "./MenuArrow";
 export * from "./MenuBar";
 export * from "./MenuBarState";
+export * from "./MenuButton";
 export * from "./MenuDisclosure";
 export * from "./MenuGroup";
 export * from "./MenuItem";

--- a/packages/reakit/src/Popover/README.md
+++ b/packages/reakit/src/Popover/README.md
@@ -197,7 +197,7 @@ Learn more in [Accessibility](/docs/accessibility/).
 - `Popover` uses [Dialog](/docs/dialog/), and is used by [Menu](/docs/menu/).
 - `PopoverArrow` uses [Box](/docs/box/), and is used by [TooltipArrow](/docs/tooltip/).
 - `PopoverBackdrop` uses [DialogBackdrop](/docs/dialog/).
-- `PopoverDisclosure` uses [DialogDisclosure](/docs/dialog/), and is used by [MenuDisclosure](/docs/menu/).
+- `PopoverDisclosure` uses [DialogDisclosure](/docs/dialog/), and is used by [MenuButton](/docs/menu/).
 
 Learn more in [Composition](/docs/composition/#props-hooks).
 

--- a/packages/reakit/src/Toolbar/README.md
+++ b/packages/reakit/src/Toolbar/README.md
@@ -57,14 +57,14 @@ You can render [Menu](/docs/menu/) within a `Toolbar` using the same techinique 
 ```jsx
 import React from "react";
 import { useToolbarState, Toolbar, ToolbarItem } from "reakit/Toolbar";
-import { useMenuState, MenuDisclosure, Menu, MenuItem } from "reakit/Menu";
+import { useMenuState, MenuButton, Menu, MenuItem } from "reakit/Menu";
 import { Button } from "reakit/Button";
 
 const MoreItems = React.forwardRef((props, ref) => {
   const menu = useMenuState({ placement: "bottom-end" });
   return (
     <>
-      <MenuDisclosure {...menu} {...props} ref={ref} aria-label="More items" />
+      <MenuButton {...menu} {...props} ref={ref} aria-label="More items" />
       <Menu {...menu} aria-label="More items">
         <MenuItem {...menu}>Item 3</MenuItem>
         <MenuItem {...menu}>Item 4</MenuItem>

--- a/packages/website/src/components/HomePlayground.tsx
+++ b/packages/website/src/components/HomePlayground.tsx
@@ -61,16 +61,16 @@ const TabsModal = React.forwardRef((props, ref) => {
 `.trim();
 
 const menuCode = `
-import { useMenuState, Menu, MenuDisclosure, MenuItem } from "reakit";
+import { useMenuState, Menu, MenuButton, MenuItem } from "reakit";
 import TabsModal from "./TabsModal";
 
 const TabsModalMenu = React.forwardRef((props, ref) => {
   const menu = useMenuState();
   return (
     <>
-      <MenuDisclosure {...menu} {...props} ref={ref}>
+      <MenuButton {...menu} {...props} ref={ref}>
         Menu
-      </MenuDisclosure>
+      </MenuButton>
       <Menu {...menu}>
         <MenuItem {...menu}>Item 1</MenuItem>
         <MenuItem {...menu}>Item 2</MenuItem>
@@ -82,16 +82,16 @@ const TabsModalMenu = React.forwardRef((props, ref) => {
 `.trim();
 
 const submenuCode = `
-import { useMenuState, Menu, MenuDisclosure, MenuItem } from "reakit";
+import { useMenuState, Menu, MenuButton, MenuItem } from "reakit";
 import TabsModalMenu from "./TabsModalMenu";
 
 const TabsModalMenuMenu = React.forwardRef((props, ref) => {
   const menu = useMenuState();
   return (
     <>
-      <MenuDisclosure {...menu} {...props} ref={ref}>
+      <MenuButton {...menu} {...props} ref={ref}>
         Menu
-      </MenuDisclosure>
+      </MenuButton>
       <Menu {...menu}>
         <MenuItem {...menu}>Item 1</MenuItem>
         <MenuItem {...menu}>Item 2</MenuItem>

--- a/stories/index.stories.tsx
+++ b/stories/index.stories.tsx
@@ -6,7 +6,7 @@ import {
   useDialogState,
   DialogDisclosure,
   useMenuState,
-  MenuDisclosure,
+  MenuButton,
   Menu,
   MenuItem,
   Tooltip,
@@ -41,7 +41,7 @@ storiesOf("Menu", module).add("Animated menu", () => {
     const menu = useMenuState({ unstable_animated: true });
     return (
       <>
-        <MenuDisclosure {...menu}>Menu</MenuDisclosure>
+        <MenuButton {...menu}>Menu</MenuButton>
         <Menu
           {...menu}
           aria-label="Menu"
@@ -80,7 +80,7 @@ storiesOf("Menu", module)
 
       return (
         <Provider unstable_system={system}>
-          <MenuDisclosure {...menu}>Menu</MenuDisclosure>
+          <MenuButton {...menu}>Menu</MenuButton>
           <Menu
             {...menu}
             as={animated.div}
@@ -127,7 +127,7 @@ storiesOf("Menu", module)
       const menu = useMenuState();
       return (
         <Provider unstable_system={system}>
-          <MenuDisclosure {...menu}>Menu</MenuDisclosure>
+          <MenuButton {...menu}>Menu</MenuButton>
           <Menu {...menu} aria-label="Menu">
             <MenuItem {...menu}>a</MenuItem>
             <MenuItem {...menu}>b</MenuItem>


### PR DESCRIPTION
This PR follows the same line of thought as #541. There's a dedicated section on the WAI-ARIA Authoring Practices website named `Menu Button`: https://www.w3.org/TR/wai-aria-practices/#menubutton

This is probably our last renaming before v1.0 gets out of beta.

**Does this PR introduce a breaking change?**

No, only deprecation warnings.