### PR TITLE
feat: Upgrade to popper.js v2

### DIFF
--- a/packages/reakit-system-bootstrap/src/Menu.tsx
+++ b/packages/reakit-system-bootstrap/src/Menu.tsx
@@ -103,28 +103,22 @@ export function useMenuOptions({
   unstable_system: { palette = "background", fill = "opaque", ...system } = {},
   ...options
 }: BootstrapMenuOptions): BootstrapMenuOptions {
-  const parentMenuOrientation = React.useContext(OrientationContext);
+  const parentOrientation = React.useContext(OrientationContext);
+  const unstable_system = { palette, fill, ...system };
+  const transform = options.unstable_popoverStyles?.transform || "";
 
-  if (
-    parentMenuOrientation &&
-    parentMenuOrientation !== "horizontal" &&
-    options.orientation === "vertical"
-  ) {
+  if (parentOrientation === "vertical" && options.orientation === "vertical") {
     return {
-      unstable_system: { palette, fill, ...system },
       ...options,
+      unstable_system,
       unstable_popoverStyles: {
         ...options.unstable_popoverStyles,
-        transform: `${options.unstable_popoverStyles?.transform ||
-          ""} translate3d(0px, -0.3em, 0px)`
+        transform: `${transform} translate3d(0px, -0.3em, 0px)`
       }
     };
   }
 
-  return {
-    unstable_system: { palette, fill, ...system },
-    ...options
-  };
+  return { ...options, unstable_system };
 }
 
 export function useMenuProps(

--- a/packages/reakit-system-bootstrap/src/Menu.tsx
+++ b/packages/reakit-system-bootstrap/src/Menu.tsx
@@ -20,6 +20,7 @@ import { useContrast } from "reakit-system-palette/utils/contrast";
 import { useDarken } from "reakit-system-palette/utils/darken";
 import { usePalette } from "reakit-system-palette/utils/palette";
 import { MenuStateReturn } from "reakit/Menu/MenuState";
+import { usePipe } from "reakit-utils/usePipe";
 import { BootstrapBoxOptions } from "./Box";
 
 export type BootstrapMenuBarOptions = BootstrapBoxOptions & MenuBarOptions;
@@ -94,10 +95,32 @@ export function useMenuItemProps(
 
 export type BootstrapMenuOptions = BootstrapBoxOptions & MenuOptions;
 
+const OrientationContext = React.createContext<
+  "horizontal" | "vertical" | undefined
+>(undefined);
+
 export function useMenuOptions({
   unstable_system: { palette = "background", fill = "opaque", ...system } = {},
   ...options
 }: BootstrapMenuOptions): BootstrapMenuOptions {
+  const parentMenuOrientation = React.useContext(OrientationContext);
+
+  if (
+    parentMenuOrientation &&
+    parentMenuOrientation !== "horizontal" &&
+    options.orientation === "vertical"
+  ) {
+    return {
+      unstable_system: { palette, fill, ...system },
+      ...options,
+      unstable_popoverStyles: {
+        ...options.unstable_popoverStyles,
+        transform: `${options.unstable_popoverStyles?.transform ||
+          ""} translate3d(0px, -0.3em, 0px)`
+      }
+    };
+  }
+
   return {
     unstable_system: { palette, fill, ...system },
     ...options
@@ -105,19 +128,28 @@ export function useMenuOptions({
 }
 
 export function useMenuProps(
-  _: BootstrapMenuOptions,
+  options: BootstrapMenuOptions,
   htmlProps: MenuHTMLProps = {}
 ): MenuHTMLProps {
   const menu = css`
     display: flex;
     border-radius: 0;
-
-    &:not([aria-orientation="horizontal"]) > &[aria-orientation="vertical"] {
-      margin-top: -0.3em;
-    }
   `;
 
-  return { ...htmlProps, className: cx(menu, htmlProps.className) };
+  const wrapElement = React.useCallback(
+    (element: React.ReactNode) => (
+      <OrientationContext.Provider value={options.orientation}>
+        {element}
+      </OrientationContext.Provider>
+    ),
+    [options.orientation]
+  );
+
+  return {
+    ...htmlProps,
+    wrapElement: usePipe(wrapElement, htmlProps.wrapElement),
+    className: cx(menu, htmlProps.className)
+  };
 }
 
 export type BootstrapMenuDisclosureOptions = BootstrapBoxOptions &

--- a/packages/reakit/package.json
+++ b/packages/reakit/package.json
@@ -38,8 +38,8 @@
     "components"
   ],
   "dependencies": {
+    "@popperjs/core": "^2.0.5",
     "body-scroll-lock": "^2.6.4",
-    "popper.js": "^1.16.1",
     "reakit-system": "^0.8.0",
     "reakit-utils": "^0.8.0"
   },

--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -542,18 +542,8 @@ by default.
   Flip the popover's placement when it starts to overlap its reference
 element.
 
-- **`unstable_shift`** <span title="Experimental">⚠️</span>
-  <code>boolean | undefined</code>
-
-  Shift popover on the start or end of its reference element.
-
-- **`unstable_inner`** <span title="Experimental">⚠️</span>
-  <code>boolean | undefined</code>
-
-  Position the popover inside the reference element.
-
 - **`unstable_offset`** <span title="Experimental">⚠️</span>
-  <code title="readonly [string | number, string | number] | undefined">readonly [string | number, string | number] | u...</code>
+  <code>[string | number, string | number] | undefined</code>
 
   Offset between the reference and the popover: [main axis, alt axis]. Should not be combined with `gutter`.
 
@@ -566,11 +556,6 @@ element.
   <code>boolean | undefined</code>
 
   Prevents popover from being positioned outside the boundary.
-
-- **`unstable_boundariesElement`** <span title="Experimental">⚠️</span>
-  <code>&#34;scrollParent&#34; | &#34;viewport&#34; | &#34;window&#34; | undefined</code>
-
-  Boundaries element used by `preventOverflow`.
 
 ### `Menu`
 

--- a/packages/reakit/src/Menu/__tests__/MenuArrow-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/MenuArrow-test.tsx
@@ -8,9 +8,10 @@ test("render", () => {
     <body>
       <div>
         <div
-          style="top: 100%; position: absolute; font-size: 30px; width: 1em; height: 1em; pointer-events: none; transform: rotateZ(180deg);"
+          style="font-size: 30px; width: 1em; height: 1em; pointer-events: none; top: 100%;"
         >
           <svg
+            style="transform: rotateZ(180deg);"
             viewBox="0 0 30 30"
           >
             <path

--- a/packages/reakit/src/Popover/PopoverArrow.tsx
+++ b/packages/reakit/src/Popover/PopoverArrow.tsx
@@ -44,19 +44,22 @@ export const usePopoverArrow = createHook<
     return {
       ref: useForkRef(options.unstable_arrowRef, htmlRef),
       style: {
-        ...arrowStyles,
-        top: arrowStyles ? arrowStyles.top || undefined : undefined,
         position: "absolute",
+        ...arrowStyles,
         fontSize: options.size,
         width: "1em",
         height: "1em",
         pointerEvents: "none",
-        transform: transformMap[placement as keyof typeof transformMap],
         [placement]: "100%",
         ...htmlStyle
       },
       children: (
-        <svg viewBox="0 0 30 30">
+        <svg
+          viewBox="0 0 30 30"
+          style={{
+            transform: `${transformMap[placement as keyof typeof transformMap]}`
+          }}
+        >
           <path
             className="stroke"
             d="M23.7,27.1L17,19.9C16.5,19.3,15.8,19,15,19s-1.6,0.3-2.1,0.9l-6.6,7.2C5.3,28.1,3.4,29,2,29h26

--- a/packages/reakit/src/Popover/PopoverArrow.tsx
+++ b/packages/reakit/src/Popover/PopoverArrow.tsx
@@ -34,17 +34,18 @@ export const usePopoverArrow = createHook<
 
   useProps(options, { ref: htmlRef, style: htmlStyle, ...htmlProps }) {
     const [placement] = options.placement.split("-");
-    const transformMap = {
+    const transformMap: Record<string, string> = {
       top: "rotateZ(180deg)",
       right: "rotateZ(-90deg)",
       bottom: "rotateZ(360deg)",
       left: "rotateZ(90deg)"
     };
     const { unstable_arrowStyles: arrowStyles } = options;
+    const transform = transformMap[placement];
+
     return {
       ref: useForkRef(options.unstable_arrowRef, htmlRef),
       style: {
-        position: "absolute",
         ...arrowStyles,
         fontSize: options.size,
         width: "1em",
@@ -54,12 +55,7 @@ export const usePopoverArrow = createHook<
         ...htmlStyle
       },
       children: (
-        <svg
-          viewBox="0 0 30 30"
-          style={{
-            transform: `${transformMap[placement as keyof typeof transformMap]}`
-          }}
-        >
+        <svg viewBox="0 0 30 30" style={{ transform }}>
           <path
             className="stroke"
             d="M23.7,27.1L17,19.9C16.5,19.3,15.8,19,15,19s-1.6,0.3-2.1,0.9l-6.6,7.2C5.3,28.1,3.4,29,2,29h26

--- a/packages/reakit/src/Popover/README.md
+++ b/packages/reakit/src/Popover/README.md
@@ -250,18 +250,8 @@ by default.
   Flip the popover's placement when it starts to overlap its reference
 element.
 
-- **`unstable_shift`** <span title="Experimental">⚠️</span>
-  <code>boolean | undefined</code>
-
-  Shift popover on the start or end of its reference element.
-
-- **`unstable_inner`** <span title="Experimental">⚠️</span>
-  <code>boolean | undefined</code>
-
-  Position the popover inside the reference element.
-
 - **`unstable_offset`** <span title="Experimental">⚠️</span>
-  <code title="readonly [string | number, string | number] | undefined">readonly [string | number, string | number] | u...</code>
+  <code>[string | number, string | number] | undefined</code>
 
   Offset between the reference and the popover: [main axis, alt axis]. Should not be combined with `gutter`.
 
@@ -274,11 +264,6 @@ element.
   <code>boolean | undefined</code>
 
   Prevents popover from being positioned outside the boundary.
-
-- **`unstable_boundariesElement`** <span title="Experimental">⚠️</span>
-  <code>&#34;scrollParent&#34; | &#34;viewport&#34; | &#34;window&#34; | undefined</code>
-
-  Boundaries element used by `preventOverflow`.
 
 ### `Popover`
 

--- a/packages/reakit/src/Popover/__tests__/PopoverArrow-test.tsx
+++ b/packages/reakit/src/Popover/__tests__/PopoverArrow-test.tsx
@@ -8,9 +8,10 @@ test("render", () => {
     <body>
       <div>
         <div
-          style="top: 100%; position: absolute; font-size: 30px; width: 1em; height: 1em; pointer-events: none; transform: rotateZ(180deg);"
+          style="font-size: 30px; width: 1em; height: 1em; pointer-events: none; top: 100%;"
         >
           <svg
+            style="transform: rotateZ(180deg);"
             viewBox="0 0 30 30"
           >
             <path
@@ -34,9 +35,10 @@ test("render bottom", () => {
     <body>
       <div>
         <div
-          style="position: absolute; font-size: 30px; width: 1em; height: 1em; pointer-events: none; transform: rotateZ(360deg); bottom: 100%;"
+          style="font-size: 30px; width: 1em; height: 1em; pointer-events: none; bottom: 100%;"
         >
           <svg
+            style="transform: rotateZ(360deg);"
             viewBox="0 0 30 30"
           >
             <path

--- a/packages/reakit/src/Tooltip/README.md
+++ b/packages/reakit/src/Tooltip/README.md
@@ -175,18 +175,8 @@ given milliseconds.
   Flip the popover's placement when it starts to overlap its reference
 element.
 
-- **`unstable_shift`** <span title="Experimental">⚠️</span>
-  <code>boolean | undefined</code>
-
-  Shift popover on the start or end of its reference element.
-
-- **`unstable_inner`** <span title="Experimental">⚠️</span>
-  <code>boolean | undefined</code>
-
-  Position the popover inside the reference element.
-
 - **`unstable_offset`** <span title="Experimental">⚠️</span>
-  <code title="readonly [string | number, string | number] | undefined">readonly [string | number, string | number] | u...</code>
+  <code>[string | number, string | number] | undefined</code>
 
   Offset between the reference and the popover: [main axis, alt axis]. Should not be combined with `gutter`.
 
@@ -199,11 +189,6 @@ element.
   <code>boolean | undefined</code>
 
   Prevents popover from being positioned outside the boundary.
-
-- **`unstable_boundariesElement`** <span title="Experimental">⚠️</span>
-  <code>&#34;scrollParent&#34; | &#34;viewport&#34; | &#34;window&#34; | undefined</code>
-
-  Boundaries element used by `preventOverflow`.
 
 ### `Tooltip`
 

--- a/packages/reakit/src/Tooltip/TooltipState.ts
+++ b/packages/reakit/src/Tooltip/TooltipState.ts
@@ -26,12 +26,8 @@ export type TooltipStateReturn = Omit<
 export function useTooltipState(
   initialState: SealedInitialState<TooltipInitialState> = {}
 ): TooltipStateReturn {
-  const {
-    placement = "top",
-    unstable_boundariesElement = "window",
-    ...sealed
-  } = useSealedState(initialState);
-  return usePopoverState({ ...sealed, placement, unstable_boundariesElement });
+  const { placement = "top", ...sealed } = useSealedState(initialState);
+  return usePopoverState({ ...sealed, placement });
 }
 
 const keys: Array<keyof PopoverStateReturn | keyof TooltipStateReturn> = [

--- a/packages/reakit/src/Tooltip/__tests__/TooltipArrow-test.tsx
+++ b/packages/reakit/src/Tooltip/__tests__/TooltipArrow-test.tsx
@@ -8,9 +8,10 @@ test("render", () => {
     <body>
       <div>
         <div
-          style="top: 100%; position: absolute; font-size: 16px; width: 1em; height: 1em; pointer-events: none; transform: rotateZ(180deg);"
+          style="font-size: 16px; width: 1em; height: 1em; pointer-events: none; top: 100%;"
         >
           <svg
+            style="transform: rotateZ(180deg);"
             viewBox="0 0 30 30"
           >
             <path

--- a/yarn.lock
+++ b/yarn.lock
@@ -4859,6 +4859,11 @@
     string-width "^2.0.0"
     strip-ansi "^3"
 
+"@popperjs/core@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.0.5.tgz#90ff3013c747c499c8b1d9684b63a7334a057f7d"
+  integrity sha512-YOV1TitTNzJDXe/14sDJO/M/aL12Jhind0EkQRnqTX2167fqJsAICJfi0vsDdapPI1WaYsheyYYgy6PO02Nqqg==
+
 "@reach/router@1.2.1", "@reach/router@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"
@@ -18134,11 +18139,6 @@ popper.js@^1.14.4, popper.js@^1.14.7:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.15.0.tgz#5560b99bbad7647e9faa475c6b8056621f5a4ff2"
   integrity sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==
-
-popper.js@^1.16.1:
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
-  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
 portfinder@^1.0.25:
   version "1.0.25"


### PR DESCRIPTION
Upgrade popper.js to v2

**Does this PR introduce a breaking change?**

- The internal `popper.js` dependency has been upgraded to `v2`. The stable `Popover` API remains the same. But, while this change has been tested with the most common use cases, there may be some edge cases where `Popover` and `Menu` (which uses `Popover` underneath) may behave differently.