### PR TITLE
examples: button with tooltip

### DIFF
--- a/packages/reakit/src/Button/__examples__/ButtonWithTootltip/__tests__/index-test.tsx
+++ b/packages/reakit/src/Button/__examples__/ButtonWithTootltip/__tests__/index-test.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { click, press, render } from "reakit-test-utils";
+import ButtonWithTooltip from "..";
+
+test("two-state button with tooltip", () => {
+  const { getByText: text } = render(<ButtonWithTooltip />);
+  const buttonUnlocked = text("🔓");
+  expect(buttonUnlocked).toBeVisible();
+  press.Tab();
+  expect(text("Click to lock")).toBeVisible();
+  expect(text("It's unlocked!")).toBeVisible();
+  click(buttonUnlocked);
+  const buttonLocked = text("🔒");
+  expect(buttonLocked).toBeVisible();
+  expect(text("Click to unlock")).toBeVisible();
+  expect(text("It's locked!")).toBeVisible();
+  press.Space(buttonLocked);
+  expect(buttonUnlocked).toBeVisible();
+});

--- a/packages/reakit/src/Button/__examples__/ButtonWithTootltip/__tests__/index-test.tsx
+++ b/packages/reakit/src/Button/__examples__/ButtonWithTootltip/__tests__/index-test.tsx
@@ -14,6 +14,6 @@ test("two-state button with tooltip", () => {
   expect(buttonLocked).toBeVisible();
   expect(text("Click to unlock")).toBeVisible();
   expect(text("It's locked!")).toBeVisible();
-  press.Space(buttonLocked);
+  press.Space();
   expect(buttonUnlocked).toBeVisible();
 });

--- a/packages/reakit/src/Button/__examples__/ButtonWithTootltip/index.tsx
+++ b/packages/reakit/src/Button/__examples__/ButtonWithTootltip/index.tsx
@@ -1,11 +1,15 @@
 import * as React from "react";
 import { Button } from "reakit/Button";
-import { Tooltip, TooltipReference, useTooltipState } from "reakit/Tooltip";
+import {
+  Tooltip,
+  TooltipReference,
+  useTooltipState,
+  TooltipReferenceHTMLProps,
+} from "reakit/Tooltip";
 import { VisuallyHidden } from "reakit/VisuallyHidden";
 
-type Props = {
-  isLocked: boolean;
-  onClick: () => void;
+type Props = TooltipReferenceHTMLProps & {
+  isLocked?: boolean;
 };
 
 function LockButton({ isLocked, ...props }: Props) {

--- a/packages/reakit/src/Button/__examples__/ButtonWithTootltip/index.tsx
+++ b/packages/reakit/src/Button/__examples__/ButtonWithTootltip/index.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { Button } from "reakit/Button";
+import { Tooltip, TooltipReference, useTooltipState } from "reakit/Tooltip";
+import { VisuallyHidden } from "reakit/VisuallyHidden";
+
+type Props = {
+  isLocked: boolean;
+  onClick: () => void;
+};
+
+function LockButton({ isLocked, ...rest }: Props) {
+  const tooltip = useTooltipState();
+  return (
+    <>
+      <TooltipReference {...rest} {...tooltip} as={Button}>
+        {isLocked ? (
+          <>
+            <VisuallyHidden>Click to unlock</VisuallyHidden>{" "}
+            <span aria-hidden>🔒</span>
+          </>
+        ) : (
+          <>
+            <VisuallyHidden>Click to lock</VisuallyHidden>{" "}
+            <span aria-hidden>🔓</span>
+          </>
+        )}
+      </TooltipReference>
+      <Tooltip {...tooltip}>{`It's ${
+        isLocked ? "locked" : "unlocked"
+      }!`}</Tooltip>
+    </>
+  );
+}
+
+export default function ButtonWithTooltip() {
+  const [isLocked, setLock] = React.useState(false);
+  return (
+    <LockButton
+      isLocked={isLocked}
+      onClick={() => setLock((prevState) => !prevState)}
+    />
+  );
+}

--- a/packages/reakit/src/Button/__examples__/ButtonWithTootltip/index.tsx
+++ b/packages/reakit/src/Button/__examples__/ButtonWithTootltip/index.tsx
@@ -8,11 +8,11 @@ type Props = {
   onClick: () => void;
 };
 
-function LockButton({ isLocked, ...rest }: Props) {
+function LockButton({ isLocked, ...props }: Props) {
   const tooltip = useTooltipState();
   return (
     <>
-      <TooltipReference {...rest} {...tooltip} as={Button}>
+      <TooltipReference {...props} {...tooltip} as={Button}>
         <>
           <VisuallyHidden>Click to {isLocked ? "unlock" : "lock"}</VisuallyHidden>{" "}
           <span aria-hidden>{isLocked ? "🔒" : "🔓"}</span>

--- a/packages/reakit/src/Button/__examples__/ButtonWithTootltip/index.tsx
+++ b/packages/reakit/src/Button/__examples__/ButtonWithTootltip/index.tsx
@@ -13,17 +13,10 @@ function LockButton({ isLocked, ...rest }: Props) {
   return (
     <>
       <TooltipReference {...rest} {...tooltip} as={Button}>
-        {isLocked ? (
-          <>
-            <VisuallyHidden>Click to unlock</VisuallyHidden>{" "}
-            <span aria-hidden>🔒</span>
-          </>
-        ) : (
-          <>
-            <VisuallyHidden>Click to lock</VisuallyHidden>{" "}
-            <span aria-hidden>🔓</span>
-          </>
-        )}
+        <>
+          <VisuallyHidden>Click to {isLocked ? "unlock" : "lock"}</VisuallyHidden>{" "}
+          <span aria-hidden>{isLocked ? "🔒" : "🔓"}</span>
+        </>
       </TooltipReference>
       <Tooltip {...tooltip}>
         It's {isLocked ? "locked" : "unlocked"}!

--- a/packages/reakit/src/Button/__examples__/ButtonWithTootltip/index.tsx
+++ b/packages/reakit/src/Button/__examples__/ButtonWithTootltip/index.tsx
@@ -14,15 +14,15 @@ type Props = TooltipReferenceHTMLProps & {
 
 function LockButton({ isLocked, ...props }: Props) {
   const tooltip = useTooltipState();
+  const text = `Click to ${isLocked ? "unlock" : "lock"}`;
+  const icon = isLocked ? "🔒" : "🔓";
   const tip = `It's ${isLocked ? "locked" : "unlocked"}!`;
   return (
     <>
       <TooltipReference {...props} {...tooltip} as={Button}>
         <>
-          <VisuallyHidden>
-            Click to {isLocked ? "unlock" : "lock"}
-          </VisuallyHidden>
-          <span aria-hidden>{isLocked ? "🔒" : "🔓"}</span>
+          <VisuallyHidden>{text}</VisuallyHidden>
+          <span aria-hidden>{icon}</span>
         </>
       </TooltipReference>
       <Tooltip {...tooltip}>{tip}</Tooltip>

--- a/packages/reakit/src/Button/__examples__/ButtonWithTootltip/index.tsx
+++ b/packages/reakit/src/Button/__examples__/ButtonWithTootltip/index.tsx
@@ -14,17 +14,18 @@ type Props = TooltipReferenceHTMLProps & {
 
 function LockButton({ isLocked, ...props }: Props) {
   const tooltip = useTooltipState();
+  const tip = `It's ${isLocked ? "locked" : "unlocked"}!`;
   return (
     <>
       <TooltipReference {...props} {...tooltip} as={Button}>
         <>
-          <VisuallyHidden>Click to {isLocked ? "unlock" : "lock"}</VisuallyHidden>{" "}
+          <VisuallyHidden>
+            Click to {isLocked ? "unlock" : "lock"}
+          </VisuallyHidden>
           <span aria-hidden>{isLocked ? "🔒" : "🔓"}</span>
         </>
       </TooltipReference>
-      <Tooltip {...tooltip}>
-        It's {isLocked ? "locked" : "unlocked"}!
-      </Tooltip>
+      <Tooltip {...tooltip}>{tip}</Tooltip>
     </>
   );
 }

--- a/packages/reakit/src/Button/__examples__/ButtonWithTootltip/index.tsx
+++ b/packages/reakit/src/Button/__examples__/ButtonWithTootltip/index.tsx
@@ -25,9 +25,9 @@ function LockButton({ isLocked, ...rest }: Props) {
           </>
         )}
       </TooltipReference>
-      <Tooltip {...tooltip}>{`It's ${
-        isLocked ? "locked" : "unlocked"
-      }!`}</Tooltip>
+      <Tooltip {...tooltip}>
+        It's {isLocked ? "locked" : "unlocked"}!
+      </Tooltip>
     </>
   );
 }


### PR DESCRIPTION
Add an example using a Button with Tooltip and VisuallyHidden.

![button-with-tooltip](https://user-images.githubusercontent.com/18534166/79639943-11f81980-818f-11ea-982e-69cd57e21e57.gif)

It will increase the list of examples related to #626