### PR TITLE
Fix for #607 - Falsey values as radio values and type updates.

### DIFF
--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -1489,7 +1489,7 @@ similarly to `readOnly` on form elements. In this case, only
   Same as the HTML attribute.
 
 - **`value`**
-  <code>any</code>
+  <code>string | number</code>
 
   Same as the `value` attribute.
 
@@ -1603,12 +1603,12 @@ and `groupId` if any. This state is automatically updated when
   Moves focus to the item below.
 
 - **`state`**
-  <code>any</code>
+  <code>string | number | undefined</code>
 
   The `value` attribute of the current checked radio.
 
 - **`setState`**
-  <code>(value: any) =&#62; void</code>
+  <code title="(value: SetStateAction&#60;string | number | undefined&#62;) =&#62; void">(value: SetStateAction&#60;string | number | undefi...</code>
 
   Sets `state`.
 

--- a/packages/reakit/src/Radio/README.md
+++ b/packages/reakit/src/Radio/README.md
@@ -167,7 +167,7 @@ item in the last row or column and the first item in the first row or
 column and vice-versa.
 
 - **`state`**
-  <code>any</code>
+  <code>string | undefined</code>
 
   The `value` attribute of the current checked radio.
 
@@ -191,7 +191,7 @@ similarly to `readOnly` on form elements. In this case, only
   Same as the HTML attribute.
 
 - **`value`**
-  <code>any</code>
+  <code>string</code>
 
   Same as the `value` attribute.
 
@@ -300,12 +300,12 @@ and `groupId` if any. This state is automatically updated when
   Moves focus to the last item.
 
 - **`state`**
-  <code>any</code>
+  <code>string | undefined</code>
 
   The `value` attribute of the current checked radio.
 
 - **`setState`**
-  <code>(value: any) =&#62; void</code>
+  <code>(value: string) =&#62; void</code>
 
   Sets `state`.
 

--- a/packages/reakit/src/Radio/README.md
+++ b/packages/reakit/src/Radio/README.md
@@ -167,7 +167,7 @@ item in the last row or column and the first item in the first row or
 column and vice-versa.
 
 - **`state`**
-  <code>string | undefined</code>
+  <code>string | number | undefined</code>
 
   The `value` attribute of the current checked radio.
 
@@ -191,7 +191,7 @@ similarly to `readOnly` on form elements. In this case, only
   Same as the HTML attribute.
 
 - **`value`**
-  <code>string</code>
+  <code>string | number</code>
 
   Same as the `value` attribute.
 
@@ -300,12 +300,12 @@ and `groupId` if any. This state is automatically updated when
   Moves focus to the last item.
 
 - **`state`**
-  <code>string | undefined</code>
+  <code>string | number | undefined</code>
 
   The `value` attribute of the current checked radio.
 
 - **`setState`**
-  <code>(value: string) =&#62; void</code>
+  <code title="(value: SetStateAction&#60;string | number | undefined&#62;) =&#62; void">(value: SetStateAction&#60;string | number | undefi...</code>
 
   Sets `state`.
 

--- a/packages/reakit/src/Radio/Radio.ts
+++ b/packages/reakit/src/Radio/Radio.ts
@@ -17,7 +17,7 @@ export type RadioOptions = CompositeItemOptions &
     /**
      * Same as the `value` attribute.
      */
-    value: string;
+    value: string | number;
     /**
      * Same as the `checked` attribute.
      */

--- a/packages/reakit/src/Radio/Radio.ts
+++ b/packages/reakit/src/Radio/Radio.ts
@@ -17,7 +17,7 @@ export type RadioOptions = CompositeItemOptions &
     /**
      * Same as the `value` attribute.
      */
-    value: any;
+    value: string;
     /**
      * Same as the `checked` attribute.
      */
@@ -37,7 +37,7 @@ function getChecked(options: RadioOptions) {
   if (typeof options.checked !== "undefined") {
     return options.checked;
   }
-  return options.value && options.state === options.value;
+  return ( typeof options.value !== undefined ) && options.state === options.value;
 }
 
 function useInitialChecked(options: RadioOptions) {

--- a/packages/reakit/src/Radio/Radio.ts
+++ b/packages/reakit/src/Radio/Radio.ts
@@ -37,7 +37,9 @@ function getChecked(options: RadioOptions) {
   if (typeof options.checked !== "undefined") {
     return options.checked;
   }
-  return ( typeof options.value !== undefined ) && options.state === options.value;
+  return (
+    typeof options.value !== "undefined" && options.state === options.value
+  );
 }
 
 function useInitialChecked(options: RadioOptions) {

--- a/packages/reakit/src/Radio/RadioState.ts
+++ b/packages/reakit/src/Radio/RadioState.ts
@@ -14,14 +14,14 @@ export type RadioState = CompositeState & {
   /**
    * The `value` attribute of the current checked radio.
    */
-  state: any;
+  state: string | undefined;
 };
 
 export type RadioActions = CompositeActions & {
   /**
    * Sets `state`.
    */
-  setState: React.Dispatch<React.SetStateAction<any>>;
+  setState: React.Dispatch<React.SetStateAction<string | undefined>>;
 };
 
 export type RadioInitialState = CompositeInitialState &

--- a/packages/reakit/src/Radio/RadioState.ts
+++ b/packages/reakit/src/Radio/RadioState.ts
@@ -14,14 +14,14 @@ export type RadioState = CompositeState & {
   /**
    * The `value` attribute of the current checked radio.
    */
-  state: string | undefined;
+  state: string | number | undefined;
 };
 
 export type RadioActions = CompositeActions & {
   /**
    * Sets `state`.
    */
-  setState: React.Dispatch<React.SetStateAction<string | undefined>>;
+  setState: React.Dispatch<React.SetStateAction<string | number | undefined>>;
 };
 
 export type RadioInitialState = CompositeInitialState &

--- a/packages/reakit/src/Radio/__tests__/index-test.tsx
+++ b/packages/reakit/src/Radio/__tests__/index-test.tsx
@@ -260,3 +260,22 @@ test("button group", () => {
 </div>
 `);
 });
+
+test("empty strings can be checked", () => {
+  // See https://github.com/reakit/reakit/issues/607
+  const Test = () => {
+    const radio = useRadioState();
+    return (
+      <RadioGroup {...radio} aria-label="radiogroup" id="base">
+        <Radio {...radio} value="" aria-label="empty-string" />
+      </RadioGroup>
+    );
+  };
+
+  const { getByLabelText } = render(<Test />);
+
+  expect(getByLabelText("empty-string")).not.toBeChecked();
+  click(getByLabelText("empty-string"));
+  expect(getByLabelText("empty-string")).toBeChecked();
+  expect(getByLabelText("empty-string")).toHaveFocus();
+});

--- a/packages/reakit/src/Radio/__tests__/index-test.tsx
+++ b/packages/reakit/src/Radio/__tests__/index-test.tsx
@@ -279,3 +279,22 @@ test("empty strings can be checked", () => {
   expect(getByLabelText("empty-string")).toBeChecked();
   expect(getByLabelText("empty-string")).toHaveFocus();
 });
+
+test("falsy numbers can be checked", () => {
+  // See https://github.com/reakit/reakit/issues/607
+  const Test = () => {
+    const radio = useRadioState();
+    return (
+      <RadioGroup {...radio} aria-label="radiogroup" id="base">
+        <Radio {...radio} value={0} aria-label="zero" />
+      </RadioGroup>
+    );
+  };
+
+  const { getByLabelText } = render(<Test />);
+
+  expect(getByLabelText("zero")).not.toBeChecked();
+  click(getByLabelText("zero"));
+  expect(getByLabelText("zero")).toBeChecked();
+  expect(getByLabelText("zero")).toHaveFocus();
+});


### PR DESCRIPTION
Closes #607 . Fixes issue with non string values being allowed as radio values, additionally fixes issue with falsey values (such as an empty string) not being able to be checked.

Added a test (based on the test by @tom-sherman) that tests that empty strings can be checked.

**Does this PR introduce a breaking change?**

Technically there is no breaking change as radio values should have always been only strings, however it is possible that end users were providing non string values so this change could break that behaviour.