### PR TITLE
feat: Select the first `Tab` by default and don't require `stopId` prop

### DIFF
--- a/docs/COMPOSITION.md
+++ b/docs/COMPOSITION.md
@@ -6,7 +6,7 @@ redirect_from:
 
 # Composition
 
-Reakit has been built with composition in mind. In fact, its own components are composed by a few other abstract ones, like [Box](/docs/box/), [Tabbable](/docs/tabbable/) and [Rover](/docs/rover/).
+Reakit has been built with composition in mind. In fact, its own components are composed by a few other abstract ones, like [Box](/docs/box/), [Tabbable](/docs/tabbable/) and [Composite](/docs/composite/).
 
 The API isn't different. It's designed so you can create new things based on any existing module.
 

--- a/packages/reakit-system/src/createHook.ts
+++ b/packages/reakit-system/src/createHook.ts
@@ -59,6 +59,7 @@ export function createHook<O, P>(options: CreateHookOptions<O, P>) {
       hookOptions = useOptions(options.name, hookOptions, htmlProps);
     }
 
+    // TODO: Check it and test DialogBackdrop
     if (options.compose) {
       composedHooks.forEach(hook => {
         hookOptions = hook.__useOptions(hookOptions, htmlProps);
@@ -77,6 +78,7 @@ export function createHook<O, P>(options: CreateHookOptions<O, P>) {
     if (!unstable_ignoreUseOptions) {
       hookOptions = __useOptions(hookOptions, htmlProps);
     }
+    // TODO
     // We're already calling composed useOptions here
     // That's why we ignoreUseOptions for composed hooks
     // if (options.compose) {

--- a/packages/reakit-system/src/createHook.ts
+++ b/packages/reakit-system/src/createHook.ts
@@ -58,6 +58,13 @@ export function createHook<O, P>(options: CreateHookOptions<O, P>) {
     if (options.name) {
       hookOptions = useOptions(options.name, hookOptions, htmlProps);
     }
+
+    if (options.compose) {
+      composedHooks.forEach(hook => {
+        hookOptions = hook.__useOptions(hookOptions, htmlProps);
+      });
+    }
+
     return hookOptions;
   };
 
@@ -72,11 +79,11 @@ export function createHook<O, P>(options: CreateHookOptions<O, P>) {
     }
     // We're already calling composed useOptions here
     // That's why we ignoreUseOptions for composed hooks
-    if (options.compose) {
-      composedHooks.forEach(hook => {
-        hookOptions = hook.__useOptions(hookOptions, htmlProps);
-      });
-    }
+    // if (options.compose) {
+    //   composedHooks.forEach(hook => {
+    //     hookOptions = hook.__useOptions(hookOptions, htmlProps);
+    //   });
+    // }
     // Call the current hook's useProps
     if (options.useProps) {
       htmlProps = options.useProps(hookOptions, htmlProps);

--- a/packages/reakit-system/src/createHook.ts
+++ b/packages/reakit-system/src/createHook.ts
@@ -58,8 +58,7 @@ export function createHook<O, P>(options: CreateHookOptions<O, P>) {
     if (options.name) {
       hookOptions = useOptions(options.name, hookOptions, htmlProps);
     }
-
-    // TODO: Check it and test DialogBackdrop
+    // Run composed hooks useOptions
     if (options.compose) {
       composedHooks.forEach(hook => {
         hookOptions = hook.__useOptions(hookOptions, htmlProps);
@@ -78,14 +77,6 @@ export function createHook<O, P>(options: CreateHookOptions<O, P>) {
     if (!unstable_ignoreUseOptions) {
       hookOptions = __useOptions(hookOptions, htmlProps);
     }
-    // TODO
-    // We're already calling composed useOptions here
-    // That's why we ignoreUseOptions for composed hooks
-    // if (options.compose) {
-    //   composedHooks.forEach(hook => {
-    //     hookOptions = hook.__useOptions(hookOptions, htmlProps);
-    //   });
-    // }
     // Call the current hook's useProps
     if (options.useProps) {
       htmlProps = options.useProps(hookOptions, htmlProps);

--- a/packages/reakit/src/Button/README.md
+++ b/packages/reakit/src/Button/README.md
@@ -139,7 +139,7 @@ Learn more in [Accessibility](/docs/accessibility/).
 
 ## Composition
 
-- `Button` uses [Tabbable](/docs/tabbable/), and is used by [FormPushButton](/docs/form/), [FormRemoveButton](/docs/form/), [Disclosure](/docs/disclosure/) and all their derivatives.
+- `Button` uses [Clickable](/docs/clickable/), and is used by [FormPushButton](/docs/form/), [FormRemoveButton](/docs/form/), [Disclosure](/docs/disclosure/) and all their derivatives.
 
 Learn more in [Composition](/docs/composition/#props-hooks).
 

--- a/packages/reakit/src/Checkbox/README.md
+++ b/packages/reakit/src/Checkbox/README.md
@@ -131,7 +131,7 @@ Learn more in [Accessibility](/docs/accessibility/).
 
 ## Composition
 
-- `Checkbox` uses [Tabbable](/docs/tabbable/), and is used by [FormCheckbox](/docs/form/) and [MenuItemCheckbox](/docs/menu/).
+- `Checkbox` uses [Clickable](/docs/clickable/), and is used by [FormCheckbox](/docs/form/) and [MenuItemCheckbox](/docs/menu/).
 
 Learn more in [Composition](/docs/composition/#props-hooks).
 

--- a/packages/reakit/src/Clickable/README.md
+++ b/packages/reakit/src/Clickable/README.md
@@ -44,7 +44,7 @@ function Example() {
 ## Accessibility
 
 - Pressing <kbd>Enter</kbd> or <kbd>Space</kbd> triggers a click event on `Clickable` regardless of its rendered element.
-- `Clickable` extends the accessibility features of [Tabbable](/docs/tabbable/).
+- `Clickable` extends the accessibility features of [Tabbable](/docs/tabbable/#accessibility).
 
 Learn more in [Accessibility](/docs/accessibility/).
 

--- a/packages/reakit/src/Composite/CompositeState.ts
+++ b/packages/reakit/src/Composite/CompositeState.ts
@@ -140,36 +140,44 @@ export type unstable_CompositeActions = unstable_IdActions & {
   /**
    * Sets `rtl`.
    */
-  setRTL: React.Dispatch<unstable_CompositeState["rtl"]>;
+  setRTL: React.Dispatch<React.SetStateAction<unstable_CompositeState["rtl"]>>;
   /**
    * Sets `orientation`.
    */
-  setOrientation: React.Dispatch<unstable_CompositeState["orientation"]>;
+  setOrientation: React.Dispatch<
+    React.SetStateAction<unstable_CompositeState["orientation"]>
+  >;
   /**
    * Sets `currentId`.
    */
-  setCurrentId: React.Dispatch<unstable_CompositeState["currentId"]>;
+  setCurrentId: React.Dispatch<
+    React.SetStateAction<unstable_CompositeState["currentId"]>
+  >;
   /**
    * Sets `loop`.
    */
-  setLoop: React.Dispatch<unstable_CompositeState["loop"]>;
+  setLoop: React.Dispatch<
+    React.SetStateAction<unstable_CompositeState["loop"]>
+  >;
   /**
    * Sets `focusWrap`.
    */
-  setFocusWrap: React.Dispatch<unstable_CompositeState["focusWrap"]>;
+  setFocusWrap: React.Dispatch<
+    React.SetStateAction<unstable_CompositeState["focusWrap"]>
+  >;
   /**
    * Sets `focusStrategy`.
    * @private
    */
   unstable_setFocusStrategy: React.Dispatch<
-    unstable_CompositeState["unstable_focusStrategy"]
+    React.SetStateAction<unstable_CompositeState["unstable_focusStrategy"]>
   >;
   /**
    * Sets `hasFocusInsideItem`.
    * @private
    */
   unstable_setHasActiveWidget: React.Dispatch<
-    unstable_CompositeState["unstable_hasActiveWidget"]
+    React.SetStateAction<unstable_CompositeState["unstable_hasActiveWidget"]>
   >;
 };
 
@@ -298,7 +306,7 @@ function reducer(
       // Finds the item group based on the DOM hierarchy
       const group = groups.find(r => r.ref.current?.contains(item.ref.current));
       // Group will be null if it's a one-dimensional composite
-      const nextItem = { ...item, groupId: group?.id };
+      const nextItem = { groupId: group?.id, ...item };
       let nextItems = [...items, nextItem];
 
       if (items.length) {

--- a/packages/reakit/src/Composite/README.md
+++ b/packages/reakit/src/Composite/README.md
@@ -191,7 +191,7 @@ Learn more in [Accessibility](/docs/accessibility/).
 
 - `Composite` uses [Tabbable](/docs/tabbable/) (when `focusStrategy` is set to `aria-activedescendant`) and [IdGroup](/docs/id/).
 - `CompositeGroup` uses [Group](/docs/group/) and [Id](/docs/id/).
-- `CompositeItem` uses [Id](/docs/id/) and [Tabbable](/docs/tabbable/).
+- `CompositeItem` uses [Id](/docs/id/) and [Clickable](/docs/clickable/).
 - `CompositeItemWidget` uses [Box](/docs/box/).
 
 Learn more in [Composition](/docs/composition/#props-hooks).
@@ -420,7 +420,7 @@ is `true`, the navigation will wrap based on the value of `orientation`:
   Moves focus to the last item.
 
 - **`setCurrentId`**
-  <code>(value: string | null) =&#62; void</code>
+  <code>(value: SetStateAction&#60;string | null&#62;) =&#62; void</code>
 
   Sets `currentId`.
 

--- a/packages/reakit/src/Dialog/DialogBackdrop.tsx
+++ b/packages/reakit/src/Dialog/DialogBackdrop.tsx
@@ -28,7 +28,7 @@ export const useDialogBackdrop = createHook<
   useState: useDialogState,
 
   useOptions({ modal = true, ...options }) {
-    return { modal, ...options };
+    return { modal, ...options, unstable_setBaseId: undefined };
   },
 
   useProps(options, { wrapElement: htmlWrapElement, ...htmlProps }) {

--- a/packages/reakit/src/Dialog/__tests__/DialogBackdrop-test.tsx
+++ b/packages/reakit/src/Dialog/__tests__/DialogBackdrop-test.tsx
@@ -3,7 +3,7 @@ import { render } from "reakit-test-utils";
 import { DialogBackdrop } from "../DialogBackdrop";
 
 test("render", () => {
-  const { baseElement } = render(<DialogBackdrop />);
+  const { baseElement } = render(<DialogBackdrop baseId="dialog" />);
   expect(baseElement).toMatchInlineSnapshot(`
     <body>
       <div />
@@ -12,6 +12,7 @@ test("render", () => {
       >
         <div
           class="hidden"
+          data-dialog-ref="dialog"
           hidden=""
           style="display: none;"
         />
@@ -21,30 +22,35 @@ test("render", () => {
 });
 
 test("render visible", () => {
-  const { baseElement } = render(<DialogBackdrop visible />);
+  const { baseElement } = render(<DialogBackdrop baseId="dialog" visible />);
   expect(baseElement).toMatchInlineSnapshot(`
-    <body>
-      <div />
-      <div
-        class="__reakit-portal"
-      >
-        <div />
-      </div>
-    </body>
-  `);
+<body>
+  <div />
+  <div
+    class="__reakit-portal"
+  >
+    <div
+      data-dialog-ref="dialog"
+    />
+  </div>
+</body>
+`);
 });
 
 test("render no modal", () => {
-  const { baseElement } = render(<DialogBackdrop modal={false} />);
+  const { baseElement } = render(
+    <DialogBackdrop baseId="dialog" modal={false} />
+  );
   expect(baseElement).toMatchInlineSnapshot(`
-    <body>
-      <div>
-        <div
-          class="hidden"
-          hidden=""
-          style="display: none;"
-        />
-      </div>
-    </body>
-  `);
+<body>
+  <div>
+    <div
+      class="hidden"
+      data-dialog-ref="dialog"
+      hidden=""
+      style="display: none;"
+    />
+  </div>
+</body>
+`);
 });

--- a/packages/reakit/src/Popover/__tests__/PopoverBackdrop-test.tsx
+++ b/packages/reakit/src/Popover/__tests__/PopoverBackdrop-test.tsx
@@ -3,12 +3,13 @@ import { render } from "reakit-test-utils";
 import { PopoverBackdrop } from "../PopoverBackdrop";
 
 test("render", () => {
-  const { baseElement } = render(<PopoverBackdrop />);
+  const { baseElement } = render(<PopoverBackdrop baseId="popover" />);
   expect(baseElement).toMatchInlineSnapshot(`
     <body>
       <div>
         <div
           class="hidden"
+          data-dialog-ref="popover"
           hidden=""
           style="display: none;"
         />
@@ -18,12 +19,14 @@ test("render", () => {
 });
 
 test("render visible", () => {
-  const { baseElement } = render(<PopoverBackdrop visible />);
+  const { baseElement } = render(<PopoverBackdrop baseId="popover" visible />);
   expect(baseElement).toMatchInlineSnapshot(`
-    <body>
-      <div>
-        <div />
-      </div>
-    </body>
-  `);
+<body>
+  <div>
+    <div
+      data-dialog-ref="popover"
+    />
+  </div>
+</body>
+`);
 });

--- a/packages/reakit/src/Rover/README.md
+++ b/packages/reakit/src/Rover/README.md
@@ -90,7 +90,7 @@ Learn more in [Accessibility](/docs/accessibility/).
 
 ## Composition
 
-- `Rover` uses [Tabbable](/docs/tabbable/), and is used by [MenuItem](/docs/menu/), [Radio](/docs/radio/), [Tab](/docs/tab/) and [ToolbarItem](/docs/toolbar/).
+- `Rover` uses [Clickable](/docs/clickable/).
 
 Learn more in [Composition](/docs/composition/#props-hooks).
 

--- a/packages/reakit/src/Tab/README.md
+++ b/packages/reakit/src/Tab/README.md
@@ -33,9 +33,7 @@ function Example() {
   return (
     <>
       <TabList {...tab} aria-label="My tabs">
-        <Tab {...tab} stopId="tab1">
-          Tab 1
-        </Tab>
+        <Tab {...tab}>Tab 1</Tab>
         <Tab {...tab} stopId="tab2" disabled>
           Tab 2
         </Tab>
@@ -43,9 +41,7 @@ function Example() {
           Tab 3
         </Tab>
       </TabList>
-      <TabPanel {...tab} stopId="tab1">
-        Tab 1
-      </TabPanel>
+      <TabPanel {...tab}>Tab 1</TabPanel>
       <TabPanel {...tab} stopId="tab2">
         Tab 2
       </TabPanel>

--- a/packages/reakit/src/Tab/README.md
+++ b/packages/reakit/src/Tab/README.md
@@ -34,20 +34,14 @@ function Example() {
     <>
       <TabList {...tab} aria-label="My tabs">
         <Tab {...tab}>Tab 1</Tab>
-        <Tab {...tab} stopId="tab2" disabled>
+        <Tab {...tab} disabled>
           Tab 2
         </Tab>
-        <Tab {...tab} stopId="tab3">
-          Tab 3
-        </Tab>
+        <Tab {...tab}>Tab 3</Tab>
       </TabList>
       <TabPanel {...tab}>Tab 1</TabPanel>
-      <TabPanel {...tab} stopId="tab2">
-        Tab 2
-      </TabPanel>
-      <TabPanel {...tab} stopId="tab3">
-        Tab 3
-      </TabPanel>
+      <TabPanel {...tab}>Tab 2</TabPanel>
+      <TabPanel {...tab}>Tab 3</TabPanel>
     </>
   );
 }
@@ -55,7 +49,7 @@ function Example() {
 
 ### Default selected tab
 
-You can set the default selected tab by passing a `stopId` to `selectedId` on `useTabState`.
+You can set the default selected tab by passing an `id` to `selectedId` on `useTabState`.
 
 ```jsx
 import { useTabState, Tab, TabList, TabPanel } from "reakit/Tab";
@@ -65,25 +59,41 @@ function Example() {
   return (
     <>
       <TabList {...tab} aria-label="My tabs">
-        <Tab {...tab} stopId="tab1">
-          Tab 1
-        </Tab>
-        <Tab {...tab} stopId="tab2" disabled>
+        <Tab {...tab}>Tab 1</Tab>
+        <Tab {...tab} disabled>
           Tab 2
         </Tab>
-        <Tab {...tab} stopId="tab3">
+        <Tab {...tab} id="tab3">
           Tab 3
         </Tab>
       </TabList>
-      <TabPanel {...tab} stopId="tab1">
-        Tab 1
-      </TabPanel>
-      <TabPanel {...tab} stopId="tab2">
-        Tab 2
-      </TabPanel>
-      <TabPanel {...tab} stopId="tab3">
-        Tab 3
-      </TabPanel>
+      <TabPanel {...tab}>Tab 1</TabPanel>
+      <TabPanel {...tab}>Tab 2</TabPanel>
+      <TabPanel {...tab}>Tab 3</TabPanel>
+    </>
+  );
+}
+```
+
+### No selected tab
+
+By default, the first tab will be selected, but you can unset it by passing `null` to `selectedId` on `useTabState`
+
+```jsx
+import { useTabState, Tab, TabList, TabPanel } from "reakit/Tab";
+
+function Example() {
+  const tab = useTabState({ selectedId: null });
+  return (
+    <>
+      <TabList {...tab} aria-label="My tabs">
+        <Tab {...tab}>Tab 1</Tab>
+        <Tab {...tab}>Tab 2</Tab>
+        <Tab {...tab}>Tab 3</Tab>
+      </TabList>
+      <TabPanel {...tab}>Tab 1</TabPanel>
+      <TabPanel {...tab}>Tab 2</TabPanel>
+      <TabPanel {...tab}>Tab 3</TabPanel>
     </>
   );
 }
@@ -101,25 +111,13 @@ function Example() {
   return (
     <>
       <TabList {...tab} aria-label="My tabs">
-        <Tab {...tab} stopId="tab1">
-          Tab 1
-        </Tab>
-        <Tab {...tab} stopId="tab2" disabled>
-          Tab 2
-        </Tab>
-        <Tab {...tab} stopId="tab3">
-          Tab 3
-        </Tab>
+        <Tab {...tab}>Tab 1</Tab>
+        <Tab {...tab}>Tab 2</Tab>
+        <Tab {...tab}>Tab 3</Tab>
       </TabList>
-      <TabPanel {...tab} stopId="tab1">
-        Tab 1
-      </TabPanel>
-      <TabPanel {...tab} stopId="tab2">
-        Tab 2
-      </TabPanel>
-      <TabPanel {...tab} stopId="tab3">
-        Tab 3
-      </TabPanel>
+      <TabPanel {...tab}>Tab 1</TabPanel>
+      <TabPanel {...tab}>Tab 2</TabPanel>
+      <TabPanel {...tab}>Tab 3</TabPanel>
     </>
   );
 }
@@ -127,7 +125,7 @@ function Example() {
 
 ### Vertical tabs
 
-You can control the orientation of the tabs by setting `orientation` on `useTabState`. Since it composes from [Rover](/docs/rover/), explicitly defining an orientation will change how arrow key navigation works. If it's set to `vertical`, only <kbd>↑</kbd> and <kbd>↓</kbd> will work.
+You can control the orientation of the tabs by setting `orientation` on `useTabState`. Since it composes from [CompositeItem](/docs/composite/), explicitly defining an orientation will change how arrow key navigation works. If it's set to `vertical`, only <kbd>↑</kbd> and <kbd>↓</kbd> will work.
 
 ```jsx
 import { useTabState, Tab, TabList, TabPanel } from "reakit/Tab";
@@ -137,25 +135,13 @@ function Example() {
   return (
     <div style={{ display: "flex" }}>
       <TabList {...tab} aria-label="My tabs">
-        <Tab {...tab} stopId="tab1">
-          Tab 1
-        </Tab>
-        <Tab {...tab} stopId="tab2" disabled>
-          Tab 2
-        </Tab>
-        <Tab {...tab} stopId="tab3">
-          Tab 3
-        </Tab>
+        <Tab {...tab}>Tab 1</Tab>
+        <Tab {...tab}>Tab 2</Tab>
+        <Tab {...tab}>Tab 3</Tab>
       </TabList>
-      <TabPanel {...tab} stopId="tab1">
-        Tab 1
-      </TabPanel>
-      <TabPanel {...tab} stopId="tab2">
-        Tab 2
-      </TabPanel>
-      <TabPanel {...tab} stopId="tab3">
-        Tab 3
-      </TabPanel>
+      <TabPanel {...tab}>Tab 1</TabPanel>
+      <TabPanel {...tab}>Tab 2</TabPanel>
+      <TabPanel {...tab}>Tab 3</TabPanel>
     </div>
   );
 }
@@ -201,13 +187,13 @@ function Example() {
   return (
     <Tabs selectedId="tab3">
       <TabList aria-label="My tabs">
-        <Tab stopId="tab1">Tab 1</Tab>
-        <Tab stopId="tab2">Tab 2</Tab>
-        <Tab stopId="tab3">Tab 3</Tab>
+        <Tab>Tab 1</Tab>
+        <Tab>Tab 2</Tab>
+        <Tab id="tab3">Tab 3</Tab>
       </TabList>
-      <TabPanel stopId="tab1">Tab 1</TabPanel>
-      <TabPanel stopId="tab2">Tab 2</TabPanel>
-      <TabPanel stopId="tab3">Tab 3</TabPanel>
+      <TabPanel>Tab 1</TabPanel>
+      <TabPanel>Tab 2</TabPanel>
+      <TabPanel>Tab 3</TabPanel>
     </Tabs>
   );
 }
@@ -218,18 +204,20 @@ function Example() {
 - `Tab` has role `tab`.
 - `Tab` has `aria-controls` referring to its associated `TabPanel`.
 - The selected `Tab` has `aria-selected` set to `true` and all other `Tab`s have it set to `false`.
-- `Tab` extends the accessibility features of [Rover](/docs/rover/#accessibility).
+- `Tab` extends the accessibility features of [CompositeItem](/docs/composite/#accessibility).
 - `TabList` has role `tablist`.
 - `TabList` has `aria-orientation` set to `vertical` or `horizontal` based on the value of the `orientation` option.
+- `TabList` extends the accessibility features of [Composite](/docs/composite/#accessibility).
 - `TabPanel` has role `tabpanel`.
 - `TabPanel` has `aria-labelledby` referring to its associated `Tab`.
+- `TabPanel` extends the accessibility features of [DisclosureContent](/docs/disclosure/#accessibility).
 
 Learn more in [Accessibility](/docs/accessibility/).
 
 ## Composition
 
-- `Tab` uses [Rover](/docs/rover/).
-- `TabList` uses [Box](/docs/box/).
+- `Tab` uses [CompositeItem](/docs/composite/).
+- `TabList` uses [Composite](/docs/composite/).
 - `TabPanel` uses [DisclosureContent](/docs/disclosure/).
 
 Learn more in [Composition](/docs/composition/#props-hooks).
@@ -245,38 +233,74 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 
   ID that will serve as a base for all the items IDs.
 
+- **`rtl`**
+  <code>boolean</code>
+
+  Determines how `next` and `previous` will behave. If `rtl` is set to `true`,
+then `next` will move focus to the previous item in the DOM.
+
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
-  Defines the orientation of the rover list.
+  Defines the orientation of the composite widget.
 
-- **`stops`**
-  <code>Stop[]</code>
+  When the composite widget has multiple groups (two-dimensional) and `wrap`
+is `true`, the navigation will wrap based on the value of `orientation`:
+  - `undefined`: wraps in both directions.
+  - `horizontal`: wraps horizontally only.
+  - `vertical`: wraps vertically only.
 
-  A list of element refs and IDs of the roving items.
+  If the composite widget has a single row or column (one-dimensional), the
+`orientation` value determines which arrow keys can be used to move focus:
+  - `undefined`: all arrow keys work.
+  - `horizontal`: only left and right arrow keys work.
+  - `vertical`: only up and down arrow keys work.
+
+- **`items`**
+  <code>Item[]</code>
+
+  Lists all the composite items.
+
+- **`groups`**
+  <code>Group[]</code>
+
+  Lists all the composite groups.
 
 - **`currentId`**
   <code>string | null</code>
 
-  The current focused element ID.
-
-- **`unstable_moves`** <span title="Experimental">⚠️</span>
-  <code>number</code>
-
-  Stores the number of moves that have been made by calling `move`, `next`,
-`previous`, `first` or `last`.
+  The current focused item ID.
 
 - **`loop`**
   <code>boolean</code>
 
-  If enabled:
-  - Jumps to the first item when moving next from the last item.
-  - Jumps to the last item when moving previous from the first item.
+  If enabled, moving to the next item from the last one will focus the first
+item and vice-versa. It doesn't work if the composite widget has multiple
+groups (two-dimensional).
+
+- **`focusWrap`**
+  <code>boolean</code>
+
+  If enabled, moving to the next item from the last one in a row or column
+will focus the first item in the next row or column and vice-versa.
+Depending on the value of the `orientation` state, it'll wrap in only one
+direction:
+  - If `orientation` is `undefined`, it wraps in both directions.
+  - If `orientation` is `horizontal`, it wraps horizontally only.
+  - If `orientation` is `vertical`, it wraps vertically only.
+
+  `focusWrap` only works if the composite widget has multiple groups
+(two-dimensional).
 
 - **`selectedId`**
-  <code>string | null</code>
+  <code>string | null | undefined</code>
 
-  The current selected tab's `stopId`.
+  The current selected tab's `id`.
+
+- **`panels`**
+  <code>Item[]</code>
+
+  Lists all the panels.
 
 - **`manual`**
   <code>boolean</code>
@@ -302,12 +326,7 @@ similarly to `readOnly` on form elements. In this case, only
 
   Same as the HTML attribute.
 
-- **`stopId`**
-  <code>string | undefined</code>
-
-  Element ID.
-
-<details><summary>15 state props</summary>
+<details><summary>17 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 
@@ -319,58 +338,74 @@ similarly to `readOnly` on form elements. In this case, only
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
-  Defines the orientation of the rover list.
+  Defines the orientation of the composite widget.
 
-- **`unstable_moves`** <span title="Experimental">⚠️</span>
-  <code>number</code>
+  When the composite widget has multiple groups (two-dimensional) and `wrap`
+is `true`, the navigation will wrap based on the value of `orientation`:
+  - `undefined`: wraps in both directions.
+  - `horizontal`: wraps horizontally only.
+  - `vertical`: wraps vertically only.
 
-  Stores the number of moves that have been made by calling `move`, `next`,
-`previous`, `first` or `last`.
+  If the composite widget has a single row or column (one-dimensional), the
+`orientation` value determines which arrow keys can be used to move focus:
+  - `undefined`: all arrow keys work.
+  - `horizontal`: only left and right arrow keys work.
+  - `vertical`: only up and down arrow keys work.
 
-- **`stops`**
-  <code>Stop[]</code>
+- **`items`**
+  <code>Item[]</code>
 
-  A list of element refs and IDs of the roving items.
+  Lists all the composite items.
 
 - **`currentId`**
   <code>string | null</code>
 
-  The current focused element ID.
+  The current focused item ID.
 
-- **`register`**
-  <code>(id: string, ref: RefObject&#60;HTMLElement&#62;) =&#62; void</code>
+- **`setCurrentId`**
+  <code>(value: SetStateAction&#60;string | null&#62;) =&#62; void</code>
 
-  Registers the element ID and ref in the roving tab index list.
+  Sets `currentId`.
 
-- **`unregister`**
+- **`registerItem`**
+  <code>(item: Item) =&#62; void</code>
+
+  Registers a composite item.
+
+- **`unregisterItem`**
   <code>(id: string) =&#62; void</code>
 
-  Unregisters the roving item.
-
-- **`move`**
-  <code title="(id: string | null, unstable_silent?: boolean | undefined) =&#62; void">(id: string | null, unstable_silent?: boolean |...</code>
-
-  Moves focus to a given element ID.
+  Unregisters a composite item.
 
 - **`next`**
-  <code>() =&#62; void</code>
+  <code>(unstable_allTheWay?: boolean | undefined) =&#62; void</code>
 
-  Moves focus to the next element.
+  Moves focus to the next item.
 
 - **`previous`**
-  <code>() =&#62; void</code>
+  <code>(unstable_allTheWay?: boolean | undefined) =&#62; void</code>
 
-  Moves focus to the previous element.
+  Moves focus to the previous item.
+
+- **`up`**
+  <code>(unstable_allTheWay?: boolean | undefined) =&#62; void</code>
+
+  Moves focus to the item above.
+
+- **`down`**
+  <code>(unstable_allTheWay?: boolean | undefined) =&#62; void</code>
+
+  Moves focus to the item below.
 
 - **`first`**
   <code>() =&#62; void</code>
 
-  Moves focus to the first element.
+  Moves focus to the first item.
 
 - **`last`**
   <code>() =&#62; void</code>
 
-  Moves focus to the last element.
+  Moves focus to the last item.
 
 - **`manual`**
   <code>boolean</code>
@@ -378,25 +413,42 @@ similarly to `readOnly` on form elements. In this case, only
   Whether the tab selection should be manual.
 
 - **`selectedId`**
-  <code>string | null</code>
+  <code>string | null | undefined</code>
 
-  The current selected tab's `stopId`.
+  The current selected tab's `id`.
+
+- **`panels`**
+  <code>Item[]</code>
+
+  Lists all the panels.
 
 - **`select`**
   <code>(id: string | null) =&#62; void</code>
 
-  Selects a tab by its `stopId`.
+  Moves into and selects a tab by its `id`.
 
 </details>
 
 ### `TabList`
+
+- **`disabled`**
+  <code>boolean | undefined</code>
+
+  Same as the HTML attribute.
+
+- **`focusable`**
+  <code>boolean | undefined</code>
+
+  When an element is `disabled`, it may still be `focusable`. It works
+similarly to `readOnly` on form elements. In this case, only
+`aria-disabled` will be set.
 
 - **`id`**
   <code>string | undefined</code>
 
   Same as the HTML attribute.
 
-<details><summary>2 state props</summary>
+<details><summary>4 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 
@@ -405,10 +457,32 @@ similarly to `readOnly` on form elements. In this case, only
 
   ID that will serve as a base for all the items IDs.
 
+- **`items`**
+  <code>Item[]</code>
+
+  Lists all the composite items.
+
+- **`currentId`**
+  <code>string | null</code>
+
+  The current focused item ID.
+
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
 
-  Defines the orientation of the rover list.
+  Defines the orientation of the composite widget.
+
+  When the composite widget has multiple groups (two-dimensional) and `wrap`
+is `true`, the navigation will wrap based on the value of `orientation`:
+  - `undefined`: wraps in both directions.
+  - `horizontal`: wraps horizontally only.
+  - `vertical`: wraps vertically only.
+
+  If the composite widget has a single row or column (one-dimensional), the
+`orientation` value determines which arrow keys can be used to move focus:
+  - `undefined`: all arrow keys work.
+  - `horizontal`: only left and right arrow keys work.
+  - `vertical`: only up and down arrow keys work.
 
 </details>
 
@@ -419,12 +493,12 @@ similarly to `readOnly` on form elements. In this case, only
 
   Same as the HTML attribute.
 
-- **`stopId`**
-  <code>string</code>
+- **`tabId`**
+  <code>string | undefined</code>
 
-  Tab's `stopId`.
+  Tab's id
 
-<details><summary>5 state props</summary>
+<details><summary>9 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 
@@ -452,9 +526,29 @@ given milliseconds.
   Stops animation. It's called automatically if there's a CSS transition.
 It's called after given milliseconds if `animated` is a number.
 
-- **`selectedId`**
-  <code>string | null</code>
+- **`items`**
+  <code>Item[]</code>
 
-  The current selected tab's `stopId`.
+  Lists all the composite items.
+
+- **`selectedId`**
+  <code>string | null | undefined</code>
+
+  The current selected tab's `id`.
+
+- **`panels`**
+  <code>Item[]</code>
+
+  Lists all the panels.
+
+- **`registerPanel`**
+  <code>(item: Item) =&#62; void</code>
+
+  Registers a tab panel.
+
+- **`unregisterPanel`**
+  <code>(id: string) =&#62; void</code>
+
+  Unregisters a tab panel.
 
 </details>

--- a/packages/reakit/src/Tab/README.md
+++ b/packages/reakit/src/Tab/README.md
@@ -256,16 +256,6 @@ is `true`, the navigation will wrap based on the value of `orientation`:
   - `horizontal`: only left and right arrow keys work.
   - `vertical`: only up and down arrow keys work.
 
-- **`items`**
-  <code>Item[]</code>
-
-  Lists all the composite items.
-
-- **`groups`**
-  <code>Group[]</code>
-
-  Lists all the composite groups.
-
 - **`currentId`**
   <code>string | null</code>
 
@@ -296,11 +286,6 @@ direction:
   <code>string | null | undefined</code>
 
   The current selected tab's `id`.
-
-- **`panels`**
-  <code>Item[]</code>
-
-  Lists all the panels.
 
 - **`manual`**
   <code>boolean</code>
@@ -352,15 +337,15 @@ is `true`, the navigation will wrap based on the value of `orientation`:
   - `horizontal`: only left and right arrow keys work.
   - `vertical`: only up and down arrow keys work.
 
-- **`items`**
-  <code>Item[]</code>
-
-  Lists all the composite items.
-
 - **`currentId`**
   <code>string | null</code>
 
   The current focused item ID.
+
+- **`items`**
+  <code>Item[]</code>
+
+  Lists all the composite items.
 
 - **`setCurrentId`**
   <code>(value: SetStateAction&#60;string | null&#62;) =&#62; void</code>
@@ -457,15 +442,15 @@ similarly to `readOnly` on form elements. In this case, only
 
   ID that will serve as a base for all the items IDs.
 
-- **`items`**
-  <code>Item[]</code>
-
-  Lists all the composite items.
-
 - **`currentId`**
   <code>string | null</code>
 
   The current focused item ID.
+
+- **`items`**
+  <code>Item[]</code>
+
+  Lists all the composite items.
 
 - **`orientation`**
   <code>&#34;horizontal&#34; | &#34;vertical&#34; | undefined</code>
@@ -526,15 +511,15 @@ given milliseconds.
   Stops animation. It's called automatically if there's a CSS transition.
 It's called after given milliseconds if `animated` is a number.
 
-- **`items`**
-  <code>Item[]</code>
-
-  Lists all the composite items.
-
 - **`selectedId`**
   <code>string | null | undefined</code>
 
   The current selected tab's `id`.
+
+- **`items`**
+  <code>Item[]</code>
+
+  Lists all the composite items.
 
 - **`panels`**
   <code>Item[]</code>

--- a/packages/reakit/src/Tab/Tab.ts
+++ b/packages/reakit/src/Tab/Tab.ts
@@ -2,52 +2,62 @@ import * as React from "react";
 import { createComponent } from "reakit-system/createComponent";
 import { createHook } from "reakit-system/createHook";
 import { useAllCallbacks } from "reakit-utils/useAllCallbacks";
-import { RoverOptions, RoverHTMLProps, useRover } from "../Rover/Rover";
-import { getTabId, getTabPanelId } from "./__utils";
+import {
+  unstable_CompositeItemOptions as CompositeItemOptions,
+  unstable_CompositeItemHTMLProps as CompositeItemHTMLProps,
+  unstable_useCompositeItem as useCompositeItem
+} from "../Composite/CompositeItem";
 import { useTabState, TabStateReturn } from "./TabState";
 
-export type TabOptions = RoverOptions &
-  Pick<Required<RoverOptions>, "stopId"> &
+export type TabOptions = CompositeItemOptions &
   Pick<Partial<TabStateReturn>, "manual"> &
-  Pick<TabStateReturn, "baseId" | "selectedId" | "select">;
+  Pick<TabStateReturn, "panels" | "selectedId" | "select">;
 
-export type TabHTMLProps = RoverHTMLProps;
+export type TabHTMLProps = CompositeItemHTMLProps;
 
 export type TabProps = TabOptions & TabHTMLProps;
 
+function getTabPanelId(options: TabOptions) {
+  return options.panels?.find(panel => panel.groupId === options.id)?.id;
+}
+
 export const useTab = createHook<TabOptions, TabHTMLProps>({
   name: "Tab",
-  compose: useRover,
+  compose: useCompositeItem,
   useState: useTabState,
 
   useOptions({ focusable = true, ...options }) {
-    return { focusable, ...options };
+    return { focusable, id: options.stopId, ...options };
   },
 
   useProps(
     options,
     { onClick: htmlOnClick, onFocus: htmlOnFocus, ...htmlProps }
   ) {
-    const stopId = options.stopId || options.id || htmlProps.id;
-    const selected = options.selectedId === stopId;
+    const selected = options.selectedId === options.id;
 
     const onClick = React.useCallback(() => {
-      if (stopId && !options.disabled && !selected) {
-        options.select(stopId);
+      if (options.id && !options.disabled && !selected) {
+        options.select?.(options.id);
       }
-    }, [options.disabled, selected, options.select, stopId]);
+    }, [options.disabled, selected, options.select, options.id]);
 
     const onFocus = React.useCallback(() => {
-      if (stopId && !options.disabled && !options.manual && !selected) {
-        options.select(stopId);
+      if (options.id && !options.disabled && !options.manual && !selected) {
+        options.select?.(options.id);
       }
-    }, [options.disabled, options.manual, selected, options.select, stopId]);
+    }, [
+      options.id,
+      options.disabled,
+      options.manual,
+      selected,
+      options.select
+    ]);
 
     return {
       role: "tab",
-      id: getTabId(stopId, options.baseId),
       "aria-selected": selected,
-      "aria-controls": getTabPanelId(stopId, options.baseId),
+      "aria-controls": getTabPanelId(options),
       onClick: useAllCallbacks(onClick, htmlOnClick),
       onFocus: useAllCallbacks(onFocus, htmlOnFocus),
       ...htmlProps

--- a/packages/reakit/src/Tab/TabList.tsx
+++ b/packages/reakit/src/Tab/TabList.tsx
@@ -3,22 +3,22 @@ import { createComponent } from "reakit-system/createComponent";
 import { useCreateElement } from "reakit-system/useCreateElement";
 import { createHook } from "reakit-system/createHook";
 import {
-  unstable_IdGroupOptions,
-  unstable_IdGroupHTMLProps,
-  unstable_useIdGroup
-} from "../Id/IdGroup";
+  unstable_CompositeOptions,
+  unstable_CompositeHTMLProps,
+  unstable_useComposite
+} from "../Composite/Composite";
 import { useTabState, TabStateReturn } from "./TabState";
 
-export type TabListOptions = unstable_IdGroupOptions &
+export type TabListOptions = unstable_CompositeOptions &
   Pick<Partial<TabStateReturn>, "orientation">;
 
-export type TabListHTMLProps = unstable_IdGroupHTMLProps;
+export type TabListHTMLProps = unstable_CompositeHTMLProps;
 
 export type TabListProps = TabListOptions & TabListHTMLProps;
 
 export const useTabList = createHook<TabListOptions, TabListHTMLProps>({
   name: "TabList",
-  compose: unstable_useIdGroup,
+  compose: unstable_useComposite,
   useState: useTabState,
 
   useProps(options, htmlProps) {

--- a/packages/reakit/src/Tab/TabPanel.ts
+++ b/packages/reakit/src/Tab/TabPanel.ts
@@ -1,46 +1,99 @@
+import * as React from "react";
 import { createComponent } from "reakit-system/createComponent";
 import { createHook } from "reakit-system/createHook";
+import { warning } from "reakit-utils/warning";
+import { useForkRef } from "reakit-utils/useForkRef";
 import {
   DisclosureContentOptions,
   DisclosureContentHTMLProps,
   useDisclosureContent
 } from "../Disclosure/DisclosureContent";
-import { getTabPanelId, getTabId } from "./__utils";
+import {
+  unstable_useId,
+  unstable_IdOptions,
+  unstable_IdHTMLProps
+} from "../Id/Id";
 import { useTabState, TabStateReturn } from "./TabState";
 
 export type TabPanelOptions = DisclosureContentOptions &
-  Pick<TabStateReturn, "baseId" | "selectedId"> & {
+  unstable_IdOptions &
+  Pick<
+    TabStateReturn,
+    "selectedId" | "registerPanel" | "unregisterPanel" | "panels" | "items"
+  > & {
     /**
      * Tab's `stopId`.
+     * @deprecated Use `tabId` instead.
+     * @private
      */
-    stopId: string;
+    stopId?: string;
+    /**
+     * Tab's id
+     */
+    tabId?: string;
   };
 
-export type TabPanelHTMLProps = DisclosureContentHTMLProps;
+export type TabPanelHTMLProps = DisclosureContentHTMLProps &
+  unstable_IdHTMLProps;
 
 export type TabPanelProps = TabPanelOptions & TabPanelHTMLProps;
 
+function getTabId({ panels, id, tabId, stopId, items }: TabPanelOptions) {
+  const panel = panels?.find(p => p.id === id);
+  const maybeId = panel?.groupId || tabId || stopId;
+  if (panels && items && panel && !maybeId) {
+    const tabIds = panels.map(p => p.groupId).filter(Boolean);
+    const index = panels.filter(p => !p.groupId).indexOf(panel);
+    const filteredItems = items.filter(i => tabIds.indexOf(i.id) === -1);
+    return filteredItems[index]?.id;
+  }
+  return maybeId;
+}
+
 export const useTabPanel = createHook<TabPanelOptions, TabPanelHTMLProps>({
   name: "TabPanel",
-  compose: useDisclosureContent,
+  compose: [unstable_useId, useDisclosureContent],
   useState: useTabState,
-  keys: ["stopId"],
+  keys: ["stopId", "tabId"],
 
   useOptions(options) {
+    return { ...options, unstable_setBaseId: undefined };
+  },
+
+  useProps(options, { ref: htmlRef, ...htmlProps }) {
+    warning(
+      Boolean(options.stopId),
+      "[reakit/TabPanel]",
+      "`TabPanel`'s `stopId` prop is deprecated. Use `tabId` instead.",
+      "See https://reakit.io/docs/tab"
+    );
+
+    const { id } = options;
+    const tabId = getTabId(options);
+    const ref = React.useRef<HTMLElement>(null);
+
+    React.useEffect(() => {
+      if (!id) return undefined;
+      options.registerPanel?.({ id, ref, groupId: tabId });
+      return () => {
+        options.unregisterPanel?.(id);
+      };
+    }, [tabId, id, options.registerPanel, options.unregisterPanel]);
+
     return {
-      visible: options.selectedId === options.stopId,
-      ...options,
-      unstable_setBaseId: undefined
+      ref: useForkRef(ref, htmlRef),
+      role: "tabpanel",
+      tabIndex: 0,
+      "aria-labelledby": tabId,
+      ...htmlProps
     };
   },
 
-  useProps(options, htmlProps) {
+  useComposeOptions(options) {
+    const tabId = getTabId(options);
     return {
-      role: "tabpanel",
-      tabIndex: 0,
-      id: getTabPanelId(options.stopId, options.baseId),
-      "aria-labelledby": getTabId(options.stopId, options.baseId),
-      ...htmlProps
+      visible: tabId ? options.selectedId === tabId : false,
+      ...options
     };
   }
 });

--- a/packages/reakit/src/Tab/TabState.ts
+++ b/packages/reakit/src/Tab/TabState.ts
@@ -6,7 +6,8 @@ import {
 import {
   unstable_useCompositeState as useCompositeState,
   unstable_CompositeState as CompositeState,
-  unstable_CompositeActions as CompositeActions
+  unstable_CompositeActions as CompositeActions,
+  unstable_CompositeInitialState as CompositeInitialState
 } from "../Composite/CompositeState";
 
 export type TabState = CompositeState & {
@@ -43,7 +44,8 @@ export type TabActions = CompositeActions & {
   unregisterPanel: TabActions["unregisterItem"];
 };
 
-export type TabInitialState = Partial<TabState>;
+export type TabInitialState = CompositeInitialState &
+  Partial<Pick<TabState, "selectedId" | "manual">>;
 
 export type TabStateReturn = TabState & TabActions;
 

--- a/packages/reakit/src/Tab/__tests__/Tab-test.tsx
+++ b/packages/reakit/src/Tab/__tests__/Tab-test.tsx
@@ -1,21 +1,24 @@
 import * as React from "react";
 import { render } from "reakit-test-utils";
-import { Tab } from "../Tab";
+import { Tab, TabProps } from "../Tab";
 
-const props: Parameters<typeof Tab>[0] = {
+const props: TabProps = {
   baseId: "base",
-  stopId: "tab",
-  stops: [],
+  id: "tab",
+  items: [],
+  panels: [],
   currentId: null,
   selectedId: null,
-  register: jest.fn(),
-  unregister: jest.fn(),
-  move: jest.fn(),
+  registerItem: jest.fn(),
+  unregisterItem: jest.fn(),
+  setCurrentId: jest.fn(),
   select: jest.fn(),
   next: jest.fn(),
   previous: jest.fn(),
   first: jest.fn(),
-  last: jest.fn()
+  last: jest.fn(),
+  up: jest.fn(),
+  down: jest.fn()
 };
 
 test("render", () => {
@@ -24,60 +27,10 @@ test("render", () => {
     <body>
       <div>
         <button
-          aria-controls="base-tab-panel"
           aria-selected="false"
           id="tab"
           role="tab"
-          stops=""
           tabindex="-1"
-        >
-          tab
-        </button>
-      </div>
-    </body>
-  `);
-});
-
-test("render active", () => {
-  const { baseElement } = render(
-    <Tab {...props} currentId="tab">
-      tab
-    </Tab>
-  );
-  expect(baseElement).toMatchInlineSnapshot(`
-    <body>
-      <div>
-        <button
-          aria-controls="base-tab-panel"
-          aria-selected="false"
-          id="tab"
-          role="tab"
-          stops=""
-          tabindex="0"
-        >
-          tab
-        </button>
-      </div>
-    </body>
-  `);
-});
-
-test("render active selected", () => {
-  const { baseElement } = render(
-    <Tab {...props} currentId="tab" selectedId="tab">
-      tab
-    </Tab>
-  );
-  expect(baseElement).toMatchInlineSnapshot(`
-    <body>
-      <div>
-        <button
-          aria-controls="base-tab-panel"
-          aria-selected="true"
-          id="tab"
-          role="tab"
-          stops=""
-          tabindex="0"
         >
           tab
         </button>
@@ -88,16 +41,81 @@ test("render active selected", () => {
 
 test("render without state props", () => {
   // @ts-ignore
-  const { baseElement } = render(<Tab id="test">tab</Tab>);
+  const { baseElement } = render(<Tab id="tab">tab</Tab>);
   expect(baseElement).toMatchInlineSnapshot(`
 <body>
   <div>
     <button
-      aria-controls="test-panel"
       aria-selected="false"
-      id="test"
+      id="tab"
       role="tab"
       tabindex="-1"
+    >
+      tab
+    </button>
+  </div>
+</body>
+`);
+});
+
+test("render active", () => {
+  const { baseElement } = render(
+    <Tab {...props} currentId="tab">
+      tab
+    </Tab>
+  );
+  expect(baseElement).toMatchInlineSnapshot(`
+<body>
+  <div>
+    <button
+      aria-selected="false"
+      id="tab"
+      role="tab"
+      tabindex="0"
+    >
+      tab
+    </button>
+  </div>
+</body>
+`);
+});
+
+test("render selected", () => {
+  const { baseElement } = render(
+    <Tab {...props} selectedId="tab">
+      tab
+    </Tab>
+  );
+  expect(baseElement).toMatchInlineSnapshot(`
+<body>
+  <div>
+    <button
+      aria-selected="true"
+      id="tab"
+      role="tab"
+      tabindex="-1"
+    >
+      tab
+    </button>
+  </div>
+</body>
+`);
+});
+
+test("render active selected", () => {
+  const { baseElement } = render(
+    <Tab {...props} currentId="tab" selectedId="tab">
+      tab
+    </Tab>
+  );
+  expect(baseElement).toMatchInlineSnapshot(`
+<body>
+  <div>
+    <button
+      aria-selected="true"
+      id="tab"
+      role="tab"
+      tabindex="0"
     >
       tab
     </button>

--- a/packages/reakit/src/Tab/__tests__/Tab-test.tsx
+++ b/packages/reakit/src/Tab/__tests__/Tab-test.tsx
@@ -26,8 +26,9 @@ test("render", () => {
         <button
           aria-controls="base-tab-panel"
           aria-selected="false"
-          id="base-tab"
+          id="tab"
           role="tab"
+          stops=""
           tabindex="-1"
         >
           tab
@@ -44,20 +45,21 @@ test("render active", () => {
     </Tab>
   );
   expect(baseElement).toMatchInlineSnapshot(`
-<body>
-  <div>
-    <button
-      aria-controls="base-tab-panel"
-      aria-selected="false"
-      id="base-tab"
-      role="tab"
-      tabindex="0"
-    >
-      tab
-    </button>
-  </div>
-</body>
-`);
+    <body>
+      <div>
+        <button
+          aria-controls="base-tab-panel"
+          aria-selected="false"
+          id="tab"
+          role="tab"
+          stops=""
+          tabindex="0"
+        >
+          tab
+        </button>
+      </div>
+    </body>
+  `);
 });
 
 test("render active selected", () => {
@@ -67,20 +69,21 @@ test("render active selected", () => {
     </Tab>
   );
   expect(baseElement).toMatchInlineSnapshot(`
-<body>
-  <div>
-    <button
-      aria-controls="base-tab-panel"
-      aria-selected="true"
-      id="base-tab"
-      role="tab"
-      tabindex="0"
-    >
-      tab
-    </button>
-  </div>
-</body>
-`);
+    <body>
+      <div>
+        <button
+          aria-controls="base-tab-panel"
+          aria-selected="true"
+          id="tab"
+          role="tab"
+          stops=""
+          tabindex="0"
+        >
+          tab
+        </button>
+      </div>
+    </body>
+  `);
 });
 
 test("render without state props", () => {

--- a/packages/reakit/src/Tab/__tests__/TabList-test.tsx
+++ b/packages/reakit/src/Tab/__tests__/TabList-test.tsx
@@ -1,9 +1,12 @@
 import * as React from "react";
 import { render } from "reakit-test-utils";
-import { TabList } from "../TabList";
+import { TabList, TabListProps } from "../TabList";
 
-const props: Parameters<typeof TabList>[0] = {
-  "aria-label": "tablist"
+const props: TabListProps = {
+  "aria-label": "tablist",
+  id: "base",
+  items: [],
+  currentId: null
 };
 
 test("render", () => {
@@ -13,7 +16,7 @@ test("render", () => {
       <div>
         <div
           aria-label="tablist"
-          id="id-f3t0fi"
+          id="base"
           role="tablist"
         >
           tablist
@@ -21,6 +24,28 @@ test("render", () => {
       </div>
     </body>
   `);
+});
+
+test("render without state props", () => {
+  const { baseElement } = render(
+    // @ts-ignore
+    <TabList id="base" aria-label="tablist">
+      tablist
+    </TabList>
+  );
+  expect(baseElement).toMatchInlineSnapshot(`
+<body>
+  <div>
+    <div
+      aria-label="tablist"
+      id="base"
+      role="tablist"
+    >
+      tablist
+    </div>
+  </div>
+</body>
+`);
 });
 
 test("render orientation", () => {
@@ -35,7 +60,7 @@ test("render orientation", () => {
         <div
           aria-label="tablist"
           aria-orientation="horizontal"
-          id="id-iqsgqj"
+          id="base"
           role="tablist"
         >
           tablist

--- a/packages/reakit/src/Tab/__tests__/TabList-test.tsx
+++ b/packages/reakit/src/Tab/__tests__/TabList-test.tsx
@@ -13,6 +13,7 @@ test("render", () => {
       <div>
         <div
           aria-label="tablist"
+          id="id-f3t0fi"
           role="tablist"
         >
           tablist
@@ -34,6 +35,7 @@ test("render orientation", () => {
         <div
           aria-label="tablist"
           aria-orientation="horizontal"
+          id="id-iqsgqj"
           role="tablist"
         >
           tablist

--- a/packages/reakit/src/Tab/__tests__/TabPanel-test.tsx
+++ b/packages/reakit/src/Tab/__tests__/TabPanel-test.tsx
@@ -1,11 +1,13 @@
 import * as React from "react";
 import { render } from "reakit-test-utils";
-import { TabPanel } from "../TabPanel";
+import { TabPanel, TabPanelProps } from "../TabPanel";
 
-const props: Parameters<typeof TabPanel>[0] = {
-  baseId: "base",
-  stopId: "tab",
-  selectedId: null
+const props: TabPanelProps = {
+  id: "panel",
+  registerPanel: jest.fn(),
+  unregisterPanel: jest.fn(),
+  panels: [],
+  items: []
 };
 
 test("render", () => {
@@ -16,51 +18,9 @@ test("render", () => {
         <div
           class="hidden"
           hidden=""
-          id="base"
+          id="panel"
           role="tabpanel"
           style="display: none;"
-          tabindex="0"
-        >
-          tabpanel
-        </div>
-      </div>
-    </body>
-  `);
-});
-
-test("render visible", () => {
-  const { baseElement } = render(
-    <TabPanel {...props} visible>
-      tabpanel
-    </TabPanel>
-  );
-  expect(baseElement).toMatchInlineSnapshot(`
-    <body>
-      <div>
-        <div
-          id="base"
-          role="tabpanel"
-          tabindex="0"
-        >
-          tabpanel
-        </div>
-      </div>
-    </body>
-  `);
-});
-
-test("render selected", () => {
-  const { baseElement } = render(
-    <TabPanel {...props} selectedId="tab">
-      tabpanel
-    </TabPanel>
-  );
-  expect(baseElement).toMatchInlineSnapshot(`
-    <body>
-      <div>
-        <div
-          id="base"
-          role="tabpanel"
           tabindex="0"
         >
           tabpanel
@@ -72,42 +32,42 @@ test("render selected", () => {
 
 test("render without state props", () => {
   // @ts-ignore
-  const { baseElement } = render(<TabPanel>tabpanel</TabPanel>);
+  const { baseElement } = render(<TabPanel id="panel">tabpanel</TabPanel>);
   expect(baseElement).toMatchInlineSnapshot(`
-    <body>
-      <div>
-        <div
-          class="hidden"
-          hidden=""
-          id="id-a5pmrk"
-          role="tabpanel"
-          style="display: none;"
-          tabindex="0"
-        >
-          tabpanel
-        </div>
-      </div>
-    </body>
-  `);
+<body>
+  <div>
+    <div
+      class="hidden"
+      hidden=""
+      id="panel"
+      role="tabpanel"
+      style="display: none;"
+      tabindex="0"
+    >
+      tabpanel
+    </div>
+  </div>
+</body>
+`);
 });
 
-test("render without state props with id", () => {
-  // @ts-ignore
-  const { baseElement } = render(<TabPanel id="test">tabpanel</TabPanel>);
+test("render visible", () => {
+  const { baseElement } = render(
+    <TabPanel {...props} visible>
+      tabpanel
+    </TabPanel>
+  );
   expect(baseElement).toMatchInlineSnapshot(`
-    <body>
-      <div>
-        <div
-          class="hidden"
-          hidden=""
-          id="test"
-          role="tabpanel"
-          style="display: none;"
-          tabindex="0"
-        >
-          tabpanel
-        </div>
-      </div>
-    </body>
-  `);
+<body>
+  <div>
+    <div
+      id="panel"
+      role="tabpanel"
+      tabindex="0"
+    >
+      tabpanel
+    </div>
+  </div>
+</body>
+`);
 });

--- a/packages/reakit/src/Tab/__tests__/TabPanel-test.tsx
+++ b/packages/reakit/src/Tab/__tests__/TabPanel-test.tsx
@@ -14,10 +14,9 @@ test("render", () => {
     <body>
       <div>
         <div
-          aria-labelledby="base-tab"
           class="hidden"
           hidden=""
-          id="base-tab-panel"
+          id="base"
           role="tabpanel"
           style="display: none;"
           tabindex="0"
@@ -39,8 +38,7 @@ test("render visible", () => {
     <body>
       <div>
         <div
-          aria-labelledby="base-tab"
-          id="base-tab-panel"
+          id="base"
           role="tabpanel"
           tabindex="0"
         >
@@ -61,8 +59,7 @@ test("render selected", () => {
     <body>
       <div>
         <div
-          aria-labelledby="base-tab"
-          id="base-tab-panel"
+          id="base"
           role="tabpanel"
           tabindex="0"
         >
@@ -80,7 +77,11 @@ test("render without state props", () => {
     <body>
       <div>
         <div
+          class="hidden"
+          hidden=""
+          id="id-a5pmrk"
           role="tabpanel"
+          style="display: none;"
           tabindex="0"
         >
           tabpanel
@@ -97,8 +98,11 @@ test("render without state props with id", () => {
     <body>
       <div>
         <div
+          class="hidden"
+          hidden=""
           id="test"
           role="tabpanel"
+          style="display: none;"
           tabindex="0"
         >
           tabpanel

--- a/packages/reakit/src/Tab/__tests__/TabState-test.ts
+++ b/packages/reakit/src/Tab/__tests__/TabState-test.ts
@@ -22,7 +22,7 @@ test("initial state", () => {
       "orientation": undefined,
       "panels": Array [],
       "rtl": false,
-      "selectedId": null,
+      "selectedId": undefined,
       "unstable_focusStrategy": "roving-tabindex",
       "unstable_hasActiveWidget": false,
       "unstable_idCountRef": Object {
@@ -31,35 +31,4 @@ test("initial state", () => {
       "unstable_moves": 0,
     }
   `);
-});
-
-test("initial state selectedId", () => {
-  const result = render({ selectedId: "a" });
-  expect(result.current).toMatchInlineSnapshot(
-    {
-      currentId: "a",
-      selectedId: "a"
-    },
-    `
-    Object {
-      "baseId": "base",
-      "currentId": "a",
-      "focusWrap": false,
-      "groups": Array [],
-      "items": Array [],
-      "loop": true,
-      "manual": false,
-      "orientation": undefined,
-      "panels": Array [],
-      "rtl": false,
-      "selectedId": "a",
-      "unstable_focusStrategy": "roving-tabindex",
-      "unstable_hasActiveWidget": false,
-      "unstable_idCountRef": Object {
-        "current": 0,
-      },
-      "unstable_moves": 0,
-    }
-  `
-  );
 });

--- a/packages/reakit/src/Tab/__tests__/TabState-test.ts
+++ b/packages/reakit/src/Tab/__tests__/TabState-test.ts
@@ -14,16 +14,21 @@ test("initial state", () => {
     Object {
       "baseId": "base",
       "currentId": null,
+      "focusWrap": false,
+      "groups": Array [],
+      "items": Array [],
       "loop": true,
       "manual": false,
       "orientation": undefined,
+      "panels": Array [],
+      "rtl": false,
       "selectedId": null,
-      "stops": Array [],
+      "unstable_focusStrategy": "roving-tabindex",
+      "unstable_hasActiveWidget": false,
       "unstable_idCountRef": Object {
         "current": 0,
       },
       "unstable_moves": 0,
-      "unstable_pastId": null,
     }
   `);
 });
@@ -39,16 +44,21 @@ test("initial state selectedId", () => {
     Object {
       "baseId": "base",
       "currentId": "a",
+      "focusWrap": false,
+      "groups": Array [],
+      "items": Array [],
       "loop": true,
       "manual": false,
       "orientation": undefined,
+      "panels": Array [],
+      "rtl": false,
       "selectedId": "a",
-      "stops": Array [],
+      "unstable_focusStrategy": "roving-tabindex",
+      "unstable_hasActiveWidget": false,
       "unstable_idCountRef": Object {
         "current": 0,
       },
       "unstable_moves": 0,
-      "unstable_pastId": null,
     }
   `
   );

--- a/packages/reakit/src/Tab/__tests__/index-test.tsx
+++ b/packages/reakit/src/Tab/__tests__/index-test.tsx
@@ -24,6 +24,28 @@ test("first tab is selected", () => {
   expect($("tabpanel3")).not.toBeVisible();
 });
 
+test("first tab is selected with tablist below", () => {
+  const Test = () => {
+    const tab = useTabState();
+    return (
+      <>
+        <TabPanel {...tab}>tabpanel1</TabPanel>
+        <TabPanel {...tab}>tabpanel2</TabPanel>
+        <TabPanel {...tab}>tabpanel3</TabPanel>
+        <TabList {...tab} aria-label="tablist">
+          <Tab {...tab}>tab1</Tab>
+          <Tab {...tab}>tab2</Tab>
+          <Tab {...tab}>tab3</Tab>
+        </TabList>
+      </>
+    );
+  };
+  const { getByText: $ } = render(<Test />);
+  expect($("tabpanel1")).toBeVisible();
+  expect($("tabpanel2")).not.toBeVisible();
+  expect($("tabpanel3")).not.toBeVisible();
+});
+
 test("focusing tab reveals the panel", () => {
   const Test = () => {
     const tab = useTabState();
@@ -138,6 +160,30 @@ test("tab is selected based on the value of selectedId", () => {
   expect($("tabpanel3")).not.toBeVisible();
 });
 
+test("tab is selected based on the value of selectedId with tablist below", () => {
+  const Test = () => {
+    const tab = useTabState({ selectedId: "tab2" });
+    return (
+      <>
+        <TabPanel {...tab}>tabpanel1</TabPanel>
+        <TabPanel {...tab}>tabpanel2</TabPanel>
+        <TabPanel {...tab}>tabpanel3</TabPanel>
+        <TabList {...tab} aria-label="tablist">
+          <Tab {...tab}>tab1</Tab>
+          <Tab {...tab} id="tab2">
+            tab2
+          </Tab>
+          <Tab {...tab}>tab3</Tab>
+        </TabList>
+      </>
+    );
+  };
+  const { getByText: $ } = render(<Test />);
+  expect($("tabpanel1")).not.toBeVisible();
+  expect($("tabpanel2")).toBeVisible();
+  expect($("tabpanel3")).not.toBeVisible();
+});
+
 test("no tab is selected if selectedId is null", () => {
   const Test = () => {
     const tab = useTabState({ selectedId: null });
@@ -175,6 +221,34 @@ test("select the last selected tab when the current one is unmounted", () => {
         {renderTab2 && <TabPanel {...tab}>tabpanel2</TabPanel>}
         <TabPanel {...tab}>tabpanel3</TabPanel>
         <TabPanel {...tab}>tabpanel4</TabPanel>
+      </>
+    );
+  };
+  const { getByText: $, rerender } = render(<Test renderTab2 />);
+  expect($("tabpanel1")).toBeVisible();
+  click($("tab4"));
+  expect($("tabpanel4")).toBeVisible();
+  click($("tab2"));
+  expect($("tabpanel2")).toBeVisible();
+  rerender(<Test />);
+  expect($("tabpanel4")).toBeVisible();
+});
+
+test("select the last selected tab when the current one is unmounted with tablist below", () => {
+  const Test = ({ renderTab2 = false }) => {
+    const tab = useTabState();
+    return (
+      <>
+        <TabPanel {...tab}>tabpanel1</TabPanel>
+        {renderTab2 && <TabPanel {...tab}>tabpanel2</TabPanel>}
+        <TabPanel {...tab}>tabpanel3</TabPanel>
+        <TabPanel {...tab}>tabpanel4</TabPanel>
+        <TabList {...tab} aria-label="tablist">
+          <Tab {...tab}>tab1</Tab>
+          {renderTab2 && <Tab {...tab}>tab2</Tab>}
+          <Tab {...tab}>tab3</Tab>
+          <Tab {...tab}>tab4</Tab>
+        </TabList>
       </>
     );
   };

--- a/packages/reakit/src/Tab/__tests__/index-test.tsx
+++ b/packages/reakit/src/Tab/__tests__/index-test.tsx
@@ -1,106 +1,271 @@
 import * as React from "react";
 import { render, focus, click } from "reakit-test-utils";
-import { Tab, TabList, TabPanel, useTabState, TabInitialState } from "..";
+import { Tab, TabList, TabPanel, useTabState } from "..";
 
-function SimpleTest(props: TabInitialState = {}) {
-  const tab = useTabState(props);
-  return (
-    <>
-      <TabList {...tab} aria-label="tablist">
-        <Tab {...tab} stopId="tab1">
-          tab1
-        </Tab>
-        <Tab {...tab} stopId="tab2">
-          tab2
-        </Tab>
-        <Tab {...tab} stopId="tab3">
-          tab3
-        </Tab>
-      </TabList>
-      <TabPanel {...tab} stopId="tab1">
-        tabpanel1
-      </TabPanel>
-      <TabPanel {...tab} stopId="tab2">
-        tabpanel2
-      </TabPanel>
-      <TabPanel {...tab} stopId="tab3">
-        tabpanel3
-      </TabPanel>
-    </>
-  );
-}
-
-test("no tab is selected", () => {
-  const { getByText } = render(<SimpleTest />);
-  const tabpanel1 = getByText("tabpanel1");
-  const tabpanel2 = getByText("tabpanel2");
-  const tabpanel3 = getByText("tabpanel3");
-  expect(tabpanel1).not.toBeVisible();
-  expect(tabpanel2).not.toBeVisible();
-  expect(tabpanel3).not.toBeVisible();
+test("first tab is selected", () => {
+  const Test = () => {
+    const tab = useTabState();
+    return (
+      <>
+        <TabList {...tab} aria-label="tablist">
+          <Tab {...tab}>tab1</Tab>
+          <Tab {...tab}>tab2</Tab>
+          <Tab {...tab}>tab3</Tab>
+        </TabList>
+        <TabPanel {...tab}>tabpanel1</TabPanel>
+        <TabPanel {...tab}>tabpanel2</TabPanel>
+        <TabPanel {...tab}>tabpanel3</TabPanel>
+      </>
+    );
+  };
+  const { getByText: $ } = render(<Test />);
+  expect($("tabpanel1")).toBeVisible();
+  expect($("tabpanel2")).not.toBeVisible();
+  expect($("tabpanel3")).not.toBeVisible();
 });
 
 test("focusing tab reveals the panel", () => {
-  const { getByText } = render(<SimpleTest />);
-  const tab1 = getByText("tab1");
-  const tabpanel1 = getByText("tabpanel1");
-  const tabpanel2 = getByText("tabpanel2");
-  const tabpanel3 = getByText("tabpanel3");
-  expect(tabpanel1).not.toBeVisible();
-  focus(tab1);
-  expect(tabpanel1).toBeVisible();
-  expect(tabpanel2).not.toBeVisible();
-  expect(tabpanel3).not.toBeVisible();
+  const Test = () => {
+    const tab = useTabState();
+    return (
+      <>
+        <TabList {...tab} aria-label="tablist">
+          <Tab {...tab}>tab1</Tab>
+          <Tab {...tab}>tab2</Tab>
+          <Tab {...tab}>tab3</Tab>
+        </TabList>
+        <TabPanel {...tab}>tabpanel1</TabPanel>
+        <TabPanel {...tab}>tabpanel2</TabPanel>
+        <TabPanel {...tab}>tabpanel3</TabPanel>
+      </>
+    );
+  };
+  const { getByText: $ } = render(<Test />);
+  expect($("tabpanel2")).not.toBeVisible();
+  focus($("tab2"));
+  expect($("tabpanel1")).not.toBeVisible();
+  expect($("tabpanel2")).toBeVisible();
+  expect($("tabpanel3")).not.toBeVisible();
 });
 
-test("focusing tab does not reveal the panel when manual is truthy", () => {
-  const { getByText } = render(<SimpleTest manual />);
-  const tab2 = getByText("tab2");
-  const tabpanel2 = getByText("tabpanel2");
-  expect(tabpanel2).not.toBeVisible();
-  focus(tab2);
-  expect(tabpanel2).not.toBeVisible();
+test("focusing tab does not reveal the panel when manual is true", () => {
+  const Test = () => {
+    const tab = useTabState({ manual: true });
+    return (
+      <>
+        <TabList {...tab} aria-label="tablist">
+          <Tab {...tab}>tab1</Tab>
+          <Tab {...tab}>tab2</Tab>
+          <Tab {...tab}>tab3</Tab>
+        </TabList>
+        <TabPanel {...tab}>tabpanel1</TabPanel>
+        <TabPanel {...tab}>tabpanel2</TabPanel>
+        <TabPanel {...tab}>tabpanel3</TabPanel>
+      </>
+    );
+  };
+  const { getByText: $ } = render(<Test />);
+  expect($("tabpanel2")).not.toBeVisible();
+  focus($("tab2"));
+  expect($("tabpanel2")).not.toBeVisible();
 });
 
 test("clicking on tab reveals the panel", () => {
-  const { getByText } = render(<SimpleTest />);
-  const tab3 = getByText("tab3");
-  const tabpanel3 = getByText("tabpanel3");
-  expect(tabpanel3).not.toBeVisible();
-  click(tab3);
-  expect(tabpanel3).toBeVisible();
+  const Test = () => {
+    const tab = useTabState();
+    return (
+      <>
+        <TabList {...tab} aria-label="tablist">
+          <Tab {...tab}>tab1</Tab>
+          <Tab {...tab}>tab2</Tab>
+          <Tab {...tab}>tab3</Tab>
+        </TabList>
+        <TabPanel {...tab}>tabpanel1</TabPanel>
+        <TabPanel {...tab}>tabpanel2</TabPanel>
+        <TabPanel {...tab}>tabpanel3</TabPanel>
+      </>
+    );
+  };
+  const { getByText: $ } = render(<Test />);
+  expect($("tabpanel3")).not.toBeVisible();
+  click($("tab3"));
+  expect($("tabpanel3")).toBeVisible();
 });
 
-test("markup", () => {
-  const { container } = render(<SimpleTest baseId="base" />);
+test("clicking on tab reveals the panel when manual is true", () => {
+  const Test = () => {
+    const tab = useTabState({ manual: true });
+    return (
+      <>
+        <TabList {...tab} aria-label="tablist">
+          <Tab {...tab}>tab1</Tab>
+          <Tab {...tab}>tab2</Tab>
+          <Tab {...tab}>tab3</Tab>
+        </TabList>
+        <TabPanel {...tab}>tabpanel1</TabPanel>
+        <TabPanel {...tab}>tabpanel2</TabPanel>
+        <TabPanel {...tab}>tabpanel3</TabPanel>
+      </>
+    );
+  };
+  const { getByText: $ } = render(<Test />);
+  expect($("tabpanel3")).not.toBeVisible();
+  click($("tab3"));
+  expect($("tabpanel3")).toBeVisible();
+});
+
+test("tab is selected based on the value of selectedId", () => {
+  const Test = () => {
+    const tab = useTabState({ selectedId: "tab2" });
+    return (
+      <>
+        <TabList {...tab} aria-label="tablist">
+          <Tab {...tab}>tab1</Tab>
+          <Tab {...tab} id="tab2">
+            tab2
+          </Tab>
+          <Tab {...tab}>tab3</Tab>
+        </TabList>
+        <TabPanel {...tab}>tabpanel1</TabPanel>
+        <TabPanel {...tab}>tabpanel2</TabPanel>
+        <TabPanel {...tab}>tabpanel3</TabPanel>
+      </>
+    );
+  };
+  const { getByText: $ } = render(<Test />);
+  expect($("tabpanel1")).not.toBeVisible();
+  expect($("tabpanel2")).toBeVisible();
+  expect($("tabpanel3")).not.toBeVisible();
+});
+
+test("no tab is selected if selectedId is null", () => {
+  const Test = () => {
+    const tab = useTabState({ selectedId: null });
+    return (
+      <>
+        <TabList {...tab} aria-label="tablist">
+          <Tab {...tab}>tab1</Tab>
+          <Tab {...tab}>tab2</Tab>
+          <Tab {...tab}>tab3</Tab>
+        </TabList>
+        <TabPanel {...tab}>tabpanel1</TabPanel>
+        <TabPanel {...tab}>tabpanel2</TabPanel>
+        <TabPanel {...tab}>tabpanel3</TabPanel>
+      </>
+    );
+  };
+  const { getByText: $ } = render(<Test />);
+  expect($("tabpanel1")).not.toBeVisible();
+  expect($("tabpanel2")).not.toBeVisible();
+  expect($("tabpanel3")).not.toBeVisible();
+});
+
+test("select the last selected tab when the current one is unmounted", () => {
+  const Test = ({ renderTab2 = false }) => {
+    const tab = useTabState();
+    return (
+      <>
+        <TabList {...tab} aria-label="tablist">
+          <Tab {...tab}>tab1</Tab>
+          {renderTab2 && <Tab {...tab}>tab2</Tab>}
+          <Tab {...tab}>tab3</Tab>
+          <Tab {...tab}>tab4</Tab>
+        </TabList>
+        <TabPanel {...tab}>tabpanel1</TabPanel>
+        {renderTab2 && <TabPanel {...tab}>tabpanel2</TabPanel>}
+        <TabPanel {...tab}>tabpanel3</TabPanel>
+        <TabPanel {...tab}>tabpanel4</TabPanel>
+      </>
+    );
+  };
+  const { getByText: $, rerender } = render(<Test renderTab2 />);
+  expect($("tabpanel1")).toBeVisible();
+  click($("tab4"));
+  expect($("tabpanel4")).toBeVisible();
+  click($("tab2"));
+  expect($("tabpanel2")).toBeVisible();
+  rerender(<Test />);
+  expect($("tabpanel4")).toBeVisible();
+});
+
+test("select the last selected tab when the current one is unmounted when manual is true", () => {
+  const Test = ({ renderTab2 = false }) => {
+    const tab = useTabState({ manual: true });
+    return (
+      <>
+        <TabList {...tab} aria-label="tablist">
+          <Tab {...tab}>tab1</Tab>
+          {renderTab2 && <Tab {...tab}>tab2</Tab>}
+          <Tab {...tab}>tab3</Tab>
+          <Tab {...tab}>tab4</Tab>
+        </TabList>
+        <TabPanel {...tab}>tabpanel1</TabPanel>
+        {renderTab2 && <TabPanel {...tab}>tabpanel2</TabPanel>}
+        <TabPanel {...tab}>tabpanel3</TabPanel>
+        <TabPanel {...tab}>tabpanel4</TabPanel>
+      </>
+    );
+  };
+  const { getByText: $, rerender } = render(<Test renderTab2 />);
+  expect($("tabpanel1")).toBeVisible();
+  click($("tab4"));
+  expect($("tabpanel4")).toBeVisible();
+  click($("tab2"));
+  expect($("tabpanel2")).toBeVisible();
+  rerender(<Test />);
+  expect($("tabpanel4")).toBeVisible();
+});
+
+test("tab panel with tabId different order", () => {
+  const Test = () => {
+    const tab = useTabState({ baseId: "base" });
+    return (
+      <>
+        <TabList {...tab} aria-label="tablist">
+          <Tab {...tab} id="tab1">
+            tab1
+          </Tab>
+          <Tab {...tab}>tab2</Tab>
+          <Tab {...tab}>tab3</Tab>
+        </TabList>
+        <TabPanel {...tab}>tabpanel2</TabPanel>
+        <TabPanel {...tab} tabId="tab1">
+          tabpanel1
+        </TabPanel>
+        <TabPanel {...tab}>tabpanel3</TabPanel>
+      </>
+    );
+  };
+  const { container } = render(<Test />);
   expect(container).toMatchInlineSnapshot(`
     <div>
       <div
         aria-label="tablist"
+        id="base"
         role="tablist"
       >
         <button
-          aria-controls="base-tab1-panel"
-          aria-selected="false"
-          id="base-tab1"
+          aria-controls="base-5"
+          aria-selected="true"
+          id="tab1"
           role="tab"
           tabindex="0"
         >
           tab1
         </button>
         <button
-          aria-controls="base-tab2-panel"
+          aria-controls="base-4"
           aria-selected="false"
-          id="base-tab2"
+          id="base-2"
           role="tab"
           tabindex="-1"
         >
           tab2
         </button>
         <button
-          aria-controls="base-tab3-panel"
+          aria-controls="base-6"
           aria-selected="false"
-          id="base-tab3"
+          id="base-3"
           role="tab"
           tabindex="-1"
         >
@@ -108,21 +273,10 @@ test("markup", () => {
         </button>
       </div>
       <div
-        aria-labelledby="base-tab1"
+        aria-labelledby="base-2"
         class="hidden"
         hidden=""
-        id="base-tab1-panel"
-        role="tabpanel"
-        style="display: none;"
-        tabindex="0"
-      >
-        tabpanel1
-      </div>
-      <div
-        aria-labelledby="base-tab2"
-        class="hidden"
-        hidden=""
-        id="base-tab2-panel"
+        id="base-4"
         role="tabpanel"
         style="display: none;"
         tabindex="0"
@@ -130,10 +284,19 @@ test("markup", () => {
         tabpanel2
       </div>
       <div
-        aria-labelledby="base-tab3"
+        aria-labelledby="tab1"
+        id="base-5"
+        role="tabpanel"
+        style=""
+        tabindex="0"
+      >
+        tabpanel1
+      </div>
+      <div
+        aria-labelledby="base-3"
         class="hidden"
         hidden=""
-        id="base-tab3-panel"
+        id="base-6"
         role="tabpanel"
         style="display: none;"
         tabindex="0"

--- a/packages/reakit/src/Tab/__utils.ts
+++ b/packages/reakit/src/Tab/__utils.ts
@@ -1,8 +1,0 @@
-export function getTabId(stopId?: string, prefix?: string, suffix?: string) {
-  if (!stopId) return undefined;
-  return [prefix, stopId, suffix].filter(Boolean).join("-");
-}
-
-export function getTabPanelId(stopId?: string, prefix?: string) {
-  return getTabId(stopId, prefix, "panel");
-}

--- a/packages/website/src/components/HomePlayground.tsx
+++ b/packages/website/src/components/HomePlayground.tsx
@@ -22,17 +22,17 @@ const tabCode = `
 import { useTabState, Tab, TabList, TabPanel } from "reakit";
 
 const Tabs = () => {
-  const tab = useTabState({ selectedId: "orders" });
+  const tab = useTabState();
   return (
     <>
       <TabList {...tab}>
-        <Tab {...tab} stopId="orders">Orders</Tab>
-        <Tab {...tab} stopId="transactions">Transactions</Tab>
+        <Tab {...tab}>Orders</Tab>
+        <Tab {...tab}>Transactions</Tab>
       </TabList>
-      <TabPanel {...tab} stopId="orders">
+      <TabPanel {...tab}>
         <p>List of orders</p>
       </TabPanel>
-      <TabPanel {...tab} stopId="transactions">
+      <TabPanel {...tab}>
         <p>List of transactions</p>
       </TabPanel>
     </>
@@ -178,7 +178,7 @@ function Panel({
 }
 
 export default function HomePlayground() {
-  const tab = useTabState({ selectedId: "tab" });
+  const tab = useTabState();
   const tabPlayground = usePlaygroundState({ code: tabCode });
   const dialogPlayground = usePlaygroundState({ code: dialogCode });
   const menuPlayground = usePlaygroundState({ code: menuCode });
@@ -252,54 +252,39 @@ export default function HomePlayground() {
           }
         `}
       >
-        <Tab {...tab} stopId="tab">
-          Tabs.js
-        </Tab>
-        <Tab {...tab} stopId="dialog">
-          TabsModal.js
-        </Tab>
-        <Tab {...tab} stopId="menu">
-          TabsModalMenu.js
-        </Tab>
-        <Tab {...tab} stopId="submenu">
-          TabsModalMenuMenu.js
-        </Tab>
-        <Tab {...tab} stopId="menubar">
-          MenuBar.js
-        </Tab>
+        <Tab {...tab}>Tabs.js</Tab>
+        <Tab {...tab}>TabsModal.js</Tab>
+        <Tab {...tab}>TabsModalMenu.js</Tab>
+        <Tab {...tab}>TabsModalMenuMenu.js</Tab>
+        <Tab {...tab}>MenuBar.js</Tab>
       </TabList>
       <Panel
         {...tab}
         {...tabPlayground}
-        stopId="tab"
         componentName="Tabs"
         modules={modules}
       />
       <Panel
         {...tab}
         {...dialogPlayground}
-        stopId="dialog"
         componentName="TabsModal"
         modules={modules}
       />
       <Panel
         {...tab}
         {...menuPlayground}
-        stopId="menu"
         componentName="TabsModalMenu"
         modules={modules}
       />
       <Panel
         {...tab}
         {...submenuPlayground}
-        stopId="submenu"
         componentName="TabsModalMenuMenu"
         modules={modules}
       />
       <Panel
         {...tab}
         {...menubarPlayground}
-        stopId="menubar"
         componentName="TabsModalMenuMenuBar"
         modules={modules}
       />


### PR DESCRIPTION
This PR is kind of a redesign on the `Tab` API. It's been refactored so it composes from the `Composite` module instead of `Rover`.

The API became a lot simpler:

```jsx
const tab = useTabState();
<TabList {...tab} aria-label="My tabs">
  <Tab {...tab}>Tab 1</Tab>
  <Tab {...tab}>Tab 2</Tab>
  <Tab {...tab}>Tab 3</Tab>
</TabList>
<TabPanel {...tab}>Tab 1</TabPanel>
<TabPanel {...tab}>Tab 2</TabPanel>
<TabPanel {...tab}>Tab 3</TabPanel>
```

Changes on this PR:

- No need to pass `selectedId` to `useTabState` to select the first tab. The first tab is now selected by default as this is the most common use case. That's a breaking change (more info below).

- When unmounting the current selected tab, instead of selecting the next or the previous tab, it selects now the last selected tab. It mimics the behavior of browsers and code editors when you close the current tab.

- No need to pass `stopId` to `Tab` and `TabPanel` to stablish their relationship. They'll be connected by their position in the DOM. That is, the second tab in the tab list controls the second panel in the panel list. Setting `stopId` (the prop has changed, see below) still works so people can still use it to stablish tab/panel relationship ignoring the DOM position.

- Because it's now using `CompositeItem`, `stopId` on `Tab` has been replaced by `id`. The former still works though. There's just a deprecation warning. Related discussion on #559

- `stopId` on `TabPanel` has been replaced by `tabId`. There's just a deprecation warning. Related discussion on #559

- Because it's now using `useCompositeState` underneath, `useTabState` now supports `rtl`. Related discussion on #546

**Does this PR introduce a breaking change?**

BREAKING CHANGE: The first `Tab` is now selected by default. There's no need to pass `selectedId` to `useTabState` anymore.

  If you're already using `selectedId` to select a tab in the initial render, you don't need to change anything as this still works. But, if you want to render tabs with none selected, you should now pass `null` to `selectedId`:

  ```js
  // if you're already using selectedId, there's no need to change anything
  const tab = useTabState({ selectedId: "tab-1" });
  ```

  ```diff
  // when there's no tab selected by default, you now need to explicitly specify it
  - const tab = useTabState();
  + const tab = useTabState({ selectedId: null });
  ```

BREAKING CHANGE: **Most users will not be affected by this**, but `stops`, `register` and `unregister` on the returned object of state hooks have been renamed to `items`, `registerItem` and `unregisterItem`, respectively.

  ```diff
  const tab = useTabState();
  - tab.stops.map(...);
  + tab.items.map(...);
  - tab.register(...);
  + tab.registerItem(...);
  - tab.unregister(...);
  + tab.unregisterItem(...);
  ```