### PR TITLE
feat: Hide `Tooltip` when pressing `Escape`

### DIFF
--- a/packages/reakit/src/Tooltip/README.md
+++ b/packages/reakit/src/Tooltip/README.md
@@ -172,6 +172,7 @@ function Example() {
 
 - `Tooltip` has role `tooltip`.
 - `TooltipReference` has `aria-describedby` referring to `Tooltip`.
+- <kbd>Escape</kbd> hides the current visible tooltip.
 
 Learn more in [Accessibility](/docs/accessibility/).
 

--- a/packages/reakit/src/Tooltip/Tooltip.tsx
+++ b/packages/reakit/src/Tooltip/Tooltip.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { createComponent } from "reakit-system/createComponent";
 import { createHook } from "reakit-system/createHook";
 import { useForkRef } from "reakit-utils/useForkRef";
+import { getDocument } from "reakit-utils/getDocument";
 import {
   DisclosureContentOptions,
   DisclosureContentHTMLProps,
@@ -9,6 +10,7 @@ import {
 } from "../Disclosure/DisclosureContent";
 import { Portal } from "../Portal/Portal";
 import { TooltipStateReturn, useTooltipState } from "./TooltipState";
+import globalState from "./__globalState";
 
 export type TooltipOptions = DisclosureContentOptions &
   Pick<
@@ -25,6 +27,13 @@ export type TooltipOptions = DisclosureContentOptions &
 export type TooltipHTMLProps = DisclosureContentHTMLProps;
 
 export type TooltipProps = TooltipOptions & TooltipHTMLProps;
+
+function globallyHideTooltipOnEscape(event: KeyboardEvent) {
+  if (event.defaultPrevented) return;
+  if (event.key === "Escape") {
+    globalState.show(null);
+  }
+}
 
 export const useTooltip = createHook<TooltipOptions, TooltipHTMLProps>({
   name: "Tooltip",
@@ -45,6 +54,11 @@ export const useTooltip = createHook<TooltipOptions, TooltipHTMLProps>({
       ...htmlProps
     }
   ) {
+    React.useEffect(() => {
+      const document = getDocument(options.unstable_popoverRef?.current);
+      document.addEventListener("keydown", globallyHideTooltipOnEscape);
+    }, []);
+
     const wrapElement = React.useCallback(
       (element: React.ReactNode) => {
         if (options.unstable_portal) {

--- a/packages/reakit/src/Tooltip/__examples__/TooltipWithToolbar/__tests__/index-test.tsx
+++ b/packages/reakit/src/Tooltip/__examples__/TooltipWithToolbar/__tests__/index-test.tsx
@@ -16,4 +16,7 @@ test("show tooltip", () => {
   expect(text("item2tooltip")).not.toBeVisible();
   expect(text("item2")).toHaveFocus();
   expect(text("item3tooltip")).toBeVisible();
+  press.Escape();
+  expect(text("item2")).toHaveFocus();
+  expect(text("item3tooltip")).not.toBeVisible();
 });

--- a/packages/reakit/src/Tooltip/__globalState.ts
+++ b/packages/reakit/src/Tooltip/__globalState.ts
@@ -1,0 +1,22 @@
+type Listener = (id: string | null) => void;
+
+export default {
+  currentTooltipId: null as string | null,
+  listeners: new Set<Listener>(),
+  subscribe(listener: Listener) {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  },
+  show(id: string | null) {
+    this.currentTooltipId = id;
+    this.listeners.forEach((listener) => listener(id));
+  },
+  hide(id: string) {
+    if (this.currentTooltipId === id) {
+      this.currentTooltipId = null;
+      this.listeners.forEach((listener) => listener(null));
+    }
+  },
+};


### PR DESCRIPTION
This implements a global event handler that hides all tooltips if <kbd>Escape</kbd> is pressed.

**Does this PR introduce a breaking change?**

No. This is part of the WAI-ARIA recommendations for tooltips.