### PR TITLE
Update Disclosure README.md

### DIFF
--- a/packages/reakit/src/Disclosure/README.md
+++ b/packages/reakit/src/Disclosure/README.md
@@ -10,7 +10,7 @@ redirect_from:
 
 # Disclosure
 
-Accessible `Disclosure` compoennt that controls visibility of a section of content (`DialogContent`). It follows the [WAI-ARIA Disclosure Pattern](https://www.w3.org/TR/wai-aria-practices/#disclosure).
+Accessible `Disclosure` component that controls visibility of a section of content (`DialogContent`). It follows the [WAI-ARIA Disclosure Pattern](https://www.w3.org/TR/wai-aria-practices/#disclosure).
 
 <carbon-ad></carbon-ad>
 


### PR DESCRIPTION
Very tiny typo

**Does this PR introduce a breaking change?**

Nope :) 

- `compoennt` has been replaced by `component`.
