### PR TITLE
fix: Fix `Checkbox` activating twice on space key on Firefox

### DIFF
--- a/packages/reakit/src/Clickable/Clickable.ts
+++ b/packages/reakit/src/Clickable/Clickable.ts
@@ -29,6 +29,7 @@ export type ClickableProps = ClickableOptions & ClickableHTMLProps;
 function isNativeClick(event: React.KeyboardEvent) {
   const self = event.currentTarget;
   if (!event.isTrusted) return false;
+  // istanbul ignore next: can't test trusted events yet
   return (
     isButton(self) ||
     self.tagName === "INPUT" ||

--- a/packages/reakit/src/Clickable/Clickable.ts
+++ b/packages/reakit/src/Clickable/Clickable.ts
@@ -29,7 +29,13 @@ export type ClickableProps = ClickableOptions & ClickableHTMLProps;
 function isNativeClick(event: React.KeyboardEvent) {
   const self = event.currentTarget;
   if (!event.isTrusted) return false;
-  return isButton(self) || self.tagName === "A" || self.tagName === "SELECT";
+  return (
+    isButton(self) ||
+    self.tagName === "INPUT" ||
+    self.tagName === "TEXTAREA" ||
+    self.tagName === "A" ||
+    self.tagName === "SELECT"
+  );
 }
 
 export const useClickable = createHook<ClickableOptions, ClickableHTMLProps>({


### PR DESCRIPTION
Closes #368

The `Clickable` component wasn't considering inputs, so the space key up was triggering another click on the checkbox.

I can't write a test for this because it checks for `event.isTrusted`, and, on tests, this is always `false`.

**Does this PR introduce a breaking change?**

No