### PR TITLE
feat: Add experimental `unstable_timeout` option to `useTooltipState`

### DIFF
--- a/packages/reakit/src/Tooltip/TooltipState.ts
+++ b/packages/reakit/src/Tooltip/TooltipState.ts
@@ -1,3 +1,4 @@
+import * as React from "react";
 import {
   useSealedState,
   SealedInitialState,
@@ -10,11 +11,24 @@ import {
   PopoverStateReturn,
 } from "../Popover/PopoverState";
 
-export type TooltipState = Omit<PopoverState, "modal">;
+export type TooltipState = Omit<PopoverState, "modal"> & {
+  /**
+   * @private
+   */
+  unstable_timeout: number;
+};
 
-export type TooltipActions = Omit<PopoverActions, "setModal">;
+export type TooltipActions = Omit<PopoverActions, "setModal"> & {
+  /**
+   * @private
+   */
+  unstable_setTimeout: React.Dispatch<
+    React.SetStateAction<TooltipState["unstable_timeout"]>
+  >;
+};
 
-export type TooltipInitialState = Omit<PopoverInitialState, "modal">;
+export type TooltipInitialState = Omit<PopoverInitialState, "modal"> &
+  Pick<Partial<TooltipState>, "unstable_timeout">;
 
 export type TooltipStateReturn = Omit<
   PopoverStateReturn,
@@ -23,15 +37,98 @@ export type TooltipStateReturn = Omit<
   TooltipState &
   TooltipActions;
 
+type Listener = (id: string | null) => void;
+
+const state = {
+  currentTooltipId: null as string | null,
+  listeners: new Set<Listener>(),
+  subscribe(listener: Listener) {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  },
+  show(id: string) {
+    this.currentTooltipId = id;
+    this.listeners.forEach((listener) => listener(id));
+  },
+  hide(id: string) {
+    if (this.currentTooltipId === id) {
+      this.currentTooltipId = null;
+      this.listeners.forEach((listener) => listener(null));
+    }
+  },
+};
+
 export function useTooltipState(
   initialState: SealedInitialState<TooltipInitialState> = {}
 ): TooltipStateReturn {
-  const { placement = "top", ...sealed } = useSealedState(initialState);
-  return usePopoverState({ ...sealed, placement });
+  const {
+    placement = "top",
+    unstable_timeout: initialTimeout = 0,
+    ...sealed
+  } = useSealedState(initialState);
+  const [timeout, setTimeout] = React.useState(initialTimeout);
+  const showTimeout = React.useRef<number | null>(null);
+  const hideTimeout = React.useRef<number | null>(null);
+
+  const popover = usePopoverState({ ...sealed, placement });
+
+  React.useEffect(() => {
+    if (!popover.visible) return undefined;
+    return state.subscribe((id) => {
+      // Make sure there will be only one tooltip open
+      if (id !== popover.baseId) {
+        popover.hide();
+      }
+    });
+  }, [popover.visible, popover.baseId, popover.hide]);
+
+  const hide = React.useCallback(() => {
+    popover.hide();
+    // Avoid race conditions when hide is called before show timeout
+    if (showTimeout.current !== null) {
+      window.clearTimeout(showTimeout.current);
+    }
+    // Let's give some time so people can move from a reference to another
+    // and still show tooltips immediately
+    hideTimeout.current = window.setTimeout(() => {
+      state.hide(popover.baseId);
+    }, timeout);
+  }, [popover.hide, timeout, popover.baseId]);
+
+  const show = React.useCallback(() => {
+    // Avoid race conditions when show is called before hide timeout
+    if (hideTimeout.current !== null) {
+      window.clearTimeout(hideTimeout.current);
+    }
+    if (!timeout || state.currentTooltipId) {
+      // If there's no timeout or a tooltip visible already, we can show this
+      // immediately
+      state.show(popover.baseId);
+      popover.show();
+    } else {
+      // Otherwise, wait a little bit to show the tooltip
+      showTimeout.current = window.setTimeout(() => {
+        state.show(popover.baseId);
+        popover.show();
+      }, timeout);
+    }
+  }, [timeout, popover.show, popover.baseId]);
+
+  return {
+    ...popover,
+    hide,
+    show,
+    unstable_timeout: timeout,
+    unstable_setTimeout: setTimeout,
+  };
 }
 
 const keys: Array<keyof PopoverStateReturn | keyof TooltipStateReturn> = [
   ...usePopoverState.__keys,
+  "unstable_timeout",
+  "unstable_setTimeout",
 ];
 
 useTooltipState.__keys = keys;

--- a/packages/reakit/src/Tooltip/__tests__/index-test.tsx
+++ b/packages/reakit/src/Tooltip/__tests__/index-test.tsx
@@ -1,12 +1,18 @@
 import * as React from "react";
-import { render, hover, wait, focus } from "reakit-test-utils";
+import { act, render, hover, focus } from "reakit-test-utils";
 import { Tooltip, TooltipReference, useTooltipState } from "..";
 
-afterEach(() => {
+function advanceTimersByTime(ms: number) {
+  act(() => {
+    jest.advanceTimersByTime(ms);
+  });
+}
+
+afterEach(async () => {
   hover(document.body);
 });
 
-test("show tooltip on hover", async () => {
+test("show tooltip on hover", () => {
   const Test = () => {
     const tooltip = useTooltipState();
     return (
@@ -19,12 +25,12 @@ test("show tooltip on hover", async () => {
   const { baseElement, getByText: text } = render(<Test />);
   expect(text("tooltip")).not.toBeVisible();
   hover(text("reference"));
-  await wait(expect(text("tooltip")).toBeVisible);
+  expect(text("tooltip")).toBeVisible();
   hover(baseElement);
   expect(text("tooltip")).not.toBeVisible();
 });
 
-test("show only one tooltip", async () => {
+test("show only one tooltip", () => {
   const Test = () => {
     const tooltip1 = useTooltipState();
     const tooltip2 = useTooltipState();
@@ -41,14 +47,14 @@ test("show only one tooltip", async () => {
   expect(text("tooltip1")).not.toBeVisible();
   expect(text("tooltip2")).not.toBeVisible();
   focus(text("reference1"));
-  await wait(expect(text("tooltip1")).toBeVisible);
+  expect(text("tooltip1")).toBeVisible();
   expect(text("tooltip2")).not.toBeVisible();
   hover(text("reference2"));
   expect(text("tooltip1")).not.toBeVisible();
-  await wait(expect(text("tooltip2")).toBeVisible);
+  expect(text("tooltip2")).toBeVisible();
 });
 
-test("show tooltip with a timeout", async () => {
+test("show tooltip with a timeout", () => {
   const Test = () => {
     const tooltip = useTooltipState({ unstable_timeout: 250 });
     return (
@@ -59,10 +65,54 @@ test("show tooltip with a timeout", async () => {
     );
   };
   const { baseElement, getByText: text } = render(<Test />);
+  jest.useFakeTimers();
   expect(text("tooltip")).not.toBeVisible();
   hover(text("reference"));
   expect(text("tooltip")).not.toBeVisible();
-  await wait(expect(text("tooltip")).toBeVisible);
+  advanceTimersByTime(249);
   hover(baseElement);
   expect(text("tooltip")).not.toBeVisible();
+  advanceTimersByTime(1);
+  expect(text("tooltip")).not.toBeVisible();
+  hover(text("reference"));
+  advanceTimersByTime(249);
+  expect(text("tooltip")).not.toBeVisible();
+  advanceTimersByTime(1);
+  expect(text("tooltip")).toBeVisible();
+  jest.useRealTimers();
+});
+
+test("show tooltip immediately if there is another one visible", () => {
+  const Test = () => {
+    const tooltip1 = useTooltipState({ unstable_timeout: 500 });
+    const tooltip2 = useTooltipState({ unstable_timeout: 300 });
+    return (
+      <>
+        <TooltipReference {...tooltip1}>reference1</TooltipReference>
+        <Tooltip {...tooltip1}>tooltip1</Tooltip>
+        <TooltipReference {...tooltip2}>reference2</TooltipReference>
+        <Tooltip {...tooltip2}>tooltip2</Tooltip>
+      </>
+    );
+  };
+  const { getByText: text } = render(<Test />);
+  jest.useFakeTimers();
+  expect(text("tooltip1")).not.toBeVisible();
+  expect(text("tooltip2")).not.toBeVisible();
+  focus(text("reference1"));
+  advanceTimersByTime(499);
+  expect(text("tooltip1")).not.toBeVisible();
+  expect(text("tooltip2")).not.toBeVisible();
+  hover(text("reference2"));
+  expect(text("tooltip1")).not.toBeVisible();
+  expect(text("tooltip2")).not.toBeVisible();
+  advanceTimersByTime(1);
+  expect(text("tooltip1")).not.toBeVisible();
+  expect(text("tooltip2")).not.toBeVisible();
+  advanceTimersByTime(499);
+  expect(text("tooltip1")).not.toBeVisible();
+  expect(text("tooltip2")).toBeVisible();
+  hover(text("reference1"));
+  expect(text("tooltip1")).toBeVisible();
+  expect(text("tooltip2")).not.toBeVisible();
 });

--- a/packages/reakit/src/Tooltip/__tests__/index-test.tsx
+++ b/packages/reakit/src/Tooltip/__tests__/index-test.tsx
@@ -1,6 +1,10 @@
 import * as React from "react";
-import { render, hover, wait } from "reakit-test-utils";
+import { render, hover, wait, focus } from "reakit-test-utils";
 import { Tooltip, TooltipReference, useTooltipState } from "..";
+
+afterEach(() => {
+  hover(document.body);
+});
 
 test("show tooltip on hover", async () => {
   const Test = () => {
@@ -12,12 +16,53 @@ test("show tooltip on hover", async () => {
       </>
     );
   };
-  const { baseElement, getByText } = render(<Test />);
-  const reference = getByText("reference");
-  const tooltip = getByText("tooltip");
-  expect(tooltip).not.toBeVisible();
-  hover(reference);
-  await wait(expect(tooltip).toBeVisible);
+  const { baseElement, getByText: text } = render(<Test />);
+  expect(text("tooltip")).not.toBeVisible();
+  hover(text("reference"));
+  await wait(expect(text("tooltip")).toBeVisible);
   hover(baseElement);
-  await wait(expect(tooltip).not.toBeVisible);
+  expect(text("tooltip")).not.toBeVisible();
+});
+
+test("show only one tooltip", async () => {
+  const Test = () => {
+    const tooltip1 = useTooltipState();
+    const tooltip2 = useTooltipState();
+    return (
+      <>
+        <TooltipReference {...tooltip1}>reference1</TooltipReference>
+        <Tooltip {...tooltip1}>tooltip1</Tooltip>
+        <TooltipReference {...tooltip2}>reference2</TooltipReference>
+        <Tooltip {...tooltip2}>tooltip2</Tooltip>
+      </>
+    );
+  };
+  const { getByText: text } = render(<Test />);
+  expect(text("tooltip1")).not.toBeVisible();
+  expect(text("tooltip2")).not.toBeVisible();
+  focus(text("reference1"));
+  await wait(expect(text("tooltip1")).toBeVisible);
+  expect(text("tooltip2")).not.toBeVisible();
+  hover(text("reference2"));
+  expect(text("tooltip1")).not.toBeVisible();
+  await wait(expect(text("tooltip2")).toBeVisible);
+});
+
+test("show tooltip with a timeout", async () => {
+  const Test = () => {
+    const tooltip = useTooltipState({ unstable_timeout: 250 });
+    return (
+      <>
+        <TooltipReference {...tooltip}>reference</TooltipReference>
+        <Tooltip {...tooltip}>tooltip</Tooltip>
+      </>
+    );
+  };
+  const { baseElement, getByText: text } = render(<Test />);
+  expect(text("tooltip")).not.toBeVisible();
+  hover(text("reference"));
+  expect(text("tooltip")).not.toBeVisible();
+  await wait(expect(text("tooltip")).toBeVisible);
+  hover(baseElement);
+  expect(text("tooltip")).not.toBeVisible();
 });


### PR DESCRIPTION
This adds an experimental `unstable_timeout` number option to `useTooltipState` so it'll wait some time before showing the tooltip.

```jsx
import { useTooltipState, Tooltip, TooltipReference } from "reakit";

function Example() {
  const tooltip = useTooltipState({ unstable_timeout: 250 });
  return (
    <>
      <TooltipReference {...tooltip}>Reference</TooltipReference>
      <Tooltip {...tooltip}>Tooltip</Tooltip>
    </>
  );
}
```

This also makes sure that there will be always only one tooltip open.

**Does this PR introduce a breaking change?**

No