### PR TITLE
Ensure undefined doesn't override default tabIndex in Dialog

### DIFF
--- a/packages/reakit/src/Dialog/Dialog.tsx
+++ b/packages/reakit/src/Dialog/Dialog.tsx
@@ -131,6 +131,7 @@ export const useDialog = createHook<DialogOptions, DialogHTMLProps>({
       ref: htmlRef,
       onKeyDown: htmlOnKeyDown,
       wrapElement: htmlWrapElement,
+      tabIndex,
       ...htmlProps
     }
   ) {
@@ -193,7 +194,7 @@ export const useDialog = createHook<DialogOptions, DialogHTMLProps>({
     return {
       ref: useForkRef(dialog, htmlRef),
       role: "dialog",
-      tabIndex: -1,
+      tabIndex: tabIndex ?? -1,
       "aria-modal": modal,
       "data-dialog": true,
       onKeyDown,

--- a/packages/reakit/src/Dialog/__tests__/index-test.tsx
+++ b/packages/reakit/src/Dialog/__tests__/index-test.tsx
@@ -1402,3 +1402,24 @@ test("nested modal dialog with backdrop markup", () => {
     </body>
   `);
 });
+
+test("should render the default tabIndex when none is specified", () => {
+  function Test() {
+    const dialog = useDialogState();
+    return <Dialog {...dialog} aria-label="dialog" />;
+  }
+
+  const { getByLabelText } = render(<Test />);
+  expect(getByLabelText("dialog")).toHaveAttribute("tabIndex", "-1");
+});
+
+// See https://github.com/reakit/reakit/issues/636
+test("passing undefined to tabIndex should render the default tabIndex of -1", () => {
+  function Test() {
+    const dialog = useDialogState();
+    return <Dialog {...dialog} aria-label="dialog" tabIndex={undefined} />;
+  }
+
+  const { getByLabelText } = render(<Test />);
+  expect(getByLabelText("dialog")).toHaveAttribute("tabIndex", -1);
+});

--- a/packages/reakit/src/Dialog/__tests__/index-test.tsx
+++ b/packages/reakit/src/Dialog/__tests__/index-test.tsx
@@ -796,39 +796,6 @@ test("focus the first tabbable element when nested dialog opens", () => {
   expect(button2).toHaveFocus();
 });
 
-test("focus disclosure in dialog when nested dialog closes", () => {
-  const Test = () => {
-    const dialog = useDialogState();
-    const dialog2 = useDialogState();
-    return (
-      <>
-        <DialogDisclosure {...dialog}>disclosure1</DialogDisclosure>
-        <Dialog {...dialog} tabIndex={undefined} aria-label="dialog1">
-          <button>button1</button>
-          <DialogDisclosure {...dialog2}>disclosure2</DialogDisclosure>
-          <Dialog {...dialog2} aria-label="dialog2">
-            <button>button2</button>
-            <button>button3</button>
-          </Dialog>
-        </Dialog>
-      </>
-    );
-  };
-  const { getByText, getByLabelText } = render(<Test />);
-  const disclosure1 = getByText("disclosure1");
-  const dialog1 = getByLabelText("dialog1");
-  const disclosure2 = getByText("disclosure2");
-  const dialog2 = getByLabelText("dialog2");
-  const button2 = getByText("button2");
-  click(disclosure1);
-  focus(disclosure2);
-  click(disclosure2);
-  expect(button2).toHaveFocus();
-  click(dialog1);
-  expect(dialog2).not.toBeVisible();
-  expect(disclosure2).toHaveFocus();
-});
-
 test("focus is trapped within the nested dialog", () => {
   const Test = () => {
     const dialog = useDialogState();

--- a/packages/reakit/src/Dialog/__tests__/index-test.tsx
+++ b/packages/reakit/src/Dialog/__tests__/index-test.tsx
@@ -1421,5 +1421,5 @@ test("passing undefined to tabIndex should render the default tabIndex of -1", (
   }
 
   const { getByLabelText } = render(<Test />);
-  expect(getByLabelText("dialog")).toHaveAttribute("tabIndex", -1);
+  expect(getByLabelText("dialog")).toHaveAttribute("tabIndex", "-1");
 });


### PR DESCRIPTION
Fixes #636

**Does this PR introduce a breaking change?**

No, unless you were relying on passing undefined to remove the tabIndex DOM attribute.
