### PR TITLE
Ensure `test()` within tests rather than `it()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -82,5 +82,18 @@ module.exports = {
         "no-useless-constructor": "off",
       },
     },
+    {
+      files: "**/*-test.tsx",
+      plugins: ["jest"],
+      rules: {
+        "jest/consistent-test-it": [
+          "error",
+          {
+            fn: "test",
+            withinDescribe: "test",
+          },
+        ],
+      },
+    },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "eslint-config-react-app": "5.2.1",
     "eslint-import-resolver-babel-module": "5.1.2",
     "eslint-plugin-import": "2.20.2",
+    "eslint-plugin-jest": "23.13.1",
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-markdown": "1.0.2",
     "eslint-plugin-prettier": "3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3958,7 +3958,7 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/experimental-utils@2.34.0":
+"@typescript-eslint/experimental-utils@2.34.0", "@typescript-eslint/experimental-utils@^2.5.0":
   version "2.34.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
   integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
@@ -8652,6 +8652,13 @@ eslint-plugin-import@2.20.2, eslint-plugin-import@^2.20.2:
     object.values "^1.1.0"
     read-pkg-up "^2.0.0"
     resolve "^1.12.0"
+
+eslint-plugin-jest@23.13.1:
+  version "23.13.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.13.1.tgz#b2ce83f76064ad8ba1f1f26f322b86a86e44148e"
+  integrity sha512-TRLJH6M6EDvGocD98a7yVThrAOCK9WJfo9phuUb0MJptcrOYZeCKzC9aOzZCD93sxXCsiJVZywaTHdI/mAi0FQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^2.5.0"
 
 eslint-plugin-jsx-a11y@6.2.3, eslint-plugin-jsx-a11y@^6.2.3:
   version "6.2.3"


### PR DESCRIPTION
Following [this suggestion](https://github.com/reakit/reakit/pull/646#discussion_r426742680).

This PR makes sure, for consistency, that `test()` is used in our tests files rather than `it()`. 

I understand all tests in this project use the `*-test.tsx` file name convention, hence the regex.