### PR TITLE
fix: Fix `Tabbable` dispatching `click` twice when composed by another `Tabbable`

### DIFF
--- a/packages/reakit/src/Button/__tests__/Button-test.tsx
+++ b/packages/reakit/src/Button/__tests__/Button-test.tsx
@@ -25,11 +25,12 @@ test("render anchor", () => {
 test("render div", () => {
   const { getByText } = render(<Button as="div">button</Button>);
   expect(getByText("button")).toMatchInlineSnapshot(`
-    <div
-      role="button"
-      tabindex="0"
-    >
-      button
-    </div>
-  `);
+<div
+  data-tabbable="true"
+  role="button"
+  tabindex="0"
+>
+  button
+</div>
+`);
 });

--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -88,8 +88,9 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
       onMouseDown: htmlOnMouseDown,
       onKeyDown: htmlOnKeyDown,
       style: htmlStyle,
+      "data-tabbable": dataTabbable,
       ...htmlProps
-    }
+    }: TabbableHTMLProps & { "data-tabbable"?: boolean }
   ) {
     const ref = React.useRef<HTMLElement>(null);
     const trulyDisabled = options.disabled && !options.focusable;
@@ -154,7 +155,11 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
         if (
           options.disabled ||
           isNativeTabbable(event.currentTarget) ||
-          event.metaKey
+          // Native interactive elements don't get clicked on cmd+Enter/Space
+          event.metaKey ||
+          // This will be true if `useTabbable` has already been used.
+          // In this case, we don't want to .click() twice.
+          dataTabbable
         ) {
           return;
         }
@@ -167,16 +172,11 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
           (options.unstable_clickOnSpace && event.key === " ")
         ) {
           event.preventDefault();
-          event.target.dispatchEvent(
-            new MouseEvent("click", {
-              view: window,
-              bubbles: true,
-              cancelable: false
-            })
-          );
+          (event.target as HTMLElement).click();
         }
       },
       [
+        dataTabbable,
         options.disabled,
         options.unstable_clickOnEnter,
         options.unstable_clickOnSpace,
@@ -193,6 +193,7 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
       onMouseDown,
       onKeyDown,
       style,
+      "data-tabbable": nativeTabbable ? undefined : true,
       ...htmlProps
     };
   }

--- a/packages/reakit/src/Tabbable/__tests__/Tabbable-test.tsx
+++ b/packages/reakit/src/Tabbable/__tests__/Tabbable-test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { render, click, focus, press } from "reakit-test-utils";
-import { Tabbable } from "../Tabbable";
+import { Tabbable, TabbableProps } from "../Tabbable";
 
 test("render", () => {
   const { getByText } = render(<Tabbable>tabbable</Tabbable>);
@@ -245,4 +245,19 @@ test("focus nested native tabbables", () => {
   expect(button).not.toHaveFocus();
   focus(button);
   expect(button).toHaveFocus();
+});
+
+test("press enter on Tabbable as another non-native Tabbable", () => {
+  const onClick = jest.fn();
+  const NonNativeTabbable = React.forwardRef<HTMLDivElement, TabbableProps>(
+    (props, ref) => <Tabbable as="div" ref={ref} {...props} />
+  );
+  const { getByText } = render(
+    <Tabbable as={NonNativeTabbable} onClick={onClick}>
+      tabbable
+    </Tabbable>
+  );
+  const tabbable = getByText("tabbable");
+  press.Enter(tabbable);
+  expect(onClick).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
When there are two `useTabbable` being composed into one component and the resulting element is not a native interactive element (`button`, `input` etc.), pressing <kbd>Enter</kbd> or `<kbd>Space</kbd>` on it will result in a double click.

**Does this PR introduce a breaking change?**

No