### PR TITLE
fix: Fix nested modals when using VoiceOver/Safari

### DIFF
--- a/packages/reakit/src/Dialog/Dialog.tsx
+++ b/packages/reakit/src/Dialog/Dialog.tsx
@@ -137,10 +137,14 @@ export const useDialog = createHook<DialogOptions, DialogHTMLProps>({
     const dialog = React.useRef<HTMLElement>(null);
     const backdrop = React.useContext(DialogBackdropContext);
     const disclosures = useDisclosuresRef(dialog, options);
-    const { dialogs, wrap } = useNestedDialogs(dialog, options);
+    const { dialogs, visibleModals, wrap } = useNestedDialogs(dialog, options);
+    // VoiceOver/Safari accepts only one `aria-modal` container, so if there
+    // are visible child modals, then we don't want to set aria-modal on the
+    // parent modal (this component).
+    const modal = options.modal && !visibleModals.length ? true : undefined;
 
     usePreventBodyScroll(dialog, options);
-    useFocusTrap(dialog, dialogs, options);
+    useFocusTrap(dialog, visibleModals, options);
     useFocusOnShow(dialog, dialogs, options);
     useFocusOnHide(dialog, disclosures, options);
     useHideOnClickOutside(dialog, disclosures, dialogs, options);
@@ -181,7 +185,7 @@ export const useDialog = createHook<DialogOptions, DialogHTMLProps>({
       tabIndex: -1,
       onKeyDown: useAllCallbacks(onKeyDown, htmlOnKeyDown),
       wrapElement: usePipe(wrapElement, htmlWrapElement),
-      "aria-modal": options.modal ? true : undefined,
+      "aria-modal": modal,
       "data-dialog": true,
       ...htmlProps
     };

--- a/packages/reakit/src/Dialog/__utils/useFocusOnHide.ts
+++ b/packages/reakit/src/Dialog/__utils/useFocusOnHide.ts
@@ -37,9 +37,7 @@ export function useFocusOnHide(
     }
 
     const finalFocusEl =
-      (options.unstable_finalFocusRef &&
-        options.unstable_finalFocusRef.current) ||
-      (disclosuresRef.current && disclosuresRef.current[0]);
+      options.unstable_finalFocusRef?.current || disclosuresRef.current?.[0];
 
     if (finalFocusEl) {
       ensureFocus(finalFocusEl);

--- a/packages/reakit/src/Dialog/__utils/useFocusOnShow.ts
+++ b/packages/reakit/src/Dialog/__utils/useFocusOnShow.ts
@@ -17,7 +17,7 @@ export function useFocusOnShow(
     const dialog = dialogRef.current;
 
     warning(
-      Boolean(shouldFocus && !dialog),
+      !!shouldFocus && !dialog,
       "[reakit/Dialog]",
       "Can't set initial focus on dialog because `ref` wasn't passed to component.",
       "See https://reakit.io/docs/dialog"
@@ -27,14 +27,12 @@ export function useFocusOnShow(
     if (
       !shouldFocus ||
       !dialog ||
-      nestedDialogs.find(child =>
-        Boolean(child.current && !child.current.hidden)
-      )
+      nestedDialogs.some(child => !child.current?.hidden)
     ) {
       return;
     }
 
-    if (initialFocusRef && initialFocusRef.current) {
+    if (initialFocusRef?.current) {
       initialFocusRef.current.focus({ preventScroll: true });
     } else {
       const tabbable = getFirstTabbableIn(dialog, true);


### PR DESCRIPTION
Historical context:

1. Last year we found a bug where nested modals weren't working when using VoiceOver/Safari because it didn't support multiple elements with the `aria-modal="true"` attribute. So I created #457 to fix the issue by putting nested modals inside their parent ones in the DOM.

2. Months later we found that rendering modals in that way was creating a lot of styling issues where the parent styles would interfere in the child modal styles. Since the same problem was happening on the WAI-ARIA site, I concluded that it was a bug on VoiceOver/Safari and reverted that change on #533.

Now, this PR fixes the same problem by removing the `aria-modal` attribute from the parent modal when the nested modal is visible.

**Does this PR introduce a breaking change?**

No