### PR TITLE
fix: Remove confusing `rover.unregister()` warning

### DIFF
--- a/packages/reakit/src/Rover/Rover.ts
+++ b/packages/reakit/src/Rover/Rover.ts
@@ -104,8 +104,8 @@ export const useRover = createHook<RoverOptions, RoverHTMLProps>({
         createOnKeyDown({
           onKeyDown: htmlOnKeyDown,
           stopPropagation: true,
-          // Ignore portals
           shouldKeyDown: event =>
+            // Ignore portals
             // https://github.com/facebook/react/issues/11387
             event.currentTarget.contains(event.target as Node),
           keyMap: {

--- a/packages/reakit/src/Rover/RoverState.ts
+++ b/packages/reakit/src/Rover/RoverState.ts
@@ -170,7 +170,6 @@ function reducer(
       const { id } = action;
       const nextStops = stops.filter(stop => stop.id !== id);
       if (nextStops.length === stops.length) {
-        warning(true, "[reakit/RoverState]", `${id} stop is not registered`);
         return state;
       }
 

--- a/packages/reakit/src/Rover/__tests__/RoverState-test.ts
+++ b/packages/reakit/src/Rover/__tests__/RoverState-test.ts
@@ -206,7 +206,6 @@ test("unregister", () => {
 test("unregister inexistent", () => {
   const result = render();
   act(() => result.current.unregister("a"));
-  expect(console).toHaveWarned();
   expect(result.current).toMatchInlineSnapshot(`
     Object {
       "baseId": "base",


### PR DESCRIPTION
Closes #488

`MenuItemRadio` composes from `MenuItem` and `Radio`. Both of them compose from `Rover`, which means that they will try to `register` and `unregister` an item twice. There's no problem with that. The result is "noop" for the second call. But this warning is indicating that a problem is happening and making users think that they need to fix something, which is not true.

**Does this PR introduce a breaking change?**

No