### PR TITLE
feat: Add `DisclosureContent` component

### DIFF
--- a/docs/BASIC_CONCEPTS.md
+++ b/docs/BASIC_CONCEPTS.md
@@ -12,11 +12,11 @@ Reakit is established on principles that make it more consistent throughout its 
 
 ## Components
 
-Like any other component library, components are the **highest level API** in Reakit. The [DisclosureRegion](/docs/disclosure/) component, for example, renders an element that can be hidden or visible.
+Like any other component library, components are the **highest level API** in Reakit. The [DisclosureContent](/docs/disclosure/) component, for example, renders an element that can be hidden or visible.
 
 <!-- eslint-disable -->
 ```jsx static
-<DisclosureRegion visible>Content</DisclosureRegion>
+<DisclosureContent visible>Content</DisclosureContent>
 ```
 
 ## Options
@@ -27,7 +27,7 @@ Components receive two kinds of props: **HTML props** and **option props**. Opti
 ```jsx static
 // `className` is an HTML prop
 // `visible` is an option
-<DisclosureRegion className="class" visible />
+<DisclosureContent className="class" visible />
 ```
 
 ## `as` prop
@@ -35,13 +35,13 @@ Components receive two kinds of props: **HTML props** and **option props**. Opti
 Components render only one element. You can change its type using the `as` prop:
 
 ```jsx
-import { DisclosureRegion } from "reakit";
+import { DisclosureContent } from "reakit";
 
 function Example() {
   return (
-    <DisclosureRegion visible as="button">
+    <DisclosureContent visible as="button">
       Content
-    </DisclosureRegion>
+    </DisclosureContent>
   );
 }
 ```
@@ -53,13 +53,13 @@ Learn more in [Composition](/docs/composition/#as-prop).
 Alternatively, you can change the underlying element by passing children as a function (also known as [render props](https://reactjs.org/docs/render-props.html)):
 
 ```jsx
-import { DisclosureRegion, Button } from "reakit";
+import { DisclosureContent, Button } from "reakit";
 
 function Example() {
   return (
-    <DisclosureRegion visible>
+    <DisclosureContent visible>
       {props => <Button {...props}>Content</Button>}
-    </DisclosureRegion>
+    </DisclosureContent>
   );
 }
 ```
@@ -73,7 +73,7 @@ Many Reakit components accept state props, and you can plug your own. As a conve
 The returned options can be passed as props directly to the components, or used separately to access, update and/or [extend the state](/docs/composition/#state-hooks).
 
 ```jsx
-import { useDisclosureState, DisclosureRegion } from "reakit";
+import { useDisclosureState, DisclosureContent } from "reakit";
 
 function Example() {
   // exposes `visible` state and methods like `show`, `hide` and `toggle`
@@ -81,7 +81,7 @@ function Example() {
   return (
     <>
       <button onClick={hidden.toggle}>Disclosure</button>
-      <DisclosureRegion {...hidden}>Content</DisclosureRegion>
+      <DisclosureContent {...hidden}>Content</DisclosureContent>
     </>
   );
 }
@@ -91,19 +91,19 @@ Learn more in [Managing state](/docs/managing-state/).
 
 ## Props hooks
 
-Finally, as the **lowest level API**, Reakit exposes props hooks. These hooks hold most of the logic behind components and are heavily used within Reakit's source code as a means to compose behaviors without the hassle of polluting the tree with multiple components. For example, [Dialog](/docs/dialog/) uses [DisclosureRegion](/docs/disclosure/), which in turn uses [Box](/docs/box/).
+Finally, as the **lowest level API**, Reakit exposes props hooks. These hooks hold most of the logic behind components and are heavily used within Reakit's source code as a means to compose behaviors without the hassle of polluting the tree with multiple components. For example, [Dialog](/docs/dialog/) uses [DisclosureContent](/docs/disclosure/), which in turn uses [Box](/docs/box/).
 
 ```jsx
 import {
   Box,
   useDisclosureState,
-  useDisclosureRegion,
+  useDisclosureContent,
   useDisclosure
 } from "reakit";
 
 function Example() {
   const state = useDisclosureState({ visible: true });
-  const contentProps = useDisclosureRegion(state);
+  const contentProps = useDisclosureContent(state);
   const disclosureProps = useDisclosure(state);
   return (
     <>

--- a/docs/COMPOSITION.md
+++ b/docs/COMPOSITION.md
@@ -81,7 +81,7 @@ State hooks are composable as well. For example, [`useTabState`](/docs/tab/) use
 
 ```jsx
 import React from "react";
-import { useDisclosureState, DisclosureRegion, Disclosure } from "reakit";
+import { useDisclosureState, DisclosureContent, Disclosure } from "reakit";
 
 function useDelayedDisclosureState({ delay, ...initialState } = {}) {
   const disclosure = useDisclosureState(initialState);
@@ -112,7 +112,7 @@ function Example() {
           ? "Hide with delay"
           : "Show with delay"}
       </Disclosure>
-      <DisclosureRegion {...disclosure}>Content</DisclosureRegion>
+      <DisclosureContent {...disclosure}>Content</DisclosureContent>
     </>
   );
 }

--- a/docs/MANAGING_STATE.md
+++ b/docs/MANAGING_STATE.md
@@ -10,13 +10,13 @@ redirect_from:
 
 Reakit components are pretty much stateless, which means that they need props to be passed in so as to modify their state.
 
-[DisclosureRegion](/docs/disclosure/), for example, is a generic component that can be disclosure or visible based on props:
+[DisclosureContent](/docs/disclosure/), for example, is a generic component that can be disclosure or visible based on props:
 
 ```jsx
-import { DisclosureRegion } from "reakit";
+import { DisclosureContent } from "reakit";
 
 function Example() {
-  return <DisclosureRegion visible>Content</DisclosureRegion>;
+  return <DisclosureContent visible>Content</DisclosureContent>;
 }
 ```
 
@@ -24,14 +24,14 @@ You can pass your own state to control it:
 
 ```jsx
 import React from "react";
-import { DisclosureRegion } from "reakit";
+import { DisclosureContent } from "reakit";
 
 function Example() {
   const [visible, setVisible] = React.useState(true);
   return (
     <>
       <button onClick={() => setVisible(!visible)}>Disclosure</button>
-      <DisclosureRegion visible={visible}>Content</DisclosureRegion>
+      <DisclosureContent visible={visible}>Content</DisclosureContent>
     </>
   );
 }
@@ -44,14 +44,14 @@ As a convenience — and because some states need more complex logic —, Reakit
 The returned [options](/docs/basic-concepts/#options) can be passed as props directly to the components, or used separately to access, update and/or [extend the state](/docs/composition/#state-hooks).
 
 ```jsx
-import { useDisclosureState, DisclosureRegion } from "reakit";
+import { useDisclosureState, DisclosureContent } from "reakit";
 
 function Example() {
   const disclosure = useDisclosureState({ visible: true });
   return (
     <>
       <button onClick={disclosure.toggle}>Disclosure</button>
-      <DisclosureRegion {...disclosure}>Content</DisclosureRegion>
+      <DisclosureContent {...disclosure}>Content</DisclosureContent>
     </>
   );
 }
@@ -71,7 +71,7 @@ useDisclosureState(() => ({ visible: getExpensiveValue() }));
 If you need to share state between multiple components within your app, you can use [Constate](https://github.com/diegohaz/constate):
 
 ```jsx
-import { useDisclosureState, Disclosure, DisclosureRegion } from "reakit";
+import { useDisclosureState, Disclosure, DisclosureContent } from "reakit";
 import constate from "constate";
 
 const [DisclosureProvider, useDisclosureContext] = constate(useDisclosureState);
@@ -83,7 +83,7 @@ function Button() {
 
 function Content() {
   const disclosure = useDisclosureContext();
-  return <DisclosureRegion {...disclosure}>Content</DisclosureRegion>;
+  return <DisclosureContent {...disclosure}>Content</DisclosureContent>;
 }
 
 function Example() {

--- a/packages/reakit-playground/src/__deps/reakit.ts
+++ b/packages/reakit-playground/src/__deps/reakit.ts
@@ -84,7 +84,7 @@ export default {
   "reakit/Form/Form": require("reakit/Form/Form"),
   "reakit/Disclosure": require("reakit/Disclosure"),
   "reakit/Disclosure/DisclosureState": require("reakit/Disclosure/DisclosureState"),
-  "reakit/Disclosure/DisclosureRegion": require("reakit/Disclosure/DisclosureRegion"),
+  "reakit/Disclosure/DisclosureContent": require("reakit/Disclosure/DisclosureContent"),
   "reakit/Disclosure/Disclosure": require("reakit/Disclosure/Disclosure"),
   "reakit/Dialog": require("reakit/Dialog"),
   "reakit/Dialog/DialogState": require("reakit/Dialog/DialogState"),

--- a/packages/reakit/src/Dialog/Dialog.tsx
+++ b/packages/reakit/src/Dialog/Dialog.tsx
@@ -7,10 +7,10 @@ import { useForkRef } from "reakit-utils/useForkRef";
 import { useAllCallbacks } from "reakit-utils/useAllCallbacks";
 import { usePipe } from "reakit-utils/usePipe";
 import {
-  DisclosureRegionOptions,
-  DisclosureRegionHTMLProps,
-  useDisclosureRegion
-} from "../Disclosure/DisclosureRegion";
+  DisclosureContentOptions,
+  DisclosureContentHTMLProps,
+  useDisclosureContent
+} from "../Disclosure/DisclosureContent";
 import { Portal } from "../Portal/Portal";
 import { useDisclosuresRef } from "./__utils/useDisclosuresRef";
 import { usePreventBodyScroll } from "./__utils/usePreventBodyScroll";
@@ -23,7 +23,7 @@ import { useDialogState, DialogStateReturn } from "./DialogState";
 import { useDisableHoverOutside } from "./__utils/useDisableHoverOutside";
 import { DialogBackdropContext } from "./__utils/DialogBackdropContext";
 
-export type DialogOptions = DisclosureRegionOptions &
+export type DialogOptions = DisclosureContentOptions &
   Pick<
     Partial<DialogStateReturn>,
     "modal" | "setModal" | "unstable_modal" | "hide"
@@ -71,13 +71,13 @@ export type DialogOptions = DisclosureRegionOptions &
     unstable_autoFocusOnHide?: boolean;
   };
 
-export type DialogHTMLProps = DisclosureRegionHTMLProps;
+export type DialogHTMLProps = DisclosureContentHTMLProps;
 
 export type DialogProps = DialogOptions & DialogHTMLProps;
 
 export const useDialog = createHook<DialogOptions, DialogHTMLProps>({
   name: "Dialog",
-  compose: useDisclosureRegion,
+  compose: useDisclosureContent,
   useState: useDialogState,
   keys: [
     "hideOnEsc",

--- a/packages/reakit/src/Dialog/DialogBackdrop.tsx
+++ b/packages/reakit/src/Dialog/DialogBackdrop.tsx
@@ -3,18 +3,18 @@ import { createComponent } from "reakit-system/createComponent";
 import { createHook } from "reakit-system/createHook";
 import { usePipe } from "reakit-utils/usePipe";
 import {
-  DisclosureRegionOptions,
-  DisclosureRegionHTMLProps,
-  useDisclosureRegion
-} from "../Disclosure/DisclosureRegion";
+  DisclosureContentOptions,
+  DisclosureContentHTMLProps,
+  useDisclosureContent
+} from "../Disclosure/DisclosureContent";
 import { Portal } from "../Portal/Portal";
 import { useDialogState, DialogStateReturn } from "./DialogState";
 import { DialogBackdropContext } from "./__utils/DialogBackdropContext";
 
-export type DialogBackdropOptions = DisclosureRegionOptions &
+export type DialogBackdropOptions = DisclosureContentOptions &
   Pick<Partial<DialogStateReturn>, "modal">;
 
-export type DialogBackdropHTMLProps = DisclosureRegionHTMLProps;
+export type DialogBackdropHTMLProps = DisclosureContentHTMLProps;
 
 export type DialogBackdropProps = DialogBackdropOptions &
   DialogBackdropHTMLProps;
@@ -24,7 +24,7 @@ export const useDialogBackdrop = createHook<
   DialogBackdropHTMLProps
 >({
   name: "DialogBackdrop",
-  compose: useDisclosureRegion,
+  compose: useDisclosureContent,
   useState: useDialogState,
 
   useOptions({ modal = true, ...options }) {

--- a/packages/reakit/src/Dialog/README.md
+++ b/packages/reakit/src/Dialog/README.md
@@ -309,9 +309,9 @@ Learn more in [Accessibility](/docs/accessibility/).
 
 ## Composition
 
-- `Dialog` uses [DisclosureRegion](/docs/disclosure/), and is used by [Popover](/docs/popover/) and its derivatives.
+- `Dialog` uses [DisclosureContent](/docs/disclosure/), and is used by [Popover](/docs/popover/) and its derivatives.
 - `DialogDisclosure` uses [Disclosure](/docs/disclosure/), and is used by [PopoverDisclosure](/docs/popover/) and its derivatives.
-- `DialogBackdrop` uses [DisclosureRegion](/docs/disclosure/), and is used by [PopoverBackdrop](/docs/popover/) and its derivatives.
+- `DialogBackdrop` uses [DisclosureContent](/docs/disclosure/), and is used by [PopoverBackdrop](/docs/popover/) and its derivatives.
 
 Learn more in [Composition](/docs/composition/#props-hooks).
 

--- a/packages/reakit/src/Disclosure/DisclosureContent.ts
+++ b/packages/reakit/src/Disclosure/DisclosureContent.ts
@@ -12,7 +12,7 @@ import { useDisclosureState, DisclosureStateReturn } from "./DisclosureState";
 import { useWarningIfMultiple } from "./__utils/useWarningIfMultiple";
 import { useSetIsMounted } from "./__utils/useSetIsMounted";
 
-export type DisclosureRegionOptions = unstable_IdGroupOptions &
+export type DisclosureContentOptions = unstable_IdGroupOptions &
   Pick<
     Partial<DisclosureStateReturn>,
     | "visible"
@@ -22,16 +22,16 @@ export type DisclosureRegionOptions = unstable_IdGroupOptions &
     | "unstable_setIsMounted"
   >;
 
-export type DisclosureRegionHTMLProps = unstable_IdGroupHTMLProps;
+export type DisclosureContentHTMLProps = unstable_IdGroupHTMLProps;
 
-export type DisclosureRegionProps = DisclosureRegionOptions &
-  DisclosureRegionHTMLProps;
+export type DisclosureContentProps = DisclosureContentOptions &
+  DisclosureContentHTMLProps;
 
-export const useDisclosureRegion = createHook<
-  DisclosureRegionOptions,
-  DisclosureRegionHTMLProps
+export const useDisclosureContent = createHook<
+  DisclosureContentOptions,
+  DisclosureContentHTMLProps
 >({
-  name: "DisclosureRegion",
+  name: "DisclosureContent",
   compose: unstable_useIdGroup,
   useState: useDisclosureState,
 
@@ -69,7 +69,6 @@ export const useDisclosureRegion = createHook<
     const hidden = !options.visible && !animating;
 
     return {
-      role: "region",
       id: options.baseId,
       className: cx(hiddenClass, htmlClassName),
       onAnimationEnd: useAllCallbacks(onTransitionEnd, htmlOnAnimationEnd),
@@ -85,7 +84,7 @@ export const useDisclosureRegion = createHook<
   }
 });
 
-export const DisclosureRegion = createComponent({
+export const DisclosureContent = createComponent({
   as: "div",
-  useHook: useDisclosureRegion
+  useHook: useDisclosureContent
 });

--- a/packages/reakit/src/Disclosure/DisclosureState.ts
+++ b/packages/reakit/src/Disclosure/DisclosureState.ts
@@ -111,8 +111,8 @@ export function useDisclosureState(
     warning(
       !isMounted,
       "[reakit/Disclosure]",
-      "You're trying to show a `DisclosureRegion` component that hasn't been mounted yet.",
-      "You shouldn't conditionally render a `DisclosureRegion` component (or any of its derivatives) as this will make some features not work.",
+      "You're trying to show a `DisclosureContent` component that hasn't been mounted yet.",
+      "You shouldn't conditionally render a `DisclosureContent` component (or any of its derivatives) as this will make some features not work.",
       "If this is intentional, you can omit this warning by passing `unstable_isMounted: true` to `useDisclosureState` or just ignore it.",
       "See https://reakit.io/docs/disclosure/#conditionally-rendering"
     );
@@ -125,8 +125,8 @@ export function useDisclosureState(
     warning(
       !isMounted,
       "[reakit/Disclosure]",
-      "You're trying to toggle a `DisclosureRegion` element that hasn't been mounted yet.",
-      "You shouldn't conditionally render a `DisclosureRegion` component (or any of its derivatives) as this will make some features not work.",
+      "You're trying to toggle a `DisclosureContent` element that hasn't been mounted yet.",
+      "You shouldn't conditionally render a `DisclosureContent` component (or any of its derivatives) as this will make some features not work.",
       "If this is intentional, you can omit this warning by passing `unstable_isMounted: true` to `useDisclosureState` or just ignore it.",
       "See https://reakit.io/docs/disclosure/#conditionally-rendering"
     );

--- a/packages/reakit/src/Disclosure/README.md
+++ b/packages/reakit/src/Disclosure/README.md
@@ -10,7 +10,7 @@ redirect_from:
 
 # Disclosure
 
-Accessible `Disclosure` compoennt that controls visibility of a section of content (`DialogContent`). It follows the [WAI-ARIA Disclosure Pattern](https://www.w3.org/TR/wai-aria-practices/#disclosure).
+Accessible `Disclosure` compoennt that controls visibility of a section of content (`DisclosureContent`). It follows the [WAI-ARIA Disclosure Pattern](https://www.w3.org/TR/wai-aria-practices/#disclosure).
 
 <carbon-ad></carbon-ad>
 
@@ -28,7 +28,7 @@ Learn more in [Get started](/docs/get-started/).
 import {
   useDisclosureState,
   Disclosure,
-  DisclosureRegion
+  DisclosureContent
 } from "reakit/Disclosure";
 
 function Example() {
@@ -36,7 +36,7 @@ function Example() {
   return (
     <>
       <Disclosure {...disclosure}>Toggle</Disclosure>
-      <DisclosureRegion {...disclosure}>Content</DisclosureRegion>
+      <DisclosureContent {...disclosure}>Content</DisclosureContent>
     </>
   );
 }
@@ -44,13 +44,13 @@ function Example() {
 
 ### Conditionally rendering
 
-You shouldn't conditionally render the `DisclosureRegion` component as this will make some Reakit features not work. Instead, you can use [render props](/docs/composition/#render-props) and conditionally render the underneath element:
+You shouldn't conditionally render the `DisclosureContent` component as this will make some Reakit features not work. Instead, you can use [render props](/docs/composition/#render-props) and conditionally render the underneath element:
 
 ```jsx
 import {
   useDisclosureState,
   Disclosure,
-  DisclosureRegion
+  DisclosureContent
 } from "reakit/Disclosure";
 
 function Example() {
@@ -58,10 +58,10 @@ function Example() {
   return (
     <>
       <Disclosure {...disclosure}>Toggle</Disclosure>
-      {/* instead of {disclosure.visible && <DisclosureRegion {...disclosure}>Content</DisclosureRegion>} */}
-      <DisclosureRegion {...disclosure}>
+      {/* instead of {disclosure.visible && <DisclosureContent {...disclosure}>Content</DisclosureContent>} */}
+      <DisclosureContent {...disclosure}>
         {props => disclosure.visible && <div {...props}>Content</div>}
-      </DisclosureRegion>
+      </DisclosureContent>
     </>
   );
 }
@@ -69,15 +69,15 @@ function Example() {
 
 ### Multiple components
 
-Each `DisclosureRegion` component should have its own `useDisclosureState`. This is also true for derivative modules like [Dialog](/docs/dialog/), [Popover](/docs/popover/), [Menu](/docs/menu/), [Tooltip](/docs/tooltip/) etc.
+Each `DisclosureContent` component should have its own `useDisclosureState`. This is also true for derivative modules like [Dialog](/docs/dialog/), [Popover](/docs/popover/), [Menu](/docs/menu/), [Tooltip](/docs/tooltip/) etc.
 
-If you want to have only one `Disclosure` element controling multiple `DisclosureRegion` components, you can use [render props](/docs/composition/#render-props) to apply the same state to different `Disclosure`s that will result in a single element.
+If you want to have only one `Disclosure` element controling multiple `DisclosureContent` components, you can use [render props](/docs/composition/#render-props) to apply the same state to different `Disclosure`s that will result in a single element.
 
 ```jsx
 import {
   useDisclosureState,
   Disclosure,
-  DisclosureRegion
+  DisclosureContent
 } from "reakit/Disclosure";
 
 function Example() {
@@ -92,8 +92,8 @@ function Example() {
           </Disclosure>
         )}
       </Disclosure>
-      <DisclosureRegion {...disclosure1}>Content 1</DisclosureRegion>
-      <DisclosureRegion {...disclosure2}>Content 2</DisclosureRegion>
+      <DisclosureContent {...disclosure1}>Content 1</DisclosureContent>
+      <DisclosureContent {...disclosure2}>Content 2</DisclosureContent>
     </>
   );
 }
@@ -102,15 +102,15 @@ function Example() {
 ## Accessibility
 
 - `Disclosure` extends the accessibility features of [Button](/docs/button/#accessibility).
-- `Disclosure` has a value specified for `aria-controls` that refers to `DisclosureRegion`.
-- When `DisclosureRegion` is visible, `Disclosure` has `aria-expanded` set to `true`. When `DisclosureRegion` is hidden, it is set to `false`.
+- `Disclosure` has a value specified for `aria-controls` that refers to `DisclosureContent`.
+- When `DisclosureContent` is visible, `Disclosure` has `aria-expanded` set to `true`. When `DisclosureContent` is hidden, it is set to `false`.
 
 Learn more in [Accessibility](/docs/accessibility/).
 
 ## Composition
 
 - `Disclosure` uses [Button](/docs/button/), and is used by [DialogDisclosure](/docs/dialog/).
-- `DisclosureRegion` uses [Box](/docs/box/), and is used by [Dialog](/docs/dialog/), [DialogBackdrop](/docs/dialog/), [TabPanel](/docs/tab/), [Tooltip](/docs/tooltip/) and all their derivatives.
+- `DisclosureContent` uses [Box](/docs/box/), and is used by [Dialog](/docs/dialog/), [DialogBackdrop](/docs/dialog/), [TabPanel](/docs/tab/), [Tooltip](/docs/tooltip/) and all their derivatives.
 
 Learn more in [Composition](/docs/composition/#props-hooks).
 
@@ -173,7 +173,7 @@ similarly to `readOnly` on form elements. In this case, only
 
 </details>
 
-### `DisclosureRegion`
+### `DisclosureContent`
 
 - **`id`**
   <code>string | undefined</code>

--- a/packages/reakit/src/Disclosure/__tests__/DisclosureContent-test.tsx
+++ b/packages/reakit/src/Disclosure/__tests__/DisclosureContent-test.tsx
@@ -1,17 +1,16 @@
 import * as React from "react";
 import { render } from "reakit-test-utils";
-import { DisclosureRegion } from "../DisclosureRegion";
+import { DisclosureContent } from "../DisclosureContent";
 
 test("render", () => {
   const { getByText } = render(
-    <DisclosureRegion id="base">content</DisclosureRegion>
+    <DisclosureContent id="base">content</DisclosureContent>
   );
   expect(getByText("content")).toMatchInlineSnapshot(`
     <div
       class="hidden"
       hidden=""
       id="base"
-      role="region"
       style="display: none;"
     >
       content
@@ -21,14 +20,13 @@ test("render", () => {
 
 test("render visible", () => {
   const { getByText } = render(
-    <DisclosureRegion id="base" visible>
+    <DisclosureContent id="base" visible>
       content
-    </DisclosureRegion>
+    </DisclosureContent>
   );
   expect(getByText("content")).toMatchInlineSnapshot(`
     <div
       id="base"
-      role="region"
     >
       content
     </div>

--- a/packages/reakit/src/Disclosure/__tests__/index-test.tsx
+++ b/packages/reakit/src/Disclosure/__tests__/index-test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { render, click } from "reakit-test-utils";
-import { DisclosureRegion, Disclosure, useDisclosureState } from "..";
+import { DisclosureContent, Disclosure, useDisclosureState } from "..";
 
 test("show", () => {
   function Test() {
@@ -8,7 +8,7 @@ test("show", () => {
     return (
       <>
         <Disclosure {...disclosure}>disclosure</Disclosure>
-        <DisclosureRegion {...disclosure}>content</DisclosureRegion>
+        <DisclosureContent {...disclosure}>content</DisclosureContent>
       </>
     );
   }
@@ -26,7 +26,7 @@ test("hide", () => {
     return (
       <>
         <Disclosure {...disclosure}>disclosure</Disclosure>
-        <DisclosureRegion {...disclosure}>content</DisclosureRegion>
+        <DisclosureContent {...disclosure}>content</DisclosureContent>
       </>
     );
   }
@@ -51,8 +51,8 @@ test("multiple components", () => {
             </Disclosure>
           )}
         </Disclosure>
-        <DisclosureRegion {...disclosure1}>content1</DisclosureRegion>
-        <DisclosureRegion {...disclosure2}>content2</DisclosureRegion>
+        <DisclosureContent {...disclosure1}>content1</DisclosureContent>
+        <DisclosureContent {...disclosure2}>content2</DisclosureContent>
       </>
     );
   }

--- a/packages/reakit/src/Disclosure/__utils/useSetIsMounted.ts
+++ b/packages/reakit/src/Disclosure/__utils/useSetIsMounted.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { DisclosureRegionOptions } from "../DisclosureRegion";
+import { DisclosureContentOptions } from "../DisclosureContent";
 
-export function useSetIsMounted(options: DisclosureRegionOptions) {
+export function useSetIsMounted(options: DisclosureContentOptions) {
   if (process.env.NODE_ENV === "production") return;
 
   React.useEffect(() => {

--- a/packages/reakit/src/Disclosure/__utils/useWarningIfMultiple.ts
+++ b/packages/reakit/src/Disclosure/__utils/useWarningIfMultiple.ts
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { warning } from "reakit-utils/warning";
-import { DisclosureRegionOptions } from "../DisclosureRegion";
+import { DisclosureContentOptions } from "../DisclosureContent";
 
-export function useWarningIfMultiple(options: DisclosureRegionOptions) {
+export function useWarningIfMultiple(options: DisclosureContentOptions) {
   if (process.env.NODE_ENV === "production") return;
 
   React.useEffect(() => {
@@ -10,8 +10,8 @@ export function useWarningIfMultiple(options: DisclosureRegionOptions) {
 
     warning(
       document.querySelectorAll(`#${options.baseId}`).length > 1,
-      "[reakit/DisclosureRegion]",
-      "You're reusing the same `useModuleState` for multiple components (DisclosureRegion, Dialog, Popover, Menu etc.).",
+      "[reakit/DisclosureContent]",
+      "You're reusing the same `useModuleState` for multiple components (DisclosureContent, Dialog, Popover, Menu etc.).",
       "This is not allowed! If you want to use multiple components, make sure you're using different states.",
       "See https://reakit.io/docs/disclosure/#multiple-components"
     );

--- a/packages/reakit/src/Disclosure/index.ts
+++ b/packages/reakit/src/Disclosure/index.ts
@@ -1,3 +1,3 @@
 export * from "./Disclosure";
-export * from "./DisclosureRegion";
+export * from "./DisclosureContent";
 export * from "./DisclosureState";

--- a/packages/reakit/src/Hidden/Hidden.ts
+++ b/packages/reakit/src/Hidden/Hidden.ts
@@ -2,28 +2,28 @@ import { createComponent } from "reakit-system/createComponent";
 import { createHook } from "reakit-system/createHook";
 import { warning } from "reakit-utils/warning";
 import {
-  DisclosureRegionOptions,
-  DisclosureRegionHTMLProps,
-  useDisclosureRegion
-} from "../Disclosure/DisclosureRegion";
+  DisclosureContentOptions,
+  DisclosureContentHTMLProps,
+  useDisclosureContent
+} from "../Disclosure/DisclosureContent";
 import { useHiddenState } from "./HiddenState";
 
-export type HiddenOptions = DisclosureRegionOptions;
+export type HiddenOptions = DisclosureContentOptions;
 
-export type HiddenHTMLProps = DisclosureRegionHTMLProps;
+export type HiddenHTMLProps = DisclosureContentHTMLProps;
 
 export type HiddenProps = HiddenOptions & HiddenHTMLProps;
 
 export const useHidden = createHook<HiddenOptions, HiddenHTMLProps>({
   name: "Hidden",
-  compose: useDisclosureRegion,
+  compose: useDisclosureContent,
   useState: useHiddenState,
 
   useProps(_, htmlProps) {
     warning(
       true,
       "[reakit/Hidden]",
-      "`Hidden` has been renamed to `DisclosureRegion`. Using `<Hidden />` will no longer work in future versions.",
+      "`Hidden` has been renamed to `DisclosureContent`. Using `<Hidden />` will no longer work in future versions.",
       "See https://reakit.io/docs/disclosure"
     );
     return htmlProps;

--- a/packages/reakit/src/Tab/README.md
+++ b/packages/reakit/src/Tab/README.md
@@ -234,7 +234,7 @@ Learn more in [Accessibility](/docs/accessibility/).
 
 - `Tab` uses [Rover](/docs/rover/).
 - `TabList` uses [Box](/docs/box/).
-- `TabPanel` uses [DisclosureRegion](/docs/disclosure/).
+- `TabPanel` uses [DisclosureContent](/docs/disclosure/).
 
 Learn more in [Composition](/docs/composition/#props-hooks).
 

--- a/packages/reakit/src/Tab/TabPanel.ts
+++ b/packages/reakit/src/Tab/TabPanel.ts
@@ -1,14 +1,14 @@
 import { createComponent } from "reakit-system/createComponent";
 import { createHook } from "reakit-system/createHook";
 import {
-  DisclosureRegionOptions,
-  DisclosureRegionHTMLProps,
-  useDisclosureRegion
-} from "../Disclosure/DisclosureRegion";
+  DisclosureContentOptions,
+  DisclosureContentHTMLProps,
+  useDisclosureContent
+} from "../Disclosure/DisclosureContent";
 import { getTabPanelId, getTabId } from "./__utils";
 import { useTabState, TabStateReturn } from "./TabState";
 
-export type TabPanelOptions = DisclosureRegionOptions &
+export type TabPanelOptions = DisclosureContentOptions &
   Pick<TabStateReturn, "baseId" | "selectedId"> & {
     /**
      * Tab's `stopId`.
@@ -16,13 +16,13 @@ export type TabPanelOptions = DisclosureRegionOptions &
     stopId: string;
   };
 
-export type TabPanelHTMLProps = DisclosureRegionHTMLProps;
+export type TabPanelHTMLProps = DisclosureContentHTMLProps;
 
 export type TabPanelProps = TabPanelOptions & TabPanelHTMLProps;
 
 export const useTabPanel = createHook<TabPanelOptions, TabPanelHTMLProps>({
   name: "TabPanel",
-  compose: useDisclosureRegion,
+  compose: useDisclosureContent,
   useState: useTabState,
   keys: ["stopId"],
 

--- a/packages/reakit/src/Tooltip/README.md
+++ b/packages/reakit/src/Tooltip/README.md
@@ -129,7 +129,7 @@ Learn more in [Accessibility](/docs/accessibility/).
 
 ## Composition
 
-- `Tooltip` uses [DisclosureRegion](/docs/disclosure/).
+- `Tooltip` uses [DisclosureContent](/docs/disclosure/).
 - `TooltipArrow` uses [PopoverArrow](/docs/popover/).
 - `TooltipReference` uses [Box](/docs/box/).
 

--- a/packages/reakit/src/Tooltip/Tooltip.tsx
+++ b/packages/reakit/src/Tooltip/Tooltip.tsx
@@ -4,14 +4,14 @@ import { createHook } from "reakit-system/createHook";
 import { useForkRef } from "reakit-utils/useForkRef";
 import { usePipe } from "reakit-utils/usePipe";
 import {
-  DisclosureRegionOptions,
-  DisclosureRegionHTMLProps,
-  useDisclosureRegion
-} from "../Disclosure/DisclosureRegion";
+  DisclosureContentOptions,
+  DisclosureContentHTMLProps,
+  useDisclosureContent
+} from "../Disclosure/DisclosureContent";
 import { Portal } from "../Portal/Portal";
 import { TooltipStateReturn, useTooltipState } from "./TooltipState";
 
-export type TooltipOptions = DisclosureRegionOptions &
+export type TooltipOptions = DisclosureContentOptions &
   Pick<
     Partial<TooltipStateReturn>,
     "unstable_popoverRef" | "unstable_popoverStyles"
@@ -23,13 +23,13 @@ export type TooltipOptions = DisclosureRegionOptions &
     unstable_portal?: boolean;
   };
 
-export type TooltipHTMLProps = DisclosureRegionHTMLProps;
+export type TooltipHTMLProps = DisclosureContentHTMLProps;
 
 export type TooltipProps = TooltipOptions & TooltipHTMLProps;
 
 export const useTooltip = createHook<TooltipOptions, TooltipHTMLProps>({
   name: "Tooltip",
-  compose: useDisclosureRegion,
+  compose: useDisclosureContent,
   useState: useTooltipState,
   keys: ["unstable_portal"],
 


### PR DESCRIPTION
This PR renames `DisclosureRegion` to `DisclosureContent` and removes the `role="region"` attribute from it. Since this is a generic component, we shouldn't make assumptions on which role it will have. This was also introducing an accessibility issue, since a `role="region"` element requires `aria-label` or `aria-labelledby`.

**Does this PR introduce a breaking change?**

- `DisclosureRegion` has been renamed to `DisclosureContent`.