### PR TITLE
Bail out of dispatching a listener in `useEventListenerOutside` when the document doesn't have focus

### DIFF
--- a/packages/reakit/src/Dialog/__utils/useEventListenerOutside.ts
+++ b/packages/reakit/src/Dialog/__utils/useEventListenerOutside.ts
@@ -59,7 +59,13 @@ export function useEventListenerOutside(
       }
 
       // Fix for https://github.com/reakit/reakit/issues/619
-      if (document.hasFocus()) return;
+      if (
+        event.type === "focus" &&
+        (target as any) === document &&
+        document.hasFocus()
+      ) {
+        return;
+      }
 
       // Click inside dialog
       if (contains(container, target)) return;

--- a/packages/reakit/src/Dialog/__utils/useEventListenerOutside.ts
+++ b/packages/reakit/src/Dialog/__utils/useEventListenerOutside.ts
@@ -58,15 +58,6 @@ export function useEventListenerOutside(
         return;
       }
 
-      // Fix for https://github.com/reakit/reakit/issues/619
-      if (
-        event.type === "focus" &&
-        (target as any) === document &&
-        document.hasFocus()
-      ) {
-        return;
-      }
-
       // Click inside dialog
       if (contains(container, target)) return;
 

--- a/packages/reakit/src/Dialog/__utils/useEventListenerOutside.ts
+++ b/packages/reakit/src/Dialog/__utils/useEventListenerOutside.ts
@@ -58,6 +58,9 @@ export function useEventListenerOutside(
         return;
       }
 
+      // Fix for https://github.com/reakit/reakit/issues/619
+      if (document.hasFocus()) return;
+
       // Click inside dialog
       if (contains(container, target)) return;
 

--- a/packages/reakit/src/Dialog/__utils/useHideOnClickOutside.ts
+++ b/packages/reakit/src/Dialog/__utils/useHideOnClickOutside.ts
@@ -47,19 +47,26 @@ export function useHideOnClickOutside(
       // triggered the mousedown event. This prevents the dialog from closing
       // by dragging the cursor (for example, selecting some text inside the
       // dialog and releasing the mouse outside of it).
-      if (mouseDownRef.current === event.target && options.hide) {
-        options.hide();
+      if (mouseDownRef.current === event.target) {
+        options.hide?.();
       }
     },
     options.visible && options.hideOnClickOutside
   );
+
+  const document = getDocument(dialogRef.current);
 
   useEventListenerOutside(
     dialogRef,
     disclosuresRef,
     nestedDialogs,
     "focus",
-    options.hide,
+    (event) => {
+      // Fix for https://github.com/reakit/reakit/issues/619
+      if ((event.target as any) !== document) {
+        options.hide?.();
+      }
+    },
     options.visible && options.hideOnClickOutside
   );
 }

--- a/packages/reakit/src/Dialog/__utils/useHideOnClickOutside.ts
+++ b/packages/reakit/src/Dialog/__utils/useHideOnClickOutside.ts
@@ -54,8 +54,6 @@ export function useHideOnClickOutside(
     options.visible && options.hideOnClickOutside
   );
 
-  const document = getDocument(dialogRef.current);
-
   useEventListenerOutside(
     dialogRef,
     disclosuresRef,
@@ -63,7 +61,7 @@ export function useHideOnClickOutside(
     "focus",
     (event) => {
       // Fix for https://github.com/reakit/reakit/issues/619
-      if ((event.target as any) !== document) {
+      if (event.target !== getDocument(dialogRef.current)) {
         options.hide?.();
       }
     },


### PR DESCRIPTION
Fixes #619

**Does this PR introduce a breaking change?**

No
