### PR TITLE
fix: Fix animated `Dialog` not being correctly focused with VoiceOver

### DIFF
--- a/packages/reakit/src/Dialog/__utils/useFocusOnHide.ts
+++ b/packages/reakit/src/Dialog/__utils/useFocusOnHide.ts
@@ -27,9 +27,11 @@ export function useFocusOnHide(
   options: DialogOptions
 ) {
   const shouldFocus = options.unstable_autoFocusOnHide && !options.visible;
+  const animating = !!(options.animated && options.animating);
 
   useUpdateEffect(() => {
     if (!shouldFocus) return;
+    if (animating) return;
 
     // Hide was triggered by a click/focus on a tabbable element outside
     // the dialog or on another dialog. We won't change focus then.
@@ -50,5 +52,5 @@ export function useFocusOnHide(
         dialogRef.current
       );
     }
-  }, [dialogRef, disclosuresRef, shouldFocus]);
+  }, [shouldFocus, animating, dialogRef, disclosuresRef]);
 }

--- a/packages/reakit/src/Dialog/__utils/useFocusOnShow.ts
+++ b/packages/reakit/src/Dialog/__utils/useFocusOnShow.ts
@@ -5,35 +5,6 @@ import { getFirstTabbableIn, ensureFocus } from "reakit-utils/tabbable";
 import { hasFocusWithin } from "reakit-utils/hasFocusWithin";
 import { DialogOptions } from "../Dialog";
 
-function focusOnShow(
-  dialog: HTMLElement,
-  nestedDialogs: Array<React.RefObject<HTMLElement>>,
-  initialFocusRef: DialogOptions["unstable_initialFocusRef"]
-) {
-  // If there're nested open dialogs, let them handle focus
-  if (nestedDialogs.some((child) => !child.current?.hidden)) {
-    return;
-  }
-  if (initialFocusRef?.current) {
-    initialFocusRef.current.focus({ preventScroll: true });
-  } else {
-    const tabbable = getFirstTabbableIn(dialog, true);
-    const isActive = () => hasFocusWithin(dialog);
-    if (tabbable) {
-      ensureFocus(tabbable, { preventScroll: true, isActive });
-    } else {
-      ensureFocus(dialog, { preventScroll: true, isActive });
-      warning(
-        dialog.tabIndex === undefined || dialog.tabIndex < 0,
-        "It's recommended to have at least one tabbable element inside dialog. The dialog element has been automatically focused.",
-        "If this is the intended behavior, pass `tabIndex={0}` to the dialog element to disable this warning.",
-        "See https://reakit.io/docs/dialog/#initial-focus",
-        dialog
-      );
-    }
-  }
-}
-
 export function useFocusOnShow(
   dialogRef: React.RefObject<HTMLElement>,
   nestedDialogs: Array<React.RefObject<HTMLElement>>,
@@ -57,6 +28,28 @@ export function useFocusOnShow(
     if (!dialog) return;
     if (animating) return;
 
-    focusOnShow(dialog, nestedDialogs, initialFocusRef);
+    // If there're nested open dialogs, let them handle focus
+    if (nestedDialogs.some((child) => !child.current?.hidden)) {
+      return;
+    }
+
+    if (initialFocusRef?.current) {
+      initialFocusRef.current.focus({ preventScroll: true });
+    } else {
+      const tabbable = getFirstTabbableIn(dialog, true);
+      const isActive = () => hasFocusWithin(dialog);
+      if (tabbable) {
+        ensureFocus(tabbable, { preventScroll: true, isActive });
+      } else {
+        ensureFocus(dialog, { preventScroll: true, isActive });
+        warning(
+          dialog.tabIndex === undefined || dialog.tabIndex < 0,
+          "It's recommended to have at least one tabbable element inside dialog. The dialog element has been automatically focused.",
+          "If this is the intended behavior, pass `tabIndex={0}` to the dialog element to disable this warning.",
+          "See https://reakit.io/docs/dialog/#initial-focus",
+          dialog
+        );
+      }
+    }
   }, [dialogRef, shouldFocus, animating, nestedDialogs, initialFocusRef]);
 }

--- a/packages/reakit/src/Dialog/__utils/useFocusOnShow.ts
+++ b/packages/reakit/src/Dialog/__utils/useFocusOnShow.ts
@@ -5,6 +5,35 @@ import { getFirstTabbableIn, ensureFocus } from "reakit-utils/tabbable";
 import { hasFocusWithin } from "reakit-utils/hasFocusWithin";
 import { DialogOptions } from "../Dialog";
 
+function focusOnShow(
+  dialog: HTMLElement,
+  nestedDialogs: Array<React.RefObject<HTMLElement>>,
+  initialFocusRef: DialogOptions["unstable_initialFocusRef"]
+) {
+  // If there're nested open dialogs, let them handle focus
+  if (nestedDialogs.some((child) => !child.current?.hidden)) {
+    return;
+  }
+  if (initialFocusRef?.current) {
+    initialFocusRef.current.focus({ preventScroll: true });
+  } else {
+    const tabbable = getFirstTabbableIn(dialog, true);
+    const isActive = () => hasFocusWithin(dialog);
+    if (tabbable) {
+      ensureFocus(tabbable, { preventScroll: true, isActive });
+    } else {
+      ensureFocus(dialog, { preventScroll: true, isActive });
+      warning(
+        dialog.tabIndex === undefined || dialog.tabIndex < 0,
+        "It's recommended to have at least one tabbable element inside dialog. The dialog element has been automatically focused.",
+        "If this is the intended behavior, pass `tabIndex={0}` to the dialog element to disable this warning.",
+        "See https://reakit.io/docs/dialog/#initial-focus",
+        dialog
+      );
+    }
+  }
+}
+
 export function useFocusOnShow(
   dialogRef: React.RefObject<HTMLElement>,
   nestedDialogs: Array<React.RefObject<HTMLElement>>,
@@ -12,6 +41,7 @@ export function useFocusOnShow(
 ) {
   const initialFocusRef = options.unstable_initialFocusRef;
   const shouldFocus = options.visible && options.unstable_autoFocusOnShow;
+  const animating = !!(options.animated && options.animating);
 
   useUpdateEffect(() => {
     const dialog = dialogRef.current;
@@ -19,36 +49,14 @@ export function useFocusOnShow(
     warning(
       !!shouldFocus && !dialog,
       "[reakit/Dialog]",
-      "Can't set initial focus on dialog because `ref` wasn't passed to component.",
+      "Can't set initial focus on dialog because `ref` wasn't passed to the dialog element.",
       "See https://reakit.io/docs/dialog"
     );
 
-    // If there're nested open dialogs, let them handle focus
-    if (
-      !shouldFocus ||
-      !dialog ||
-      nestedDialogs.some((child) => !child.current?.hidden)
-    ) {
-      return;
-    }
+    if (!shouldFocus) return;
+    if (!dialog) return;
+    if (animating) return;
 
-    if (initialFocusRef?.current) {
-      initialFocusRef.current.focus({ preventScroll: true });
-    } else {
-      const tabbable = getFirstTabbableIn(dialog, true);
-      const isActive = () => hasFocusWithin(dialog);
-      if (tabbable) {
-        ensureFocus(tabbable, { preventScroll: true, isActive });
-      } else {
-        ensureFocus(dialog, { preventScroll: true, isActive });
-        warning(
-          dialog.tabIndex === undefined || dialog.tabIndex < 0,
-          "It's recommended to have at least one tabbable element inside dialog. The dialog element has been automatically focused.",
-          "If this is the intended behavior, pass `tabIndex={0}` to the dialog element to disable this warning.",
-          "See https://reakit.io/docs/dialog/#initial-focus",
-          dialog
-        );
-      }
-    }
-  }, [dialogRef, nestedDialogs, initialFocusRef, shouldFocus]);
+    focusOnShow(dialog, nestedDialogs, initialFocusRef);
+  }, [dialogRef, shouldFocus, animating, nestedDialogs, initialFocusRef]);
 }

--- a/packages/reakit/src/Menu/__tests__/index-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/index-test.tsx
@@ -106,6 +106,7 @@ import {
           </Menu>
         );
       };
+      jest.useFakeTimers();
       const { getByText, getByLabelText } = render(<Test />);
       const subdisclosure = getByText("subdisclosure");
       const submenu = getByLabelText("submenu");
@@ -114,6 +115,10 @@ import {
       click(subdisclosure);
       expect(submenu).toBeVisible();
       expect(subitem1).not.toHaveFocus();
+      act(() => {
+        jest.runAllTimers();
+      });
+      jest.useRealTimers();
     });
 
     test("focusing menu item disclosure does not open submenu", () => {


### PR DESCRIPTION
When using VoiceOver, opening or closing an animated `Dialog` (and its derivative components) doesn't move focus correctly. This PR changes the code so that it waits for the animation to complete before moving focus.

**Before:**

![Apr-14-2020 18-41-23](https://user-images.githubusercontent.com/3068563/79277481-4c587280-7e80-11ea-86b3-ec8103810926.gif)

**After:**

![Apr-14-2020 18-41-48](https://user-images.githubusercontent.com/3068563/79277493-4f536300-7e80-11ea-8ec9-32a50edcb9b7.gif)


**Does this PR introduce a breaking change?**

No