### PR TITLE
Examples: Toolbar with Popover

### DIFF
--- a/packages/reakit/src/Toolbar/__examples__/ToolbarWithPopover/__tests__/index-test.tsx
+++ b/packages/reakit/src/Toolbar/__examples__/ToolbarWithPopover/__tests__/index-test.tsx
@@ -2,17 +2,16 @@ import * as React from "react";
 import { render, press } from "reakit-test-utils";
 import ToolbarWithPopover from "..";
 
-const popoverText =
-  "This trip lasts three days and takes place in the otherworldly environment of Ares Station.";
-
 test("renders toolbar items with closed popover", () => {
-  const { getByText: text } = render(<ToolbarWithPopover />);
+  const { getByText: text, getByLabelText: labelText } = render(
+    <ToolbarWithPopover />
+  );
 
   expect(text("Beach")).toBeVisible();
   expect(text("Mountain")).toBeVisible();
   expect(text("Mars")).toBeVisible();
 
-  expect(text(popoverText)).not.toBeVisible();
+  expect(labelText("Trip to Mars details")).not.toBeVisible();
 });
 
 test("allows to navigate toolbar items through keyboard", () => {
@@ -30,10 +29,15 @@ test("allows to navigate toolbar items through keyboard", () => {
   press.ArrowRight();
   press.ArrowRight();
   expect(text("Mars")).toHaveFocus();
+
+  press.ArrowLeft();
+  expect(text("Mountain")).toHaveFocus();
 });
 
 test("allows to open / close the popover through keyboard", () => {
-  const { getByText: text } = render(<ToolbarWithPopover />);
+  const { getByText: text, getByLabelText: labelText } = render(
+    <ToolbarWithPopover />
+  );
 
   press.Tab();
   expect(text("Beach")).toHaveFocus();
@@ -44,10 +48,10 @@ test("allows to open / close the popover through keyboard", () => {
   expect(text("Mars")).toHaveFocus();
 
   press.Enter();
-  expect(text(popoverText)).toBeVisible();
-  expect(text(popoverText)).toHaveFocus();
+  expect(labelText("Trip to Mars details")).toBeVisible();
+  expect(labelText("Trip to Mars details")).toHaveFocus();
 
   press.Escape();
-  expect(text(popoverText)).not.toBeVisible();
+  expect(labelText("Trip to Mars details")).not.toBeVisible();
   expect(text("Mars")).toHaveFocus();
 });

--- a/packages/reakit/src/Toolbar/__examples__/ToolbarWithPopover/__tests__/index-test.tsx
+++ b/packages/reakit/src/Toolbar/__examples__/ToolbarWithPopover/__tests__/index-test.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { render, press } from "reakit-test-utils";
+import ToolbarWithPopover from "..";
+
+const popoverText =
+  "This trip lasts three days and takes place in the otherworldly environment of Ares Station.";
+
+test("renders toolbar items with closed popover", () => {
+  const { getByText: text } = render(<ToolbarWithPopover />);
+
+  expect(text("Beach")).toBeVisible();
+  expect(text("Mountain")).toBeVisible();
+  expect(text("Mars")).toBeVisible();
+
+  expect(text(popoverText)).not.toBeVisible();
+});
+
+test("allows to navigate toolbar items through keyboard", () => {
+  const { getByText: text } = render(<ToolbarWithPopover />);
+
+  press.Tab();
+  expect(text("Beach")).toHaveFocus();
+
+  press.ArrowRight();
+  expect(text("Mountain")).toHaveFocus();
+
+  press.ArrowLeft();
+  expect(text("Beach")).toHaveFocus();
+
+  press.ArrowRight();
+  press.ArrowRight();
+  expect(text("Mars")).toHaveFocus();
+});
+
+test("allows to open / close the popover through keyboard", () => {
+  const { getByText: text } = render(<ToolbarWithPopover />);
+
+  press.Tab();
+  expect(text("Beach")).toHaveFocus();
+
+  press.ArrowRight();
+  press.ArrowRight();
+
+  expect(text("Mars")).toHaveFocus();
+
+  press.Enter();
+  expect(text(popoverText)).toBeVisible();
+  expect(text(popoverText)).toHaveFocus();
+
+  press.Escape();
+  expect(text(popoverText)).not.toBeVisible();
+  expect(text("Mars")).toHaveFocus();
+});

--- a/packages/reakit/src/Toolbar/__examples__/ToolbarWithPopover/index.tsx
+++ b/packages/reakit/src/Toolbar/__examples__/ToolbarWithPopover/index.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { useToolbarState, Toolbar, ToolbarItem } from "reakit/Toolbar";
+import {
+  usePopoverState,
+  Popover,
+  PopoverDisclosure,
+  PopoverArrow,
+  PopoverProps,
+} from "reakit/Popover";
+import { Button } from "reakit/Button";
+
+const PopoverItem = React.forwardRef<HTMLButtonElement, PopoverProps>(
+  (_, ref) => {
+    const popover = usePopoverState();
+    return (
+      <>
+        <PopoverDisclosure {...popover} ref={ref}>
+          Mars
+        </PopoverDisclosure>
+        <Popover {...popover} aria-label="Mars" tabIndex={0}>
+          <PopoverArrow {...popover} />
+          This trip lasts three days and takes place in the otherworldly
+          environment of Ares Station.
+        </Popover>
+      </>
+    );
+  }
+);
+
+export default function ToolbarWithPopover() {
+  const toolbar = useToolbarState();
+  return (
+    <Toolbar {...toolbar} aria-label="Vacations">
+      <ToolbarItem {...toolbar} as={Button}>
+        Beach
+      </ToolbarItem>
+      <ToolbarItem {...toolbar} as={Button}>
+        Mountain
+      </ToolbarItem>
+      <ToolbarItem {...toolbar} as={PopoverItem} />
+    </Toolbar>
+  );
+}

--- a/packages/reakit/src/Toolbar/__examples__/ToolbarWithPopover/index.tsx
+++ b/packages/reakit/src/Toolbar/__examples__/ToolbarWithPopover/index.tsx
@@ -9,23 +9,24 @@ import {
 } from "reakit/Popover";
 import { Button } from "reakit/Button";
 
-const PopoverItem = React.forwardRef<HTMLButtonElement, PopoverDisclosureProps>(
-  (props, ref) => {
-    const popover = usePopoverState();
-    return (
-      <>
-        <PopoverDisclosure {...popover} {...props} ref={ref}>
-          Mars
-        </PopoverDisclosure>
-        <Popover {...popover} aria-label="Trip to Mars details" tabIndex={0}>
-          <PopoverArrow {...popover} />
-          This trip lasts three days and takes place in the otherworldly
-          environment of Ares Station.
-        </Popover>
-      </>
-    );
-  }
-);
+const PopoverItem = React.forwardRef<
+  HTMLButtonElement,
+  Partial<PopoverDisclosureProps>
+>((props, ref) => {
+  const popover = usePopoverState();
+  return (
+    <>
+      <PopoverDisclosure {...popover} {...props} ref={ref}>
+        Mars
+      </PopoverDisclosure>
+      <Popover {...popover} aria-label="Trip to Mars details" tabIndex={0}>
+        <PopoverArrow {...popover} />
+        This trip lasts three days and takes place in the otherworldly
+        environment of Ares Station.
+      </Popover>
+    </>
+  );
+});
 
 export default function ToolbarWithPopover() {
   const toolbar = useToolbarState();

--- a/packages/reakit/src/Toolbar/__examples__/ToolbarWithPopover/index.tsx
+++ b/packages/reakit/src/Toolbar/__examples__/ToolbarWithPopover/index.tsx
@@ -5,19 +5,19 @@ import {
   Popover,
   PopoverDisclosure,
   PopoverArrow,
-  PopoverProps,
+  PopoverDisclosureProps,
 } from "reakit/Popover";
 import { Button } from "reakit/Button";
 
-const PopoverItem = React.forwardRef<HTMLButtonElement, PopoverProps>(
-  (_, ref) => {
+const PopoverItem = React.forwardRef<HTMLButtonElement, PopoverDisclosureProps>(
+  (props, ref) => {
     const popover = usePopoverState();
     return (
       <>
-        <PopoverDisclosure {...popover} ref={ref}>
+        <PopoverDisclosure {...popover} {...props} ref={ref}>
           Mars
         </PopoverDisclosure>
-        <Popover {...popover} aria-label="Mars" tabIndex={0}>
+        <Popover {...popover} aria-label="Trip to Mars details" tabIndex={0}>
           <PopoverArrow {...popover} />
           This trip lasts three days and takes place in the otherworldly
           environment of Ares Station.


### PR DESCRIPTION
## Summary 🍊

![toolbar-with-popover](https://user-images.githubusercontent.com/5938217/82653909-35940100-9c20-11ea-8114-c4c166777a17.gif)

Add an example for a **toolbar with a popover** and test it, following the effort of #626 

## Notes

<img width="74" alt="Screenshot 2020-05-22 at 11 40 22" src="https://user-images.githubusercontent.com/5938217/82654468-134eb300-9c21-11ea-9244-872f4a43765c.png">

I noticed the **popover arrow** is not centred within the disclosure and it's `border-bottom` being visible. I guess this is something we should fix? 💅🏻

<img width="100" alt="Screenshot 2020-05-22 at 11 40 13" src="https://user-images.githubusercontent.com/5938217/82654584-4133f780-9c21-11ea-8af2-5911cd0f31b2.png">

When focusing on an element _two outlines appear_, the browser one and a smaller one wrapping the text, is this intended? 