### PR TITLE
feat: Mark `Composite` as stable

### DIFF
--- a/packages/reakit-playground/src/__deps/reakit.ts
+++ b/packages/reakit-playground/src/__deps/reakit.ts
@@ -15,7 +15,7 @@ export default {
   "reakit/Composite/Composite": require("reakit/Composite/Composite"),
   "reakit/Composite/CompositeGroup": require("reakit/Composite/CompositeGroup"),
   "reakit/Composite/CompositeItem": require("reakit/Composite/CompositeItem"),
-  "reakit/Composite/CompositeItemWidget": require("reakit/Composite/CompositeItemWidget"),
+  "reakit/Composite/unstable_CompositeItemWidget": require("reakit/Composite/unstable_CompositeItemWidget"),
   "reakit/Composite/CompositeState": require("reakit/Composite/CompositeState"),
   "reakit/Dialog": require("reakit/Dialog"),
   "reakit/Dialog/Dialog": require("reakit/Dialog/Dialog"),

--- a/packages/reakit-playground/src/__deps/reakit.ts
+++ b/packages/reakit-playground/src/__deps/reakit.ts
@@ -15,7 +15,7 @@ export default {
   "reakit/Composite/Composite": require("reakit/Composite/Composite"),
   "reakit/Composite/CompositeGroup": require("reakit/Composite/CompositeGroup"),
   "reakit/Composite/CompositeItem": require("reakit/Composite/CompositeItem"),
-  "reakit/Composite/unstable_CompositeItemWidget": require("reakit/Composite/unstable_CompositeItemWidget"),
+  "reakit/Composite/CompositeItemWidget": require("reakit/Composite/CompositeItemWidget"),
   "reakit/Composite/CompositeState": require("reakit/Composite/CompositeState"),
   "reakit/Dialog": require("reakit/Dialog"),
   "reakit/Dialog/Dialog": require("reakit/Dialog/Dialog"),

--- a/packages/reakit-system-bootstrap/src/Composite.ts
+++ b/packages/reakit-system-bootstrap/src/Composite.ts
@@ -1,7 +1,7 @@
 import { css, cx } from "emotion";
 import {
-  unstable_CompositeItemHTMLProps as CompositeItemHTMLProps,
-  unstable_CompositeItemOptions as CompositeItemOptions,
+  CompositeItemHTMLProps,
+  CompositeItemOptions,
 } from "reakit/Composite/CompositeItem";
 import { useBoxProps as usePaletteBoxProps } from "reakit-system-palette/Box";
 import { BootstrapBoxOptions } from "./Box";

--- a/packages/reakit/src/Composite/Composite.ts
+++ b/packages/reakit/src/Composite/Composite.ts
@@ -12,10 +12,7 @@ import { isSelfTarget } from "reakit-utils/isSelfTarget";
 import { useLiveRef } from "reakit-utils/useLiveRef";
 import { useTabbable, TabbableOptions, TabbableHTMLProps } from "../Tabbable";
 import { useBox } from "../Box/Box";
-import {
-  unstable_CompositeStateReturn,
-  unstable_useCompositeState,
-} from "./CompositeState";
+import { CompositeStateReturn, useCompositeState } from "./CompositeState";
 import { Item } from "./__utils/types";
 import { groupItems } from "./__utils/groupItems";
 import { flatten } from "./__utils/flatten";
@@ -25,9 +22,9 @@ import { getCurrentId } from "./__utils/getCurrentId";
 import { getNextActiveElementOnBlur } from "./__utils/getNextActiveElementOnBlur";
 import { findEnabledItemById } from "./__utils/findEnabledItemById";
 
-export type unstable_CompositeOptions = TabbableOptions &
+export type CompositeOptions = TabbableOptions &
   Pick<
-    Partial<unstable_CompositeStateReturn>,
+    Partial<CompositeStateReturn>,
     | "baseId"
     | "unstable_virtual"
     | "currentId"
@@ -37,14 +34,13 @@ export type unstable_CompositeOptions = TabbableOptions &
     | "groups"
   > &
   Pick<
-    unstable_CompositeStateReturn,
+    CompositeStateReturn,
     "items" | "setCurrentId" | "first" | "last" | "move"
   >;
 
-export type unstable_CompositeHTMLProps = TabbableHTMLProps;
+export type CompositeHTMLProps = TabbableHTMLProps;
 
-export type unstable_CompositeProps = unstable_CompositeOptions &
-  unstable_CompositeHTMLProps;
+export type CompositeProps = CompositeOptions & CompositeHTMLProps;
 
 const validCompositeRoles = [
   "combobox",
@@ -121,13 +117,10 @@ function isItem(items: Item[], element?: Element | EventTarget | null) {
   return items?.some((item) => !!element && item.ref.current === element);
 }
 
-export const unstable_useComposite = createHook<
-  unstable_CompositeOptions,
-  unstable_CompositeHTMLProps
->({
+export const useComposite = createHook<CompositeOptions, CompositeHTMLProps>({
   name: "Composite",
   compose: [useTabbable],
-  useState: unstable_useCompositeState,
+  useState: useCompositeState,
 
   useOptions(options) {
     return { ...options, currentId: getCurrentId(options) };
@@ -357,9 +350,9 @@ export const unstable_useComposite = createHook<
   },
 });
 
-export const unstable_Composite = createComponent({
+export const Composite = createComponent({
   as: "div",
-  useHook: unstable_useComposite,
+  useHook: useComposite,
   useCreateElement: (type, props, children) => {
     useWarning(
       !props.role || validCompositeRoles.indexOf(props.role) === -1,

--- a/packages/reakit/src/Composite/CompositeGroup.ts
+++ b/packages/reakit/src/Composite/CompositeGroup.ts
@@ -9,33 +9,26 @@ import {
   unstable_IdOptions,
   unstable_IdHTMLProps,
 } from "../Id/Id";
-import {
-  unstable_CompositeStateReturn,
-  unstable_useCompositeState,
-} from "./CompositeState";
+import { CompositeStateReturn, useCompositeState } from "./CompositeState";
 import { findEnabledItemById } from "./__utils/findEnabledItemById";
 
-export type unstable_CompositeGroupOptions = GroupOptions &
+export type CompositeGroupOptions = GroupOptions &
   unstable_IdOptions &
-  Pick<unstable_CompositeStateReturn, "registerGroup" | "unregisterGroup"> &
-  Pick<
-    Partial<unstable_CompositeStateReturn>,
-    "currentId" | "unstable_moves" | "items"
-  >;
+  Pick<CompositeStateReturn, "registerGroup" | "unregisterGroup"> &
+  Pick<Partial<CompositeStateReturn>, "currentId" | "unstable_moves" | "items">;
 
-export type unstable_CompositeGroupHTMLProps = GroupHTMLProps &
-  unstable_IdHTMLProps;
+export type CompositeGroupHTMLProps = GroupHTMLProps & unstable_IdHTMLProps;
 
-export type unstable_CompositeGroupProps = unstable_CompositeGroupOptions &
-  unstable_CompositeGroupHTMLProps;
+export type CompositeGroupProps = CompositeGroupOptions &
+  CompositeGroupHTMLProps;
 
-export const unstable_useCompositeGroup = createHook<
-  unstable_CompositeGroupOptions,
-  unstable_CompositeGroupHTMLProps
+export const useCompositeGroup = createHook<
+  CompositeGroupOptions,
+  CompositeGroupHTMLProps
 >({
   name: "CompositeGroup",
   compose: [useGroup, unstable_useId],
-  useState: unstable_useCompositeState,
+  useState: useCompositeState,
 
   propsAreEqual(prev, next) {
     if (!next.id || prev.id !== next.id) {
@@ -80,7 +73,7 @@ export const unstable_useCompositeGroup = createHook<
   },
 });
 
-export const unstable_CompositeGroup = createComponent({
+export const CompositeGroup = createComponent({
   as: "div",
-  useHook: unstable_useCompositeGroup,
+  useHook: useCompositeGroup,
 });

--- a/packages/reakit/src/Composite/CompositeItem.ts
+++ b/packages/reakit/src/Composite/CompositeItem.ts
@@ -189,7 +189,7 @@ export const useCompositeItem = createHook<
         // When using aria-activedescendant, we want to make sure that the
         // composite container receives focus, not the composite item.
         // But we don't want to do this if the target is another focusable
-        // element inside the composite item, such as unstable_CompositeItemWidget.
+        // element inside the composite item, such as CompositeItemWidget.
         if (options.unstable_virtual && options.baseId && isSelfTarget(event)) {
           const { target } = event;
           const composite = getDocument(target).getElementById(options.baseId);
@@ -252,7 +252,7 @@ export const useCompositeItem = createHook<
           onKeyDown: onCharacterKeyDown,
           stopPropagation: true,
           // We don't want to listen to focusable elements inside the composite
-          // item, such as a unstable_CompositeItemWidget.
+          // item, such as a CompositeItemWidget.
           shouldKeyDown: isSelfTarget,
           keyMap: () => {
             // `options.orientation` can also be undefined, which means that

--- a/packages/reakit/src/Composite/CompositeItem.ts
+++ b/packages/reakit/src/Composite/CompositeItem.ts
@@ -21,18 +21,15 @@ import {
   unstable_IdOptions,
   unstable_IdHTMLProps,
 } from "../Id/Id";
-import {
-  unstable_CompositeStateReturn,
-  unstable_useCompositeState,
-} from "./CompositeState";
+import { CompositeStateReturn, useCompositeState } from "./CompositeState";
 import { setTextFieldValue } from "./__utils/setTextFieldValue";
 import { getCurrentId } from "./__utils/getCurrentId";
 import { Item } from "./__utils/types";
 
-export type unstable_CompositeItemOptions = ClickableOptions &
+export type CompositeItemOptions = ClickableOptions &
   unstable_IdOptions &
   Pick<
-    Partial<unstable_CompositeStateReturn>,
+    Partial<CompositeStateReturn>,
     | "unstable_virtual"
     | "baseId"
     | "orientation"
@@ -40,7 +37,7 @@ export type unstable_CompositeItemOptions = ClickableOptions &
     | "unstable_hasActiveWidget"
   > &
   Pick<
-    unstable_CompositeStateReturn,
+    CompositeStateReturn,
     | "items"
     | "currentId"
     | "registerItem"
@@ -54,17 +51,15 @@ export type unstable_CompositeItemOptions = ClickableOptions &
     | "last"
   >;
 
-export type unstable_CompositeItemHTMLProps = ClickableHTMLProps &
-  unstable_IdHTMLProps;
+export type CompositeItemHTMLProps = ClickableHTMLProps & unstable_IdHTMLProps;
 
-export type unstable_CompositeItemProps = unstable_CompositeItemOptions &
-  unstable_CompositeItemHTMLProps;
+export type CompositeItemProps = CompositeItemOptions & CompositeItemHTMLProps;
 
 function getWidget(itemElement: Element) {
   return itemElement.querySelector<HTMLElement>("[data-composite-item-widget]");
 }
 
-function useItem(options: unstable_CompositeItemOptions) {
+function useItem(options: CompositeItemOptions) {
   return React.useMemo(
     () => options.items?.find((item) => options.id && item.id === options.id),
     [options.items, options.id]
@@ -81,13 +76,13 @@ function targetIsAnotherItem(event: React.SyntheticEvent, items: Item[]) {
   return false;
 }
 
-export const unstable_useCompositeItem = createHook<
-  unstable_CompositeItemOptions,
-  unstable_CompositeItemHTMLProps
+export const useCompositeItem = createHook<
+  CompositeItemOptions,
+  CompositeItemHTMLProps
 >({
   name: "CompositeItem",
   compose: [useClickable, unstable_useId],
-  useState: unstable_useCompositeState,
+  useState: useCompositeState,
 
   propsAreEqual(prev, next) {
     if (!next.id || prev.id !== next.id) {
@@ -194,7 +189,7 @@ export const unstable_useCompositeItem = createHook<
         // When using aria-activedescendant, we want to make sure that the
         // composite container receives focus, not the composite item.
         // But we don't want to do this if the target is another focusable
-        // element inside the composite item, such as CompositeItemWidget.
+        // element inside the composite item, such as unstable_CompositeItemWidget.
         if (options.unstable_virtual && options.baseId && isSelfTarget(event)) {
           const { target } = event;
           const composite = getDocument(target).getElementById(options.baseId);
@@ -257,7 +252,7 @@ export const unstable_useCompositeItem = createHook<
           onKeyDown: onCharacterKeyDown,
           stopPropagation: true,
           // We don't want to listen to focusable elements inside the composite
-          // item, such as a CompositeItemWidget.
+          // item, such as a unstable_CompositeItemWidget.
           shouldKeyDown: isSelfTarget,
           keyMap: () => {
             // `options.orientation` can also be undefined, which means that
@@ -356,8 +351,8 @@ export const unstable_useCompositeItem = createHook<
   },
 });
 
-export const unstable_CompositeItem = createComponent({
+export const CompositeItem = createComponent({
   as: "button",
   memo: true,
-  useHook: unstable_useCompositeItem,
+  useHook: useCompositeItem,
 });

--- a/packages/reakit/src/Composite/CompositeItemWidget.ts
+++ b/packages/reakit/src/Composite/CompositeItemWidget.ts
@@ -6,16 +6,13 @@ import { getDocument } from "reakit-utils/getDocument";
 import { isSelfTarget } from "reakit-utils/isSelfTarget";
 import { useLiveRef } from "reakit-utils/useLiveRef";
 import { useBox, BoxOptions, BoxHTMLProps } from "../Box/Box";
-import {
-  unstable_CompositeStateReturn,
-  unstable_useCompositeState,
-} from "./CompositeState";
+import { CompositeStateReturn, useCompositeState } from "./CompositeState";
 import { setTextFieldValue } from "./__utils/setTextFieldValue";
 
 export type unstable_CompositeItemWidgetOptions = BoxOptions &
-  Pick<Partial<unstable_CompositeStateReturn>, "wrap"> &
+  Pick<Partial<CompositeStateReturn>, "wrap"> &
   Pick<
-    unstable_CompositeStateReturn,
+    CompositeStateReturn,
     "unstable_hasActiveWidget" | "unstable_setHasActiveWidget" | "currentId"
   >;
 
@@ -40,7 +37,7 @@ export const unstable_useCompositeItemWidget = createHook<
 >({
   name: "CompositeItemWidget",
   compose: useBox,
-  useState: unstable_useCompositeState,
+  useState: useCompositeState,
 
   useProps(
     options,

--- a/packages/reakit/src/Composite/CompositeState.ts
+++ b/packages/reakit/src/Composite/CompositeState.ts
@@ -27,7 +27,7 @@ import { getOppositeOrientation } from "./__utils/getOppositeOrientation";
 import { addItemAtIndex } from "./__utils/addItemAtIndex";
 import { sortBasedOnDOMPosition } from "./__utils/sortBasedOnDOMPosition";
 
-export type unstable_CompositeState = unstable_IdState & {
+export type CompositeState = unstable_IdState & {
   /**
    * If enabled, the composite element will act as an
    * [aria-activedescendant](https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_focus_activedescendant)
@@ -121,7 +121,7 @@ export type unstable_CompositeState = unstable_IdState & {
   unstable_hasActiveWidget: boolean;
 };
 
-export type unstable_CompositeActions = unstable_IdActions & {
+export type CompositeActions = unstable_IdActions & {
   /**
    * Registers a composite item.
    */
@@ -175,36 +175,32 @@ export type unstable_CompositeActions = unstable_IdActions & {
    * Sets `virtual`.
    */
   unstable_setVirtual: React.Dispatch<
-    React.SetStateAction<unstable_CompositeState["unstable_virtual"]>
+    React.SetStateAction<CompositeState["unstable_virtual"]>
   >;
   /**
    * Sets `rtl`.
    */
-  setRTL: React.Dispatch<React.SetStateAction<unstable_CompositeState["rtl"]>>;
+  setRTL: React.Dispatch<React.SetStateAction<CompositeState["rtl"]>>;
   /**
    * Sets `orientation`.
    */
   setOrientation: React.Dispatch<
-    React.SetStateAction<unstable_CompositeState["orientation"]>
+    React.SetStateAction<CompositeState["orientation"]>
   >;
   /**
    * Sets `currentId`.
    */
   setCurrentId: React.Dispatch<
-    React.SetStateAction<unstable_CompositeState["currentId"]>
+    React.SetStateAction<CompositeState["currentId"]>
   >;
   /**
    * Sets `loop`.
    */
-  setLoop: React.Dispatch<
-    React.SetStateAction<unstable_CompositeState["loop"]>
-  >;
+  setLoop: React.Dispatch<React.SetStateAction<CompositeState["loop"]>>;
   /**
    * Sets `wrap`.
    */
-  setWrap: React.Dispatch<
-    React.SetStateAction<unstable_CompositeState["wrap"]>
-  >;
+  setWrap: React.Dispatch<React.SetStateAction<CompositeState["wrap"]>>;
   /**
    * Resets to initial state.
    */
@@ -214,21 +210,21 @@ export type unstable_CompositeActions = unstable_IdActions & {
    * @private
    */
   unstable_setHasActiveWidget: React.Dispatch<
-    React.SetStateAction<unstable_CompositeState["unstable_hasActiveWidget"]>
+    React.SetStateAction<CompositeState["unstable_hasActiveWidget"]>
   >;
 };
 
-export type unstable_CompositeInitialState = unstable_IdInitialState &
+export type CompositeInitialState = unstable_IdInitialState &
   Partial<
     Pick<
-      unstable_CompositeState,
+      CompositeState,
       "unstable_virtual" | "rtl" | "orientation" | "currentId" | "loop" | "wrap"
     >
   >;
 
-export type unstable_CompositeStateReturn = unstable_IdStateReturn &
-  unstable_CompositeState &
-  unstable_CompositeActions;
+export type CompositeStateReturn = unstable_IdStateReturn &
+  CompositeState &
+  CompositeActions;
 
 type CompositeReducerAction =
   | { type: "registerItem"; item: Item }
@@ -245,45 +241,41 @@ type CompositeReducerAction =
   | { type: "sort" }
   | {
       type: "setVirtual";
-      virtual: React.SetStateAction<
-        unstable_CompositeState["unstable_virtual"]
-      >;
+      virtual: React.SetStateAction<CompositeState["unstable_virtual"]>;
     }
   | {
       type: "setRTL";
-      rtl: React.SetStateAction<unstable_CompositeState["rtl"]>;
+      rtl: React.SetStateAction<CompositeState["rtl"]>;
     }
   | {
       type: "setOrientation";
-      orientation?: React.SetStateAction<
-        unstable_CompositeState["orientation"]
-      >;
+      orientation?: React.SetStateAction<CompositeState["orientation"]>;
     }
   | {
       type: "setCurrentId";
-      currentId?: React.SetStateAction<unstable_CompositeState["currentId"]>;
+      currentId?: React.SetStateAction<CompositeState["currentId"]>;
     }
   | {
       type: "setLoop";
-      loop: React.SetStateAction<unstable_CompositeState["loop"]>;
+      loop: React.SetStateAction<CompositeState["loop"]>;
     }
   | {
       type: "setWrap";
-      wrap: React.SetStateAction<unstable_CompositeState["wrap"]>;
+      wrap: React.SetStateAction<CompositeState["wrap"]>;
     }
   | { type: "reset" };
 
 type CompositeReducerState = Omit<
-  unstable_CompositeState,
+  CompositeState,
   "unstable_hasActiveWidget" | keyof unstable_IdState
 > & {
   pastIds: string[];
-  initialVirtual: unstable_CompositeState["unstable_virtual"];
-  initialRTL: unstable_CompositeState["rtl"];
-  initialOrientation: unstable_CompositeState["orientation"];
-  initialCurrentId: unstable_CompositeState["currentId"];
-  initialLoop: unstable_CompositeState["loop"];
-  initialWrap: unstable_CompositeState["wrap"];
+  initialVirtual: CompositeState["unstable_virtual"];
+  initialRTL: CompositeState["rtl"];
+  initialOrientation: CompositeState["orientation"];
+  initialCurrentId: CompositeState["currentId"];
+  initialLoop: CompositeState["loop"];
+  initialWrap: CompositeState["wrap"];
   hasSetCurrentId?: boolean;
 };
 
@@ -593,9 +585,9 @@ function useAction<T extends (...args: any[]) => any>(fn: T) {
   return React.useCallback(fn, []);
 }
 
-export function unstable_useCompositeState(
-  initialState: SealedInitialState<unstable_CompositeInitialState> = {}
-): unstable_CompositeStateReturn {
+export function useCompositeState(
+  initialState: SealedInitialState<CompositeInitialState> = {}
+): CompositeStateReturn {
   const {
     unstable_virtual: virtual = false,
     rtl = false,
@@ -678,7 +670,7 @@ export function unstable_useCompositeState(
   };
 }
 
-const keys: Array<keyof unstable_CompositeStateReturn> = [
+const keys: Array<keyof CompositeStateReturn> = [
   ...unstable_useIdState.__keys,
   "unstable_virtual",
   "rtl",
@@ -712,4 +704,4 @@ const keys: Array<keyof unstable_CompositeStateReturn> = [
   "unstable_setHasActiveWidget",
 ];
 
-unstable_useCompositeState.__keys = keys;
+useCompositeState.__keys = keys;

--- a/packages/reakit/src/Composite/README.md
+++ b/packages/reakit/src/Composite/README.md
@@ -1,13 +1,8 @@
 ---
 path: /docs/composite/
-experimental: true
 ---
 
 # Composite
-
-<blockquote experimental="true">
-  <strong>This is experimental</strong> and may have breaking changes in minor or patch version updates. Issues for this module will have lower priority. Even so, if you use it, feel free to <a href="https://github.com/reakit/reakit/issues/new/choose" target="_blank">give us feedback</a>.
-</blockquote>
 
 `Composite` is a component that may contain navigable items represented by `CompositeItem`. It's inspired by the [WAI-ARIA Composite Role](https://www.w3.org/TR/wai-aria-1.1/#composite) and implements all the [keyboard navigation mechanisms](https://www.w3.org/TR/wai-aria-practices/#kbd_general_within) to ensure that there's only one tab stop for the whole `Composite` element. This means that it can behave as a [roving tabindex](https://www.w3.org/TR/wai-aria-practices/#kbd_roving_tabindex) or [aria-activedescendant](https://www.w3.org/TR/wai-aria-practices/#kbd_focus_activedescendant) container.
 
@@ -31,11 +26,7 @@ In the most basic usage, `Composite` will work as a [roving tabindex](https://ww
 
 ```jsx
 import React from "react";
-import {
-  unstable_useCompositeState as useCompositeState,
-  unstable_Composite as Composite,
-  unstable_CompositeItem as CompositeItem,
-} from "reakit/Composite";
+import { useCompositeState, Composite, CompositeItem } from "reakit/Composite";
 
 function Example() {
   const composite = useCompositeState();
@@ -63,11 +54,7 @@ You can still attach event handlers to `CompositeItem` just like it were using t
 
 ```jsx
 import React from "react";
-import {
-  unstable_useCompositeState as useCompositeState,
-  unstable_Composite as Composite,
-  unstable_CompositeItem as CompositeItem,
-} from "reakit/Composite";
+import { useCompositeState, Composite, CompositeItem } from "reakit/Composite";
 
 function Example() {
   const composite = useCompositeState({ unstable_virtual: true });
@@ -90,10 +77,10 @@ You can build a two-dimensional `Composite` by using `CompositeGroup`.
 ```jsx
 import React from "react";
 import {
-  unstable_useCompositeState as useCompositeState,
-  unstable_Composite as Composite,
-  unstable_CompositeGroup as CompositeGroup,
-  unstable_CompositeItem as CompositeItem,
+  useCompositeState,
+  Composite,
+  CompositeGroup,
+  CompositeItem,
 } from "reakit/Composite";
 
 function Grid(props) {
@@ -153,11 +140,7 @@ In the example below, focus on any item and keep <kbd>→</kbd> pressed to see i
 
 ```jsx unstyled
 import React from "react";
-import {
-  unstable_useCompositeState as useCompositeState,
-  unstable_Composite as Composite,
-  unstable_CompositeItem as CompositeItem,
-} from "reakit/Composite";
+import { useCompositeState, Composite, CompositeItem } from "reakit/Composite";
 
 const items = Array.from({ length: 88 }).map((_, i) => `item-${i}`);
 
@@ -215,9 +198,9 @@ Learn more in [Accessibility](/docs/accessibility/).
 
 ## Composition
 
-- `Composite` uses [Tabbable](/docs/tabbable/) (when `focusStrategy` is set to `aria-activedescendant`) and [IdGroup](/docs/id/), and is used by [TabList](/docs/tab/), [RadioGroup](/docs/radio/) and [Toolbar](/docs/toolbar/).
+- `Composite` uses [Tabbable](/docs/tabbable/), and is used by [TabList](/docs/tab/), [RadioGroup](/docs/radio/), [Menu](/docs/menu/) and [Toolbar](/docs/toolbar/).
 - `CompositeGroup` uses [Group](/docs/group/) and [Id](/docs/id/).
-- `CompositeItem` uses [Id](/docs/id/) and [Clickable](/docs/clickable/), and is used by [Tab](/docs/tab/), [Radio](/docs/radio/) and [ToolbarItem](/docs/toolbar/).
+- `CompositeItem` uses [Id](/docs/id/) and [Clickable](/docs/clickable/), and is used by [Tab](/docs/tab/), [Radio](/docs/radio/), [MenuItem](/docs/menu/) and [ToolbarItem](/docs/toolbar/).
 
 Learn more in [Composition](/docs/composition/#props-hooks).
 
@@ -589,7 +572,7 @@ and `groupId` if any. This state is automatically updated when
 
 </details>
 
-### `CompositeItemWidget`
+### `unstable_CompositeItemWidget`
 
 <details><summary>2 state props</summary>
 

--- a/packages/reakit/src/Composite/README.md
+++ b/packages/reakit/src/Composite/README.md
@@ -572,7 +572,7 @@ and `groupId` if any. This state is automatically updated when
 
 </details>
 
-### `unstable_CompositeItemWidget`
+### `CompositeItemWidget`
 
 <details><summary>2 state props</summary>
 

--- a/packages/reakit/src/Composite/__examples__/CompositeWithTooltip/index.tsx
+++ b/packages/reakit/src/Composite/__examples__/CompositeWithTooltip/index.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { useTooltipState, Tooltip, TooltipReference } from "reakit/Tooltip";
 import {
-  unstable_useCompositeState as useCompositeState,
-  unstable_Composite as Composite,
-  unstable_CompositeItem as CompositeItem,
-  unstable_CompositeItemProps as CompositeItemProps,
+  useCompositeState,
+  Composite,
+  CompositeItem,
+  CompositeItemProps,
 } from "reakit/Composite";
 
 function CompositeItemWithTooltip({ children, ...props }: CompositeItemProps) {

--- a/packages/reakit/src/Composite/__examples__/DynamicComposite/index.tsx
+++ b/packages/reakit/src/Composite/__examples__/DynamicComposite/index.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { VisuallyHidden } from "reakit/VisuallyHidden";
 import {
-  unstable_useCompositeState as useCompositeState,
-  unstable_Composite as Composite,
-  unstable_CompositeGroup as CompositeGroup,
-  unstable_CompositeItem as CompositeItem,
+  useCompositeState,
+  Composite,
+  CompositeGroup,
+  CompositeItem,
 } from "reakit/Composite";
 
 function move<T>(item: T, times: number) {

--- a/packages/reakit/src/Composite/__examples__/NestedCompositeItems/index.tsx
+++ b/packages/reakit/src/Composite/__examples__/NestedCompositeItems/index.tsx
@@ -1,9 +1,5 @@
 import * as React from "react";
-import {
-  unstable_useCompositeState as useCompositeState,
-  unstable_Composite as Composite,
-  unstable_CompositeItem as CompositeItem,
-} from "reakit/Composite";
+import { useCompositeState, Composite, CompositeItem } from "reakit/Composite";
 
 export default function NestedCompositeItems() {
   const composite = useCompositeState({ loop: true });

--- a/packages/reakit/src/Composite/__examples__/VirtualCompositeWithTooltip/index.tsx
+++ b/packages/reakit/src/Composite/__examples__/VirtualCompositeWithTooltip/index.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { useTooltipState, Tooltip, TooltipReference } from "reakit/Tooltip";
 import {
-  unstable_useCompositeState as useCompositeState,
-  unstable_Composite as Composite,
-  unstable_CompositeItem as CompositeItem,
-  unstable_CompositeItemProps as CompositeItemProps,
+  useCompositeState,
+  Composite,
+  CompositeItem,
+  CompositeItemProps,
 } from "reakit/Composite";
 
 function CompositeItemWithTooltip(props: CompositeItemProps) {

--- a/packages/reakit/src/Composite/__examples__/VirtualNestedCompositeItems/index.tsx
+++ b/packages/reakit/src/Composite/__examples__/VirtualNestedCompositeItems/index.tsx
@@ -1,9 +1,5 @@
 import * as React from "react";
-import {
-  unstable_useCompositeState as useCompositeState,
-  unstable_Composite as Composite,
-  unstable_CompositeItem as CompositeItem,
-} from "reakit/Composite";
+import { useCompositeState, Composite, CompositeItem } from "reakit/Composite";
 
 export default function VirtualNestedCompositeItems() {
   const composite = useCompositeState({ loop: true, unstable_virtual: true });

--- a/packages/reakit/src/Composite/__tests__/Composite-test.tsx
+++ b/packages/reakit/src/Composite/__tests__/Composite-test.tsx
@@ -1,11 +1,8 @@
 import * as React from "react";
 import { render, press } from "reakit-test-utils";
-import {
-  unstable_Composite as Composite,
-  unstable_CompositeProps,
-} from "../Composite";
+import { Composite, CompositeProps } from "../Composite";
 
-const props: unstable_CompositeProps = {
+const props: CompositeProps = {
   id: "composite",
   items: [
     { id: "1", ref: { current: null } },

--- a/packages/reakit/src/Composite/__tests__/CompositeGroup-test.tsx
+++ b/packages/reakit/src/Composite/__tests__/CompositeGroup-test.tsx
@@ -1,9 +1,6 @@
 import * as React from "react";
 import { render } from "reakit-test-utils";
-import {
-  unstable_CompositeGroupProps as CompositeGroupProps,
-  unstable_CompositeGroup as CompositeGroup,
-} from "../CompositeGroup";
+import { CompositeGroupProps, CompositeGroup } from "../CompositeGroup";
 
 const props: CompositeGroupProps = {
   registerGroup: jest.fn(),

--- a/packages/reakit/src/Composite/__tests__/CompositeItem-test.tsx
+++ b/packages/reakit/src/Composite/__tests__/CompositeItem-test.tsx
@@ -1,9 +1,6 @@
 import * as React from "react";
 import { render, focus, press, click } from "reakit-test-utils";
-import {
-  unstable_CompositeItemProps as CompositeItemProps,
-  unstable_CompositeItem as CompositeItem,
-} from "../CompositeItem";
+import { CompositeItemProps, CompositeItem } from "../CompositeItem";
 
 const props: CompositeItemProps = {
   items: [

--- a/packages/reakit/src/Composite/__tests__/CompositeItemWidget-test.tsx
+++ b/packages/reakit/src/Composite/__tests__/CompositeItemWidget-test.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { render, focus, press, blur } from "reakit-test-utils";
 import {
-  unstable_CompositeItemWidgetProps,
+  unstable_CompositeItemWidgetProps as CompositeItemWidgetProps,
   unstable_CompositeItemWidget as CompositeItemWidget,
 } from "../CompositeItemWidget";
 
-const props: unstable_CompositeItemWidgetProps = {
+const props: CompositeItemWidgetProps = {
   unstable_hasActiveWidget: false,
   unstable_setHasActiveWidget: jest.fn(),
   currentId: "a",

--- a/packages/reakit/src/Composite/__tests__/CompositeState-test.ts
+++ b/packages/reakit/src/Composite/__tests__/CompositeState-test.ts
@@ -1,10 +1,7 @@
 import * as React from "react";
 import { renderHook, act } from "reakit-test-utils/hooks";
 import { jestSerializerStripFunctions } from "reakit-test-utils/jestSerializerStripFunctions";
-import {
-  unstable_useCompositeState as useCompositeState,
-  unstable_CompositeInitialState as CompositeInitialState,
-} from "../CompositeState";
+import { useCompositeState, CompositeInitialState } from "../CompositeState";
 
 expect.addSnapshotSerializer(jestSerializerStripFunctions);
 

--- a/packages/reakit/src/Composite/__tests__/index-test.tsx
+++ b/packages/reakit/src/Composite/__tests__/index-test.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { render, focus, press, click, type, wait } from "reakit-test-utils";
 import {
-  unstable_useCompositeState as useCompositeState,
-  unstable_Composite as Composite,
-  unstable_CompositeGroup as CompositeGroup,
-  unstable_CompositeItem as CompositeItem,
+  useCompositeState,
+  Composite,
+  CompositeGroup,
+  CompositeItem,
   unstable_CompositeItemWidget as CompositeItemWidget,
 } from "..";
 

--- a/packages/reakit/src/Composite/__utils/getCurrentId.ts
+++ b/packages/reakit/src/Composite/__utils/getCurrentId.ts
@@ -1,9 +1,9 @@
-import { unstable_CompositeState } from "../CompositeState";
+import { CompositeState } from "../CompositeState";
 import { findFirstEnabledItem } from "./findFirstEnabledItem";
 
 export function getCurrentId(
-  options: Pick<unstable_CompositeState, "currentId" | "items">,
-  passedId?: unstable_CompositeState["currentId"]
+  options: Pick<CompositeState, "currentId" | "items">,
+  passedId?: CompositeState["currentId"]
 ) {
   if (passedId || passedId === null) {
     return passedId;

--- a/packages/reakit/src/Dialog/__examples__/DialogWithCompositeWithTooltip/index.tsx
+++ b/packages/reakit/src/Dialog/__examples__/DialogWithCompositeWithTooltip/index.tsx
@@ -2,10 +2,10 @@ import * as React from "react";
 import { useTooltipState, Tooltip, TooltipReference } from "reakit/Tooltip";
 import { useDialogState, Dialog, DialogDisclosure } from "reakit/Dialog";
 import {
-  unstable_useCompositeState as useCompositeState,
-  unstable_Composite as Composite,
-  unstable_CompositeItem as CompositeItem,
-  unstable_CompositeItemProps as CompositeItemProps,
+  useCompositeState,
+  Composite,
+  CompositeItem,
+  CompositeItemProps,
 } from "reakit/Composite";
 
 function CompositeItemWithTooltip({ children, ...props }: CompositeItemProps) {

--- a/packages/reakit/src/Dialog/__examples__/DialogWithVirtualCompositeWithTooltip/index.tsx
+++ b/packages/reakit/src/Dialog/__examples__/DialogWithVirtualCompositeWithTooltip/index.tsx
@@ -2,10 +2,10 @@ import * as React from "react";
 import { useTooltipState, Tooltip, TooltipReference } from "reakit/Tooltip";
 import { useDialogState, Dialog, DialogDisclosure } from "reakit/Dialog";
 import {
-  unstable_useCompositeState as useCompositeState,
-  unstable_Composite as Composite,
-  unstable_CompositeItem as CompositeItem,
-  unstable_CompositeItemProps as CompositeItemProps,
+  useCompositeState,
+  Composite,
+  CompositeItem,
+  CompositeItemProps,
 } from "reakit/Composite";
 
 function CompositeItemWithTooltip({ children, ...props }: CompositeItemProps) {

--- a/packages/reakit/src/Form/FormRadioGroup.tsx
+++ b/packages/reakit/src/Form/FormRadioGroup.tsx
@@ -3,8 +3,8 @@ import { createComponent } from "reakit-system/createComponent";
 import { As, PropsWithAs } from "reakit-utils/types";
 import { createHook } from "reakit-system/createHook";
 import {
-  unstable_CompositeStateReturn as CompositeStateReturn,
-  unstable_useCompositeState as useCompositeState,
+  CompositeStateReturn,
+  useCompositeState,
 } from "../Composite/CompositeState";
 import {
   unstable_FormGroupOptions,

--- a/packages/reakit/src/Menu/MenuBar.tsx
+++ b/packages/reakit/src/Menu/MenuBar.tsx
@@ -5,9 +5,9 @@ import { useCreateElement } from "reakit-system/useCreateElement";
 import { createHook } from "reakit-system/createHook";
 import { useForkRef } from "reakit-utils/useForkRef";
 import {
-  unstable_CompositeOptions as CompositeOptions,
-  unstable_CompositeHTMLProps as CompositeHTMLProps,
-  unstable_useComposite as useComposite,
+  CompositeOptions,
+  CompositeHTMLProps,
+  useComposite,
 } from "../Composite/Composite";
 import { useShortcuts } from "./__utils/useShortcuts";
 import { useMenuContext } from "./__utils/MenuContext";

--- a/packages/reakit/src/Menu/MenuBarState.ts
+++ b/packages/reakit/src/Menu/MenuBarState.ts
@@ -4,10 +4,10 @@ import {
   useSealedState,
 } from "reakit-utils/useSealedState";
 import {
-  unstable_CompositeState as CompositeState,
-  unstable_CompositeActions as CompositeActions,
-  unstable_CompositeInitialState as CompositeInitialState,
-  unstable_useCompositeState as useCompositeState,
+  CompositeState,
+  CompositeActions,
+  CompositeInitialState,
+  useCompositeState,
 } from "../Composite";
 
 export type MenuBarState = CompositeState & {

--- a/packages/reakit/src/Menu/MenuItem.tsx
+++ b/packages/reakit/src/Menu/MenuItem.tsx
@@ -5,9 +5,9 @@ import { contains } from "reakit-utils/contains";
 import { useLiveRef } from "reakit-utils/useLiveRef";
 import { hasFocusWithin } from "reakit-utils/hasFocusWithin";
 import {
-  unstable_CompositeItemOptions as CompositeItemOptions,
-  unstable_CompositeItemHTMLProps as CompositeItemHTMLProps,
-  unstable_useCompositeItem as useCompositeItem,
+  CompositeItemOptions,
+  CompositeItemHTMLProps,
+  useCompositeItem,
 } from "../Composite/CompositeItem";
 import { useMenuState, MenuStateReturn } from "./MenuState";
 import { MenuContext } from "./__utils/MenuContext";

--- a/packages/reakit/src/Radio/Radio.ts
+++ b/packages/reakit/src/Radio/Radio.ts
@@ -6,9 +6,9 @@ import { useForkRef } from "reakit-utils/useForkRef";
 import { createEvent } from "reakit-utils/createEvent";
 import { warning } from "reakit-warning/warning";
 import {
-  unstable_CompositeItemOptions as CompositeItemOptions,
-  unstable_CompositeItemHTMLProps as CompositeItemHTMLProps,
-  unstable_useCompositeItem as useCompositeItem,
+  CompositeItemOptions,
+  CompositeItemHTMLProps,
+  useCompositeItem,
 } from "../Composite/CompositeItem";
 import { useRadioState, RadioStateReturn } from "./RadioState";
 

--- a/packages/reakit/src/Radio/RadioGroup.tsx
+++ b/packages/reakit/src/Radio/RadioGroup.tsx
@@ -4,22 +4,22 @@ import { useCreateElement } from "reakit-system/useCreateElement";
 import { createHook } from "reakit-system/createHook";
 import { useWarning } from "reakit-warning";
 import {
-  unstable_CompositeOptions,
-  unstable_CompositeHTMLProps,
-  unstable_useComposite,
+  CompositeOptions,
+  CompositeHTMLProps,
+  useComposite,
 } from "../Composite/Composite";
 import { useRadioState } from "./RadioState";
 
-export type RadioGroupOptions = unstable_CompositeOptions;
+export type RadioGroupOptions = CompositeOptions;
 
-export type RadioGroupHTMLProps = unstable_CompositeHTMLProps &
+export type RadioGroupHTMLProps = CompositeHTMLProps &
   React.FieldsetHTMLAttributes<any>;
 
 export type RadioGroupProps = RadioGroupOptions & RadioGroupHTMLProps;
 
 const useRadioGroup = createHook<RadioGroupOptions, RadioGroupHTMLProps>({
   name: "RadioGroup",
-  compose: unstable_useComposite,
+  compose: useComposite,
   useState: useRadioState,
 
   useProps(_, htmlProps) {

--- a/packages/reakit/src/Radio/RadioState.ts
+++ b/packages/reakit/src/Radio/RadioState.ts
@@ -4,10 +4,10 @@ import {
   SealedInitialState,
 } from "reakit-utils/useSealedState";
 import {
-  unstable_CompositeState as CompositeState,
-  unstable_CompositeActions as CompositeActions,
-  unstable_CompositeInitialState as CompositeInitialState,
-  unstable_useCompositeState as useCompositeState,
+  CompositeState,
+  CompositeActions,
+  CompositeInitialState,
+  useCompositeState,
 } from "../Composite";
 
 export type RadioState = CompositeState & {

--- a/packages/reakit/src/Tab/Tab.ts
+++ b/packages/reakit/src/Tab/Tab.ts
@@ -3,9 +3,9 @@ import { createComponent } from "reakit-system/createComponent";
 import { createHook } from "reakit-system/createHook";
 import { useLiveRef } from "reakit-utils/useLiveRef";
 import {
-  unstable_CompositeItemOptions as CompositeItemOptions,
-  unstable_CompositeItemHTMLProps as CompositeItemHTMLProps,
-  unstable_useCompositeItem as useCompositeItem,
+  CompositeItemOptions,
+  CompositeItemHTMLProps,
+  useCompositeItem,
 } from "../Composite/CompositeItem";
 import { useTabState, TabStateReturn } from "./TabState";
 

--- a/packages/reakit/src/Tab/TabList.tsx
+++ b/packages/reakit/src/Tab/TabList.tsx
@@ -3,22 +3,22 @@ import { createComponent } from "reakit-system/createComponent";
 import { useCreateElement } from "reakit-system/useCreateElement";
 import { createHook } from "reakit-system/createHook";
 import {
-  unstable_CompositeOptions,
-  unstable_CompositeHTMLProps,
-  unstable_useComposite,
+  CompositeOptions,
+  CompositeHTMLProps,
+  useComposite,
 } from "../Composite/Composite";
 import { useTabState, TabStateReturn } from "./TabState";
 
-export type TabListOptions = unstable_CompositeOptions &
+export type TabListOptions = CompositeOptions &
   Pick<Partial<TabStateReturn>, "orientation">;
 
-export type TabListHTMLProps = unstable_CompositeHTMLProps;
+export type TabListHTMLProps = CompositeHTMLProps;
 
 export type TabListProps = TabListOptions & TabListHTMLProps;
 
 export const useTabList = createHook<TabListOptions, TabListHTMLProps>({
   name: "TabList",
-  compose: unstable_useComposite,
+  compose: useComposite,
   useState: useTabState,
 
   useProps(options, htmlProps) {

--- a/packages/reakit/src/Tab/TabState.ts
+++ b/packages/reakit/src/Tab/TabState.ts
@@ -4,10 +4,10 @@ import {
   useSealedState,
 } from "reakit-utils/useSealedState";
 import {
-  unstable_useCompositeState as useCompositeState,
-  unstable_CompositeState as CompositeState,
-  unstable_CompositeActions as CompositeActions,
-  unstable_CompositeInitialState as CompositeInitialState,
+  useCompositeState,
+  CompositeState,
+  CompositeActions,
+  CompositeInitialState,
 } from "../Composite/CompositeState";
 
 export type TabState = CompositeState & {

--- a/packages/reakit/src/Toolbar/Toolbar.tsx
+++ b/packages/reakit/src/Toolbar/Toolbar.tsx
@@ -3,22 +3,22 @@ import { createComponent } from "reakit-system/createComponent";
 import { useCreateElement } from "reakit-system/useCreateElement";
 import { createHook } from "reakit-system/createHook";
 import {
-  unstable_CompositeOptions,
-  unstable_CompositeHTMLProps,
-  unstable_useComposite,
+  CompositeOptions,
+  CompositeHTMLProps,
+  useComposite,
 } from "../Composite/Composite";
 import { ToolbarStateReturn, useToolbarState } from "./ToolbarState";
 
-export type ToolbarOptions = unstable_CompositeOptions &
+export type ToolbarOptions = CompositeOptions &
   Pick<Partial<ToolbarStateReturn>, "orientation">;
 
-export type ToolbarHTMLProps = unstable_CompositeHTMLProps;
+export type ToolbarHTMLProps = CompositeHTMLProps;
 
 export type ToolbarProps = ToolbarOptions & ToolbarHTMLProps;
 
 export const useToolbar = createHook<ToolbarOptions, ToolbarHTMLProps>({
   name: "Toolbar",
-  compose: unstable_useComposite,
+  compose: useComposite,
   useState: useToolbarState,
 
   useProps(options, htmlProps) {

--- a/packages/reakit/src/Toolbar/ToolbarItem.ts
+++ b/packages/reakit/src/Toolbar/ToolbarItem.ts
@@ -1,9 +1,9 @@
 import { createComponent } from "reakit-system/createComponent";
 import { createHook } from "reakit-system/createHook";
 import {
-  unstable_CompositeItemOptions as CompositeItemOptions,
-  unstable_CompositeItemHTMLProps as CompositeItemHTMLProps,
-  unstable_useCompositeItem as useCompositeItem,
+  CompositeItemOptions,
+  CompositeItemHTMLProps,
+  useCompositeItem,
 } from "../Composite/CompositeItem";
 import { useToolbarState } from "./ToolbarState";
 

--- a/packages/reakit/src/Toolbar/ToolbarState.ts
+++ b/packages/reakit/src/Toolbar/ToolbarState.ts
@@ -3,10 +3,10 @@ import {
   useSealedState,
 } from "reakit-utils/useSealedState";
 import {
-  unstable_useCompositeState as useCompositeState,
-  unstable_CompositeState as CompositeState,
-  unstable_CompositeActions as CompositeActions,
-  unstable_CompositeInitialState as CompositeInitialState,
+  useCompositeState,
+  CompositeState,
+  CompositeActions,
+  CompositeInitialState,
 } from "../Composite/CompositeState";
 
 export type ToolbarState = CompositeState;

--- a/packages/reakit/src/__tests__/index-test.tsx
+++ b/packages/reakit/src/__tests__/index-test.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import { render, press, wait } from "reakit-test-utils";
 import {
-  unstable_useCompositeState as useCompositeState,
-  unstable_Composite as Composite,
-  unstable_CompositeItem as CompositeItem,
+  useCompositeState,
+  Composite,
+  CompositeItem,
   useMenuState,
   Menu,
   MenuButton,


### PR DESCRIPTION
This PR marks the `Composite` module as stable, except the `CompositeItemWidget` component.

**Does this PR introduce a breaking change?**

This removes the `unstable_` prefix from the `Composite` components. So this is going to break code that is currently using this module.