### PR TITLE
fix: Fix `Menu` -> `Dialog` -> `Menu` behaving as a sub menu

### DIFF
--- a/packages/reakit/src/Dialog/Dialog.tsx
+++ b/packages/reakit/src/Dialog/Dialog.tsx
@@ -11,6 +11,7 @@ import {
   useDisclosureContent,
 } from "../Disclosure/DisclosureContent";
 import { Portal } from "../Portal/Portal";
+import { MenuContext } from "../Menu/__utils/MenuContext";
 import { useDisclosuresRef } from "./__utils/useDisclosuresRef";
 import { usePreventBodyScroll } from "./__utils/usePreventBodyScroll";
 import { useFocusOnShow } from "./__utils/useFocusOnShow";
@@ -179,9 +180,12 @@ export const useDialog = createHook<DialogOptions, DialogHTMLProps>({
           element = <Portal>{element}</Portal>;
         }
         if (htmlWrapElement) {
-          return htmlWrapElement(element);
+          element = htmlWrapElement(element);
         }
-        return element;
+        return (
+          // Prevents Menu > Dialog > Menu to behave as a sub menu
+          <MenuContext.Provider value={null}>{element}</MenuContext.Provider>
+        );
       },
       [wrap, options.modal, hasBackdrop, htmlWrapElement]
     );

--- a/packages/reakit/src/Menu/Menu.tsx
+++ b/packages/reakit/src/Menu/Menu.tsx
@@ -67,7 +67,10 @@ export const useMenu = createHook<MenuOptions, MenuHTMLProps>({
           stopPropagation: (event) => {
             // On Esc, only stop propagation if there's no parent menu.
             // Otherwise, pressing Esc should close all menus
-            return event.key !== "Escape" && hasParent;
+            if (hasParent) {
+              return event.key !== "Escape";
+            }
+            return event.key === "Escape";
           },
           keyMap: ({ currentTarget, target }) => {
             const { hide } = options;

--- a/packages/reakit/src/Menu/MenuButton.ts
+++ b/packages/reakit/src/Menu/MenuButton.ts
@@ -45,7 +45,7 @@ export const useMenuButton = createHook<MenuButtonOptions, MenuButtonHTMLProps>(
       const ref = React.useRef<HTMLElement>(null);
       const hasPressedMouse = React.useRef(false);
       const [dir] = options.placement.split("-");
-      const hasParent = Boolean(parent);
+      const hasParent = !!parent;
       const parentIsMenuBar = parent?.role === "menubar";
       const onClickRef = useLiveRef(htmlOnClick);
       const onKeyDownRef = useLiveRef(htmlOnKeyDown);
@@ -57,6 +57,9 @@ export const useMenuButton = createHook<MenuButtonOptions, MenuButtonHTMLProps>(
         () =>
           createOnKeyDown({
             onKeyDown: onKeyDownRef,
+            // Doesn't prevent default on Escape, otherwise we can't close
+            // dialogs when MenuButton is focused
+            preventDefault: (event) => event.key !== "Escape",
             stopPropagation: (event) => event.key !== "Escape",
             onKey: () => options.show(),
             keyMap: () => {

--- a/packages/reakit/src/Menu/MenuItem.tsx
+++ b/packages/reakit/src/Menu/MenuItem.tsx
@@ -10,7 +10,7 @@ import {
   unstable_useCompositeItem as useCompositeItem,
 } from "../Composite/CompositeItem";
 import { useMenuState, MenuStateReturn } from "./MenuState";
-import { MenuRoleContext } from "./__utils/MenuContext";
+import { MenuContext } from "./__utils/MenuContext";
 
 export type MenuItemOptions = CompositeItemOptions &
   Pick<Partial<MenuStateReturn>, "visible" | "hide" | "placement"> &
@@ -76,7 +76,8 @@ export const useMenuItem = createHook<MenuItemOptions, MenuItemHTMLProps>({
       ...htmlProps
     }
   ) {
-    const menuRole = React.useContext(MenuRoleContext);
+    const menu = React.useContext(MenuContext);
+    const menuRole = menu?.role;
     const onMouseEnterRef = useLiveRef(htmlOnMouseEnter);
     const onMouseLeaveRef = useLiveRef(htmlOnMouseLeave);
 

--- a/packages/reakit/src/Menu/__utils/MenuContext.tsx
+++ b/packages/reakit/src/Menu/__utils/MenuContext.tsx
@@ -18,7 +18,6 @@ export type MenuContextType = Pick<
 };
 
 export const MenuContext = React.createContext<MenuContextType | null>(null);
-export const MenuRoleContext = React.createContext<string | null>(null);
 
 export function useMenuContext(
   menuRef: Ref,
@@ -75,9 +74,9 @@ export function useMenuContext(
   );
 
   const wrapElement = React.useCallback(
-    (c: React.ReactNode) => (
+    (element: React.ReactNode) => (
       <MenuContext.Provider value={providerValue}>
-        <MenuRoleContext.Provider value={role}>{c}</MenuRoleContext.Provider>
+        {element}
       </MenuContext.Provider>
     ),
     [providerValue]

--- a/packages/reakit/src/__tests__/index-test.tsx
+++ b/packages/reakit/src/__tests__/index-test.tsx
@@ -8,6 +8,9 @@ import {
   Menu,
   MenuButton,
   MenuItem,
+  usePopoverState,
+  Popover,
+  PopoverDisclosure,
 } from "..";
 
 [true, false].forEach((virtual) => {
@@ -39,22 +42,22 @@ import {
         </Composite>
       );
     };
-    const { getByText: get, getByLabelText: getLabel } = render(<Test />);
+    const { getByText: text, getByLabelText: label } = render(<Test />);
     press.Tab();
-    expect(get("item1")).toHaveFocus();
+    expect(text("item1")).toHaveFocus();
     press.ArrowRight();
-    expect(get("item2")).toHaveFocus();
+    expect(text("item2")).toHaveFocus();
     press.ArrowRight();
-    expect(get("item3")).toHaveFocus();
-    expect(getLabel("menu")).not.toBeVisible();
+    expect(text("item3")).toHaveFocus();
+    expect(label("menu")).not.toBeVisible();
     press.ArrowRight();
-    expect(get("item3")).not.toHaveFocus();
-    expect(getLabel("menu")).toBeVisible();
-    await wait(expect(get("menuitem1")).toHaveFocus);
+    expect(text("item3")).not.toHaveFocus();
+    expect(label("menu")).toBeVisible();
+    await wait(expect(text("menuitem1")).toHaveFocus);
     press.ArrowRight();
-    expect(get("item3")).not.toHaveFocus();
-    expect(getLabel("menu")).toBeVisible();
-    expect(get("menuitem1")).toHaveFocus();
+    expect(text("item3")).not.toHaveFocus();
+    expect(label("menu")).toBeVisible();
+    expect(text("menuitem1")).toHaveFocus();
   });
 
   test(`${strategy} composite with menu button not controlling arrow keys`, async () => {
@@ -83,31 +86,136 @@ import {
         </Composite>
       );
     };
-    const { getByText: get, getByLabelText: getLabel } = render(<Test />);
+    const { getByText: text, getByLabelText: label } = render(<Test />);
     press.Tab();
-    expect(get("item1")).toHaveFocus();
+    expect(text("item1")).toHaveFocus();
     press.ArrowRight();
-    expect(get("item2")).toHaveFocus();
+    expect(text("item2")).toHaveFocus();
     press.ArrowRight();
-    expect(get("item3")).toHaveFocus();
-    expect(getLabel("menu")).not.toBeVisible();
+    expect(text("item3")).toHaveFocus();
+    expect(label("menu")).not.toBeVisible();
     press.ArrowRight();
-    expect(get("item4")).toHaveFocus();
-    expect(getLabel("menu")).not.toBeVisible();
+    expect(text("item4")).toHaveFocus();
+    expect(label("menu")).not.toBeVisible();
     press.ArrowLeft();
-    expect(get("item3")).toHaveFocus();
+    expect(text("item3")).toHaveFocus();
     press.Enter();
-    expect(get("item3")).not.toHaveFocus();
-    expect(getLabel("menu")).toBeVisible();
-    await wait(expect(get("menuitem1")).toHaveFocus);
+    expect(text("item3")).not.toHaveFocus();
+    expect(label("menu")).toBeVisible();
+    await wait(expect(text("menuitem1")).toHaveFocus);
     press.ArrowRight();
-    expect(get("item3")).not.toHaveFocus();
-    expect(getLabel("menu")).toBeVisible();
-    expect(get("menuitem1")).toHaveFocus();
+    expect(text("item3")).not.toHaveFocus();
+    expect(label("menu")).toBeVisible();
+    expect(text("menuitem1")).toHaveFocus();
     press.Escape();
-    expect(get("item3")).toHaveFocus();
-    expect(getLabel("menu")).not.toBeVisible();
+    expect(text("item3")).toHaveFocus();
+    expect(label("menu")).not.toBeVisible();
     press.ArrowRight();
-    expect(get("item4")).toHaveFocus();
+    expect(text("item4")).toHaveFocus();
+  });
+
+  test(`${strategy} menu inside dialog closes only itself when pressing Esc`, () => {
+    const Test = () => {
+      const popover = usePopoverState();
+      const menu = useMenuState({ unstable_virtual: virtual });
+      return (
+        <>
+          <PopoverDisclosure {...popover}>Open popover</PopoverDisclosure>
+          <Popover {...popover} aria-label="popover">
+            <MenuButton {...menu}>Open menu</MenuButton>
+            <Menu {...menu} aria-label="menu">
+              <MenuItem {...menu}>Item 1</MenuItem>
+            </Menu>
+          </Popover>
+        </>
+      );
+    };
+    const { getByText: text, getByLabelText: label } = render(<Test />);
+    press.Tab();
+    expect(text("Open popover")).toHaveFocus();
+    expect(label("popover")).not.toBeVisible();
+    expect(label("menu")).not.toBeVisible();
+    press.Enter();
+    expect(text("Open menu")).toHaveFocus();
+    expect(label("popover")).toBeVisible();
+    expect(label("menu")).not.toBeVisible();
+    press.Enter();
+    expect(text("Item 1")).toHaveFocus();
+    expect(label("popover")).toBeVisible();
+    expect(label("menu")).toBeVisible();
+    press.Escape();
+    expect(text("Open menu")).toHaveFocus();
+    expect(label("popover")).toBeVisible();
+    expect(label("menu")).not.toBeVisible();
+    press.Escape();
+    expect(text("Open popover")).toHaveFocus();
+    expect(label("popover")).not.toBeVisible();
+    expect(label("menu")).not.toBeVisible();
+  });
+
+  test(`${strategy} menu inside dialog inside menu closes only itself when pressing Esc`, () => {
+    const Test = () => {
+      const popover = usePopoverState();
+      const menu1 = useMenuState({ unstable_virtual: virtual });
+      const menu2 = useMenuState({ unstable_virtual: virtual });
+      return (
+        <>
+          <MenuButton {...menu1}>Open menu 1</MenuButton>
+          <Menu {...menu1} aria-label="menu1">
+            <MenuItem {...menu1}>
+              {(props) => (
+                <>
+                  <PopoverDisclosure {...popover} {...props}>
+                    Open popover
+                  </PopoverDisclosure>
+                  <Popover {...popover} aria-label="popover">
+                    <MenuButton {...menu2}>Open menu 2</MenuButton>
+                    <Menu {...menu2} aria-label="menu2">
+                      <MenuItem {...menu2}>Item 1</MenuItem>
+                    </Menu>
+                  </Popover>
+                </>
+              )}
+            </MenuItem>
+          </Menu>
+        </>
+      );
+    };
+    const { getByText: text, getByLabelText: label } = render(<Test />);
+    press.Tab();
+    expect(text("Open menu 1")).toHaveFocus();
+    expect(label("menu1")).not.toBeVisible();
+    expect(label("popover")).not.toBeVisible();
+    expect(label("menu2")).not.toBeVisible();
+    press.Enter();
+    expect(text("Open popover")).toHaveFocus();
+    expect(label("menu1")).toBeVisible();
+    expect(label("popover")).not.toBeVisible();
+    expect(label("menu2")).not.toBeVisible();
+    press.Enter();
+    expect(text("Open menu 2")).toHaveFocus();
+    expect(label("menu1")).toBeVisible();
+    expect(label("popover")).toBeVisible();
+    expect(label("menu2")).not.toBeVisible();
+    press.Enter();
+    expect(text("Item 1")).toHaveFocus();
+    expect(label("menu1")).toBeVisible();
+    expect(label("popover")).toBeVisible();
+    expect(label("menu2")).toBeVisible();
+    press.Escape();
+    expect(text("Open menu 2")).toHaveFocus();
+    expect(label("menu1")).toBeVisible();
+    expect(label("popover")).toBeVisible();
+    expect(label("menu2")).not.toBeVisible();
+    press.Escape();
+    expect(text("Open popover")).toHaveFocus();
+    expect(label("menu1")).toBeVisible();
+    expect(label("popover")).not.toBeVisible();
+    expect(label("menu2")).not.toBeVisible();
+    press.Escape();
+    expect(text("Open menu 1")).toHaveFocus();
+    expect(label("menu1")).not.toBeVisible();
+    expect(label("popover")).not.toBeVisible();
+    expect(label("menu2")).not.toBeVisible();
   });
 });


### PR DESCRIPTION
See tests

**Does this PR introduce a breaking change?**

No