### PR TITLE
Examples: Toolbar with Menu

### DIFF
--- a/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/__tests__/index-test.tsx
+++ b/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/__tests__/index-test.tsx
@@ -2,77 +2,113 @@ import * as React from "react";
 import { render, press, click } from "reakit-test-utils";
 import ToolbarWithMenu from "..";
 
-describe("<ToolbarWithMenu />", () => {
-  test("renders toolbar items with closed menu", () => {
-    const { getByText: text } = render(<ToolbarWithMenu />);
+test("renders toolbar items with closed menu", () => {
+  const { getByText: text } = render(<ToolbarWithMenu />);
 
-    expect(text("Apples")).toBeVisible();
-    expect(text("Oranges")).toBeVisible();
-    expect(text("Other Fruits")).toBeVisible();
+  expect(text("Apples")).toBeVisible();
+  expect(text("Oranges")).toBeVisible();
+  expect(text("Other Fruits")).toBeVisible();
 
-    expect(text("Pears")).not.toBeVisible();
-    expect(text("Kiwis")).not.toBeVisible();
-    expect(text("Lemons")).not.toBeVisible();
-  });
+  expect(text("Pears")).not.toBeVisible();
+  expect(text("Kiwis")).not.toBeVisible();
+  expect(text("Lemons")).not.toBeVisible();
+});
 
-  it("can navigate toolbar items through keyboard", () => {
-    const { getByText: text } = render(<ToolbarWithMenu />);
+it("can navigate toolbar items through keyboard", () => {
+  const { getByText: text } = render(<ToolbarWithMenu />);
 
-    press.Tab();
-    expect(text("Apples")).toHaveFocus();
+  press.Tab();
+  expect(text("Apples")).toHaveFocus();
 
-    press.ArrowRight();
-    expect(text("Oranges")).toHaveFocus();
+  press.ArrowRight();
+  expect(text("Oranges")).toHaveFocus();
 
-    press.ArrowLeft();
-    expect(text("Apples")).toHaveFocus();
+  press.ArrowLeft();
+  expect(text("Apples")).toHaveFocus();
 
-    press.ArrowRight();
-    press.ArrowRight();
-    expect(text("Other Fruits")).toHaveFocus();
+  press.ArrowRight();
+  press.ArrowRight();
+  expect(text("Other Fruits")).toHaveFocus();
 
-    press.Enter();
-    expect(text("Pears")).toBeVisible();
-    expect(text("Pears")).toHaveFocus();
-  });
+  press.Enter();
+  expect(text("Pears")).toBeVisible();
+  expect(text("Pears")).toHaveFocus();
+});
 
-  it("can open and close the menu through mouse", () => {
-    const { getByText: text } = render(<ToolbarWithMenu />);
+test("can open and close the menu through mouse", () => {
+  const { getByText: text } = render(<ToolbarWithMenu />);
 
-    click(text("Other Fruits"));
-    expect(text("Pears")).toBeVisible();
+  click(text("Other Fruits"));
+  expect(text("Pears")).toBeVisible();
 
-    click(text("Oranges"));
-    expect(text("Pears")).not.toBeVisible();
-  });
+  click(text("Oranges"));
+  expect(text("Pears")).not.toBeVisible();
+});
 
-  it("can open menu, navigate it and close it through keyboard", () => {
-    const { getByText: text } = render(<ToolbarWithMenu />);
+test("can open menu, navigate it and close it through keyboard", () => {
+  const { getByText: text } = render(<ToolbarWithMenu />);
 
-    press.Tab();
-    expect(text("Apples")).toHaveFocus();
-    press.ArrowRight();
-    press.ArrowRight();
-    expect(text("Other Fruits")).toHaveFocus();
-    press.Enter();
+  press.Tab();
+  expect(text("Apples")).toHaveFocus();
+  press.ArrowRight();
+  press.ArrowRight();
+  expect(text("Other Fruits")).toHaveFocus();
+  press.Enter();
 
-    expect(text("Pears")).toHaveFocus();
-    expect(text("Pears")).toBeVisible();
-    expect(text("Kiwis")).toBeVisible();
-    expect(text("Lemons")).toBeVisible();
+  expect(text("Pears")).toHaveFocus();
+  expect(text("Pears")).toBeVisible();
+  expect(text("Kiwis")).toBeVisible();
+  expect(text("Lemons")).toBeVisible();
 
-    press.ArrowDown();
-    expect(text("Kiwis")).toHaveFocus();
-    press.ArrowDown();
-    expect(text("Lemons")).toHaveFocus();
-    press.ArrowUp();
-    expect(text("Kiwis")).toHaveFocus();
+  press.ArrowDown();
+  expect(text("Kiwis")).toHaveFocus();
+  press.ArrowDown();
+  expect(text("Lemons")).toHaveFocus();
+  press.ArrowUp();
+  expect(text("Kiwis")).toHaveFocus();
 
-    press.Escape();
+  press.Escape();
 
-    expect(text("Pears")).not.toBeVisible();
-    expect(text("Kiwis")).not.toBeVisible();
-    expect(text("Lemons")).not.toBeVisible();
-    expect(text("Other Fruits")).toHaveFocus();
-  });
+  expect(text("Pears")).not.toBeVisible();
+  expect(text("Kiwis")).not.toBeVisible();
+  expect(text("Lemons")).not.toBeVisible();
+  expect(text("Other Fruits")).toHaveFocus();
+});
+
+test("opens menu pressing arrow down focusing first item", async () => {
+  const { getByText: getText, findByText: findText } = render(
+    <ToolbarWithMenu />
+  );
+
+  press.Tab();
+  expect(getText("Apples")).toHaveFocus();
+  press.ArrowRight();
+  press.ArrowRight();
+  expect(getText("Other Fruits")).toHaveFocus();
+
+  press.ArrowDown();
+
+  const firstMenuItem = await findText("Pears");
+
+  expect(firstMenuItem).toHaveFocus();
+  expect(firstMenuItem).toBeVisible();
+});
+
+test("opens menu pressing arrow up focusing last item", async () => {
+  const { getByText: getText, findByText: findText } = render(
+    <ToolbarWithMenu />
+  );
+
+  press.Tab();
+  expect(getText("Apples")).toHaveFocus();
+  press.ArrowRight();
+  press.ArrowRight();
+  expect(getText("Other Fruits")).toHaveFocus();
+
+  press.ArrowUp();
+
+  const firstMenuItem = await findText("Lemons");
+
+  expect(firstMenuItem).toHaveFocus();
+  expect(firstMenuItem).toBeVisible();
 });

--- a/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/__tests__/index-test.tsx
+++ b/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/__tests__/index-test.tsx
@@ -14,7 +14,7 @@ test("renders toolbar items with closed menu", () => {
   expect(text("Lemons")).not.toBeVisible();
 });
 
-it("can navigate toolbar items through keyboard", () => {
+test("can navigate toolbar items through keyboard", () => {
   const { getByText: text } = render(<ToolbarWithMenu />);
 
   press.Tab();

--- a/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/__tests__/index-test.tsx
+++ b/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/__tests__/index-test.tsx
@@ -1,40 +1,66 @@
 import * as React from "react";
-import { render, press } from "reakit-test-utils";
+import { render, press, click } from "reakit-test-utils";
 import ToolbarWithMenu from "..";
 
 describe("<ToolbarWithMenu />", () => {
-  test("renders toolbar with open / close menu", () => {
+  test("renders toolbar items with closed menu", () => {
     const { getByText: text } = render(<ToolbarWithMenu />);
 
-    // 1. Toolbar items are visible
     expect(text("Apples")).toBeVisible();
     expect(text("Oranges")).toBeVisible();
     expect(text("Other Fruits")).toBeVisible();
 
-    // 2. Menu is closed
     expect(text("Pears")).not.toBeVisible();
     expect(text("Kiwis")).not.toBeVisible();
     expect(text("Lemons")).not.toBeVisible();
+  });
 
-    // 3. Can navigate toolbar items
+  it("can navigate toolbar items through keyboard", () => {
+    const { getByText: text } = render(<ToolbarWithMenu />);
+
     press.Tab();
     expect(text("Apples")).toHaveFocus();
+
     press.ArrowRight();
     expect(text("Oranges")).toHaveFocus();
+
     press.ArrowLeft();
     expect(text("Apples")).toHaveFocus();
+
     press.ArrowRight();
     press.ArrowRight();
     expect(text("Other Fruits")).toHaveFocus();
 
-    // 4. Can open the menu
-    press.ArrowDown();
+    press.Enter();
+    expect(text("Pears")).toBeVisible();
+    expect(text("Pears")).toHaveFocus();
+  });
+
+  it("can open and close the menu through mouse", () => {
+    const { getByText: text } = render(<ToolbarWithMenu />);
+
+    click(text("Other Fruits"));
+    expect(text("Pears")).toBeVisible();
+
+    click(text("Oranges"));
+    expect(text("Pears")).not.toBeVisible();
+  });
+
+  it("can open menu, navigate it and close it through keyboard", () => {
+    const { getByText: text } = render(<ToolbarWithMenu />);
+
+    press.Tab();
+    expect(text("Apples")).toHaveFocus();
+    press.ArrowRight();
+    press.ArrowRight();
+    expect(text("Other Fruits")).toHaveFocus();
+    press.Enter();
+
+    expect(text("Pears")).toHaveFocus();
     expect(text("Pears")).toBeVisible();
     expect(text("Kiwis")).toBeVisible();
     expect(text("Lemons")).toBeVisible();
-    expect(text("Pears")).toHaveFocus();
 
-    // 5. Can navigate the menu
     press.ArrowDown();
     expect(text("Kiwis")).toHaveFocus();
     press.ArrowDown();
@@ -42,8 +68,8 @@ describe("<ToolbarWithMenu />", () => {
     press.ArrowUp();
     expect(text("Kiwis")).toHaveFocus();
 
-    // 6. Can close the menu
     press.Escape();
+
     expect(text("Pears")).not.toBeVisible();
     expect(text("Kiwis")).not.toBeVisible();
     expect(text("Lemons")).not.toBeVisible();

--- a/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/__tests__/index-test.tsx
+++ b/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/__tests__/index-test.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { render, press } from "reakit-test-utils";
+import ToolbarWithMenu from "..";
+
+describe("<ToolbarWithMenu />", () => {
+  test("renders toolbar with open / close menu", () => {
+    const { getByText: text } = render(<ToolbarWithMenu />);
+
+    // 1. Toolbar items are visible
+    expect(text("Apples")).toBeVisible();
+    expect(text("Oranges")).toBeVisible();
+    expect(text("Other Fruits")).toBeVisible();
+
+    // 2. Menu is closed
+    expect(text("Pears")).not.toBeVisible();
+    expect(text("Kiwis")).not.toBeVisible();
+    expect(text("Lemons")).not.toBeVisible();
+
+    // 3. Can navigate toolbar items
+    press.Tab();
+    expect(text("Apples")).toHaveFocus();
+    press.ArrowRight();
+    expect(text("Oranges")).toHaveFocus();
+    press.ArrowLeft();
+    expect(text("Apples")).toHaveFocus();
+    press.ArrowRight();
+    press.ArrowRight();
+    expect(text("Other Fruits")).toHaveFocus();
+
+    // 4. Can open the menu
+    press.ArrowDown();
+    expect(text("Pears")).toBeVisible();
+    expect(text("Kiwis")).toBeVisible();
+    expect(text("Lemons")).toBeVisible();
+    expect(text("Pears")).toHaveFocus();
+
+    // 5. Can navigate the menu
+    press.ArrowDown();
+    expect(text("Kiwis")).toHaveFocus();
+    press.ArrowDown();
+    expect(text("Lemons")).toHaveFocus();
+    press.ArrowUp();
+    expect(text("Kiwis")).toHaveFocus();
+
+    // 6. Can close the menu
+    press.Escape();
+    expect(text("Pears")).not.toBeVisible();
+    expect(text("Kiwis")).not.toBeVisible();
+    expect(text("Lemons")).not.toBeVisible();
+    expect(text("Other Fruits")).toHaveFocus();
+  });
+});

--- a/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/index.tsx
+++ b/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/index.tsx
@@ -1,0 +1,69 @@
+import React, { RefObject } from "react";
+import {
+  useToolbarState,
+  Toolbar,
+  ToolbarItem,
+  ToolbarProps,
+} from "reakit/Toolbar";
+import { useMenuState, MenuButton, Menu, MenuItem } from "reakit/Menu";
+import { Button } from "reakit/Button";
+
+const MoreItems = React.forwardRef((props: ToolbarProps, ref) => {
+  const menu = useMenuState({ placement: "bottom-end" });
+  const buttonRef = ref as RefObject<HTMLButtonElement>;
+
+  return (
+    <>
+      <MenuButton
+        {...menu}
+        {...props}
+        ref={buttonRef}
+        as={Button}
+        aria-label="Other fruits"
+      >
+        Other Fruits
+      </MenuButton>
+      <Menu {...menu} aria-label="Other fruits">
+        <MenuItem {...menu}>
+          Pears &nbsp;
+          <span role="img" aria-label="Pear emoji">
+            🍐
+          </span>
+        </MenuItem>
+        <MenuItem {...menu}>
+          Kiwis &nbsp;
+          <span role="img" aria-label="Kiwi emoji">
+            🥝
+          </span>
+        </MenuItem>
+        <MenuItem {...menu}>
+          Lemons &nbsp;
+          <span role="img" aria-label="Lemon emoji">
+            🍋
+          </span>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+});
+
+export default function ToolbarWithMenu() {
+  const toolbar = useToolbarState();
+  return (
+    <Toolbar {...toolbar} aria-label="Fruits">
+      <ToolbarItem {...toolbar} as={Button}>
+        Apples &nbsp;
+        <span role="img" aria-label="Apple emoji">
+          🍏
+        </span>
+      </ToolbarItem>
+      <ToolbarItem {...toolbar} as={Button}>
+        Oranges &nbsp;
+        <span role="img" aria-label="Orange emoji">
+          🍊
+        </span>
+      </ToolbarItem>
+      <ToolbarItem {...toolbar} as={MoreItems} />
+    </Toolbar>
+  );
+}

--- a/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/index.tsx
+++ b/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/index.tsx
@@ -1,36 +1,33 @@
 import React, { RefObject } from "react";
-import {
-  useToolbarState,
-  Toolbar,
-  ToolbarItem,
-  ToolbarProps,
-} from "reakit/Toolbar";
+import { useToolbarState, Toolbar, ToolbarItem } from "reakit/Toolbar";
 import { useMenuState, MenuButton, Menu, MenuItem } from "reakit/Menu";
 import { Button } from "reakit/Button";
+import { ToolbarProps } from "../../Toolbar";
 
-const MoreItems = React.forwardRef((props: ToolbarProps, ref) => {
-  const menu = useMenuState({ placement: "bottom-end" });
-  const buttonRef = ref as RefObject<HTMLButtonElement>;
+const MoreItems = React.forwardRef<HTMLButtonElement, ToolbarProps>(
+  (props, ref) => {
+    const menu = useMenuState({ placement: "bottom-end" });
+    const buttonRef = ref as RefObject<HTMLButtonElement>;
 
-  return (
-    <>
-      <MenuButton
-        {...menu}
-        {...props}
-        ref={buttonRef}
-        as={Button}
-        aria-label="Other fruits"
-      >
-        Other Fruits
-      </MenuButton>
-      <Menu {...menu} aria-label="Other fruits">
-        <MenuItem {...menu}>Pears</MenuItem>
-        <MenuItem {...menu}>Kiwis</MenuItem>
-        <MenuItem {...menu}>Lemons</MenuItem>
-      </Menu>
-    </>
-  );
-});
+    return (
+      <>
+        <MenuButton
+          {...menu}
+          {...props}
+          ref={buttonRef}
+          aria-label="Other fruits"
+        >
+          Other Fruits
+        </MenuButton>
+        <Menu {...menu} aria-label="Other fruits">
+          <MenuItem {...menu}>Pears</MenuItem>
+          <MenuItem {...menu}>Kiwis</MenuItem>
+          <MenuItem {...menu}>Lemons</MenuItem>
+        </Menu>
+      </>
+    );
+  }
+);
 
 export default function ToolbarWithMenu() {
   const toolbar = useToolbarState();

--- a/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/index.tsx
+++ b/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   useToolbarState,
   Toolbar,

--- a/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/index.tsx
+++ b/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/index.tsx
@@ -1,22 +1,20 @@
-import React, { RefObject } from "react";
-import { useToolbarState, Toolbar, ToolbarItem } from "reakit/Toolbar";
+import React from "react";
+import {
+  useToolbarState,
+  Toolbar,
+  ToolbarItem,
+  ToolbarProps,
+} from "reakit/Toolbar";
 import { useMenuState, MenuButton, Menu, MenuItem } from "reakit/Menu";
 import { Button } from "reakit/Button";
-import { ToolbarProps } from "../../Toolbar";
 
 const MoreItems = React.forwardRef<HTMLButtonElement, ToolbarProps>(
   (props, ref) => {
     const menu = useMenuState({ placement: "bottom-end" });
-    const buttonRef = ref;
 
     return (
       <>
-        <MenuButton
-          {...menu}
-          {...props}
-          ref={buttonRef}
-          aria-label="Other fruits"
-        >
+        <MenuButton {...menu} {...props} ref={ref} aria-label="Other fruits">
           Other Fruits
         </MenuButton>
         <Menu {...menu} aria-label="Other fruits">

--- a/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/index.tsx
+++ b/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/index.tsx
@@ -24,24 +24,9 @@ const MoreItems = React.forwardRef((props: ToolbarProps, ref) => {
         Other Fruits
       </MenuButton>
       <Menu {...menu} aria-label="Other fruits">
-        <MenuItem {...menu}>
-          Pears &nbsp;
-          <span role="img" aria-label="Pear emoji">
-            🍐
-          </span>
-        </MenuItem>
-        <MenuItem {...menu}>
-          Kiwis &nbsp;
-          <span role="img" aria-label="Kiwi emoji">
-            🥝
-          </span>
-        </MenuItem>
-        <MenuItem {...menu}>
-          Lemons &nbsp;
-          <span role="img" aria-label="Lemon emoji">
-            🍋
-          </span>
-        </MenuItem>
+        <MenuItem {...menu}>Pears</MenuItem>
+        <MenuItem {...menu}>Kiwis</MenuItem>
+        <MenuItem {...menu}>Lemons</MenuItem>
       </Menu>
     </>
   );
@@ -52,16 +37,10 @@ export default function ToolbarWithMenu() {
   return (
     <Toolbar {...toolbar} aria-label="Fruits">
       <ToolbarItem {...toolbar} as={Button}>
-        Apples &nbsp;
-        <span role="img" aria-label="Apple emoji">
-          🍏
-        </span>
+        Apples
       </ToolbarItem>
       <ToolbarItem {...toolbar} as={Button}>
-        Oranges &nbsp;
-        <span role="img" aria-label="Orange emoji">
-          🍊
-        </span>
+        Oranges
       </ToolbarItem>
       <ToolbarItem {...toolbar} as={MoreItems} />
     </Toolbar>

--- a/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/index.tsx
+++ b/packages/reakit/src/Toolbar/__examples__/ToolbarWithMenu/index.tsx
@@ -7,7 +7,7 @@ import { ToolbarProps } from "../../Toolbar";
 const MoreItems = React.forwardRef<HTMLButtonElement, ToolbarProps>(
   (props, ref) => {
     const menu = useMenuState({ placement: "bottom-end" });
-    const buttonRef = ref as RefObject<HTMLButtonElement>;
+    const buttonRef = ref;
 
     return (
       <>


### PR DESCRIPTION
## Summary

![toolbar](https://user-images.githubusercontent.com/5938217/82118261-4eab3680-9776-11ea-92ea-6834a0f2218d.gif)


As part of the documentation effort ono #626 this PR adds examples for a [Toolbar with Menu](https://reakit.io/docs/toolbar/#toolbar-with-menu).

I tried to stay consistent with existing examples 💅🏻

## Notes

I can remove the **emojis from the example** if needed, I think they add a bit of fun to it, however, I tend to over-use them 😄