### PR TITLE
feat(website): add BLM banner

### DIFF
--- a/packages/website/src/components/CoreLayout.tsx
+++ b/packages/website/src/components/CoreLayout.tsx
@@ -31,13 +31,14 @@ type CoreLayoutProps = {
 };
 
 export default function CoreLayout(props: CoreLayoutProps) {
-  const scrolled = useScrolled();
+  const scrolled = useScrolled(50);
   const title =
     props.data && props.data.markdownRemark && props.data.markdownRemark.title;
   const isHome = props.location.pathname === "/";
   const background = usePalette("background");
   const foreground = usePalette("foreground");
   const codeBackground = useFade(foreground, 0.95);
+
   return (
     <>
       <Global
@@ -62,8 +63,8 @@ export default function CoreLayout(props: CoreLayoutProps) {
             background: ${background};
             width: 240px;
             z-index: 900;
-            top: var(--header-height, 60px);
-            left: 0;
+            top: 120px;
+            left: 10px;
             overflow: auto;
             -webkit-overflow-scrolling: touch;
             height: calc(100vh - var(--header-height, 60px));
@@ -88,30 +89,43 @@ export default function CoreLayout(props: CoreLayoutProps) {
             font-size: 0.875em;
             padding: 0.2em 0.4em;
           }
-          ${!title &&
-          !isHome &&
-          css`
-            margin: 72px auto;
-            max-width: 1200px;
-          `}
-          ${title &&
-          css`
-            margin: 72px 232px 72px 262px;
-            padding: 8px;
-            box-sizing: border-box;
+          ${
+            isHome &&
+            css`
+              @media (max-width: 768px) {
+                margin-top: 50px;
+              }
+            `
+          }
+          ${
+            !title &&
+            !isHome &&
+            css`
+              margin: 100px auto 72px;
+              max-width: 1200px;
+            `
+          }
+          ${
+            title &&
+            css`
+              margin: 100px 232px 72px 262px;
+              padding: 8px;
+              box-sizing: border-box;
 
-            @media (max-width: 1024px) {
-              margin-right: 0;
-            }
-            @media (max-width: 768px) {
-              margin-left: 0;
-            }
-            @media (min-width: 1440px) {
-              max-width: 946px;
-              margin-right: auto;
-              margin-left: auto;
-            }
-          `}
+              @media (max-width: 1024px) {
+                margin-right: 0;
+              }
+              @media (max-width: 768px) {
+                margin-left: 0;
+                margin-top: 120px;
+              }
+              @media (min-width: 1440px) {
+                max-width: 946px;
+                margin-right: auto;
+                margin-left: auto;
+              }
+            `
+          }
         `}
       >
         {props.children}
@@ -120,7 +134,7 @@ export default function CoreLayout(props: CoreLayoutProps) {
         <aside
           css={css`
             position: fixed;
-            top: var(--header-height, 60px);
+            top: 80px;
             right: 0;
             width: 210px;
             background: ${background};

--- a/packages/website/src/components/Header.tsx
+++ b/packages/website/src/components/Header.tsx
@@ -46,32 +46,62 @@ export default function Header({ transparent }: HeaderProps) {
   const boxShadowColor = useFade(foreground, 0.85);
   const dialog = useDialogState({ animated: true });
   const location = useLocation();
+  const headerZIndex = 910;
+  const narrowBreakpoint = 450;
 
   React.useEffect(dialog.hide, [location.pathname]);
 
   return (
     <>
+      <div
+        className={css`
+          background-color: black;
+          color: white;
+          position: fixed;
+          top: 0;
+          width: 100%;
+          padding: 17px 15px;
+          z-index: ${headerZIndex};
+          @media (min-width: 768px) {
+            padding: 15px 56px;
+          }
+        `}
+      >
+        Black Lives Matter.&nbsp;&nbsp;
+        <a
+          target="_blank"
+          rel="noreferrer"
+          href="https://support.eji.org/give/153413/#!/donation/checkout"
+          className={css`
+            text-decoration: none;
+            color: #61dafb;
+            @media (max-width: ${narrowBreakpoint}px) {
+              display: block;
+            }
+          `}
+        >
+          Support the Equal Justice Initiative.
+        </a>
+      </div>
       <header
         className={css`
           position: fixed;
-          top: -32px;
+          top: 48px;
           left: 0;
           width: 100%;
           z-index: 910;
-          height: calc(var(--header-height) + 32px);
+          height: calc(var(--header-height));
           box-sizing: border-box;
           background: ${background};
           display: flex;
           align-items: center;
-          padding: 32px 56px 0;
-          will-change: background, transform;
-          transition: transform 250ms ease-in-out;
+          padding: 0 56px;
+          will-change: background;
           ${!transparent && `box-shadow: 0 1px 2px ${boxShadowColor}`};
           ${transparent &&
           css`
             background: transparent;
             color: white;
-            transform: translateY(32px);
           `};
 
           & > *:not(:last-child) {
@@ -104,7 +134,6 @@ export default function Header({ transparent }: HeaderProps) {
           @media (max-width: 768px) {
             padding: 0 8px;
             transform: initial;
-            top: 0;
             height: var(--header-height);
             & > *:not(:last-child) {
               margin-right: 8px;
@@ -112,6 +141,10 @@ export default function Header({ transparent }: HeaderProps) {
             a {
               font-size: 1em !important;
             }
+          }
+
+          @media (max-width: ${narrowBreakpoint}px) {
+            top: 66px;
           }
         `}
       >


### PR DESCRIPTION
## Summary

Following the effort of other successful _open source_ projects within the front-end community
( [React](https://reactjs.org/), [Redux](https://redux.js.org/), [Webpack](https://webpack.js.org/), [Styled Components](https://styled-components.com/), etc... ) this pull-request adds a **BLM banner** on top of the website.

### Home 

<img width="1000" alt="Screenshot 2020-06-03 at 12 39 37" src="https://user-images.githubusercontent.com/5938217/83627600-76cccf00-a597-11ea-8e5f-b0b1aee5ee41.png">

### Docs

<img width="1000" alt="Screenshot 2020-06-03 at 12 40 11" src="https://user-images.githubusercontent.com/5938217/83627627-82b89100-a597-11ea-9040-14507c70c4d3.png">

### Mid viewports

<img width="500" alt="Screenshot 2020-06-03 at 12 39 50" src="https://user-images.githubusercontent.com/5938217/83627762-bd222e00-a597-11ea-8751-f62427cde0db.png">


### Small viewports

<img width="400" alt="Screenshot 2020-06-03 at 12 40 01" src="https://user-images.githubusercontent.com/5938217/83627635-851aeb00-a597-11ea-8be7-91871600163a.png">

