### PR TITLE
Update live ref in commit phase

### DIFF
--- a/packages/reakit-utils/src/useLiveRef.ts
+++ b/packages/reakit-utils/src/useLiveRef.ts
@@ -1,10 +1,13 @@
 import * as React from "react";
+import { useIsomorphicEffect } from "./useIsomorphicEffect";
 
 /**
  * A `React.Ref` that keeps track of the passed `value`.
  */
 export function useLiveRef<T>(value: T): React.MutableRefObject<T> {
   const ref = React.useRef(value);
-  ref.current = value;
+  useIsomorphicEffect(() => {
+    ref.current = value;
+  });
   return ref;
 }


### PR DESCRIPTION
This fixes the timing of live ref updates. Writing to refs during the render phase is considered a side-effect and the React team is thinking how to surface this "problem" to the users. 

It's somewhat hard to 

**Does this PR introduce a breaking change?**

No