### PR TITLE
fix: Fix inconsistent `Tooltip` behavior on disabled `Tabbable`

### DIFF
--- a/packages/reakit/src/Checkbox/__tests__/Checkbox-test.tsx
+++ b/packages/reakit/src/Checkbox/__tests__/Checkbox-test.tsx
@@ -21,19 +21,20 @@ test("render", () => {
 test("render disabled", () => {
   const { baseElement } = render(<Checkbox disabled />);
   expect(baseElement).toMatchInlineSnapshot(`
-    <body>
-      <div>
-        <input
-          aria-checked="false"
-          aria-disabled="true"
-          disabled=""
-          role="checkbox"
-          type="checkbox"
-          value=""
-        />
-      </div>
-    </body>
-  `);
+<body>
+  <div>
+    <input
+      aria-checked="false"
+      aria-disabled="true"
+      disabled=""
+      role="checkbox"
+      style="pointer-events: none;"
+      type="checkbox"
+      value=""
+    />
+  </div>
+</body>
+`);
 });
 
 test("render disabled focusable", () => {

--- a/packages/reakit/src/Form/__tests__/FormSubmitButton-test.tsx
+++ b/packages/reakit/src/Form/__tests__/FormSubmitButton-test.tsx
@@ -22,14 +22,15 @@ test("disabled", () => {
     <FormSubmitButton baseId="base" submit={jest.fn()} disabled />
   );
   expect(baseElement).toMatchInlineSnapshot(`
-    <body>
-      <div>
-        <button
-          aria-disabled="true"
-          disabled=""
-          type="submit"
-        />
-      </div>
-    </body>
-  `);
+<body>
+  <div>
+    <button
+      aria-disabled="true"
+      disabled=""
+      style="pointer-events: none;"
+      type="submit"
+    />
+  </div>
+</body>
+`);
 });

--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -95,10 +95,9 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
     const trulyDisabled = options.disabled && !options.focusable;
     const [nativeTabbable, setNativeTabbable] = React.useState(true);
     const tabIndex = nativeTabbable ? htmlTabIndex : htmlTabIndex || 0;
-    const style =
-      options.disabled && !nativeTabbable
-        ? { pointerEvents: "none" as const, ...htmlStyle }
-        : htmlStyle;
+    const style = trulyDisabled
+      ? { pointerEvents: "none" as const, ...htmlStyle }
+      : htmlStyle;
 
     React.useEffect(() => {
       const tabbable = ref.current;

--- a/packages/reakit/src/Tabbable/__tests__/Tabbable-test.tsx
+++ b/packages/reakit/src/Tabbable/__tests__/Tabbable-test.tsx
@@ -14,13 +14,14 @@ test("render", () => {
 test("render disabled", () => {
   const { getByText } = render(<Tabbable disabled>tabbable</Tabbable>);
   expect(getByText("tabbable")).toMatchInlineSnapshot(`
-    <button
-      aria-disabled="true"
-      disabled=""
-    >
-      tabbable
-    </button>
-  `);
+<button
+  aria-disabled="true"
+  disabled=""
+  style="pointer-events: none;"
+>
+  tabbable
+</button>
+`);
 });
 
 test("render disabled focusable", () => {

--- a/packages/reakit/src/Tooltip/__tests__/index-test.tsx
+++ b/packages/reakit/src/Tooltip/__tests__/index-test.tsx
@@ -1,41 +1,23 @@
 import * as React from "react";
 import { render, hover, wait } from "reakit-test-utils";
-import {
-  Tooltip,
-  TooltipArrow,
-  TooltipReference,
-  useTooltipState,
-  TooltipInitialState
-} from "..";
+import { Tooltip, TooltipReference, useTooltipState } from "..";
 
-function Test(props: TooltipInitialState) {
-  const tooltip = useTooltipState(props);
-  return (
-    <>
-      <TooltipReference {...tooltip}>disclosure</TooltipReference>
-      <Tooltip {...tooltip} aria-label="tooltip" tabIndex={0}>
-        <TooltipArrow {...tooltip} />
-        tooltip
-      </Tooltip>
-    </>
-  );
-}
-
-test("show", async () => {
-  const { getByText } = render(<Test />);
-  const disclosure = getByText("disclosure");
+test("show tooltip on hover", async () => {
+  const Test = () => {
+    const tooltip = useTooltipState();
+    return (
+      <>
+        <TooltipReference {...tooltip}>reference</TooltipReference>
+        <Tooltip {...tooltip}>tooltip</Tooltip>
+      </>
+    );
+  };
+  const { baseElement, getByText } = render(<Test />);
+  const reference = getByText("reference");
   const tooltip = getByText("tooltip");
   expect(tooltip).not.toBeVisible();
-  hover(disclosure);
+  hover(reference);
   await wait(expect(tooltip).toBeVisible);
-});
-
-test("hide", async () => {
-  const { getByText, baseElement } = render(<Test visible />);
-  const disclosure = getByText("disclosure");
-  const tooltip = getByText("tooltip");
-  expect(tooltip).toBeVisible();
-  hover(disclosure);
   hover(baseElement);
   await wait(expect(tooltip).not.toBeVisible);
 });


### PR DESCRIPTION
Closes #471

While this issue should be fixed in the React side for all elements (https://github.com/facebook/react/issues/17229), this PR guarantees that Reakit's `Tabbable` will behave consistently with a `Tooltip`, even when used with non-native interactive elements (e.g. `<Tabbable as="div">`).

**Does this PR introduce a breaking change?**

No