### PR TITLE
feat: introduce Input primitive as base for FormInput (#665)

### DIFF
--- a/packages/reakit-playground/src/__deps/reakit-system-bootstrap.ts
+++ b/packages/reakit-playground/src/__deps/reakit-system-bootstrap.ts
@@ -8,6 +8,7 @@ export default {
   "reakit-system-bootstrap/Dialog": require("reakit-system-bootstrap/Dialog"),
   "reakit-system-bootstrap/Form": require("reakit-system-bootstrap/Form"),
   "reakit-system-bootstrap/Group": require("reakit-system-bootstrap/Group"),
+  "reakit-system-bootstrap/Input": require("reakit-system-bootstrap/Input"),
   "reakit-system-bootstrap/Menu": require("reakit-system-bootstrap/Menu"),
   "reakit-system-bootstrap/Popover": require("reakit-system-bootstrap/Popover"),
   "reakit-system-bootstrap/Separator": require("reakit-system-bootstrap/Separator"),

--- a/packages/reakit-playground/src/__deps/reakit.ts
+++ b/packages/reakit-playground/src/__deps/reakit.ts
@@ -49,6 +49,8 @@ export default {
   "reakit/Id/Id": require("reakit/Id/Id"),
   "reakit/Id/IdProvider": require("reakit/Id/IdProvider"),
   "reakit/Id/IdState": require("reakit/Id/IdState"),
+  "reakit/Input": require("reakit/Input"),
+  "reakit/Input/Input": require("reakit/Input/Input"),
   "reakit/Menu": require("reakit/Menu"),
   "reakit/Menu/Menu": require("reakit/Menu/Menu"),
   "reakit/Menu/MenuArrow": require("reakit/Menu/MenuArrow"),

--- a/packages/reakit-system-bootstrap/.gitignore
+++ b/packages/reakit-system-bootstrap/.gitignore
@@ -5,6 +5,7 @@
 /Dialog
 /Form
 /Group
+/Input
 /Menu
 /Popover
 /Separator

--- a/packages/reakit-system-bootstrap/src/Form.ts
+++ b/packages/reakit-system-bootstrap/src/Form.ts
@@ -1,9 +1,6 @@
 import { css, cx } from "emotion";
 import { unstable_FormHTMLProps, unstable_FormOptions } from "reakit/Form/Form";
-import {
-  unstable_FormInputHTMLProps,
-  unstable_FormInputOptions,
-} from "reakit/Form/FormInput";
+import { unstable_FormInputOptions } from "reakit/Form/FormInput";
 import {
   unstable_FormMessageHTMLProps,
   unstable_FormMessageOptions,
@@ -21,7 +18,6 @@ import { unstable_getIn } from "reakit/Form/utils/getIn";
 import { useBoxProps as usePaletteBoxProps } from "reakit-system-palette/Box";
 import { useContrast } from "reakit-system-palette/utils/contrast";
 import { useFade } from "reakit-system-palette/utils/fade";
-import { usePalette } from "reakit-system-palette/utils/palette";
 import { useLighten } from "reakit-system-palette/utils/lighten";
 import { BootstrapBoxOptions } from "./Box";
 
@@ -59,38 +55,6 @@ export function useFormInputOptions({
     },
     ...options,
   };
-}
-
-export function useFormInputProps(
-  { unstable_system }: BootstrapFormInputOptions,
-  htmlProps: unstable_FormInputHTMLProps = {}
-): unstable_FormInputHTMLProps {
-  const {
-    style: { backgroundColor, borderColor: originalBorderColor },
-  } = usePaletteBoxProps({ unstable_system });
-
-  const foreground = useContrast(backgroundColor) || "black";
-  const color = useLighten(foreground, 0.3);
-  const primary = usePalette("primary");
-  const borderColor = useFade(foreground, 0.75);
-  const focusBorderColor = useLighten(primary, 0.4);
-
-  const formInput = css`
-    display: block;
-    width: 100%;
-    border-radius: 0.2rem;
-    padding: 0.5em 0.75em;
-    font-size: 100%;
-    border: 1px solid ${originalBorderColor || borderColor};
-    color: ${color};
-    margin: 0 !important;
-
-    &:focus {
-      border-color: ${originalBorderColor || focusBorderColor};
-    }
-  `;
-
-  return { ...htmlProps, className: cx(formInput, htmlProps.className) };
 }
 
 export type BootstrapFormMessageOptions = BootstrapBoxOptions &

--- a/packages/reakit-system-bootstrap/src/Input.ts
+++ b/packages/reakit-system-bootstrap/src/Input.ts
@@ -1,0 +1,42 @@
+import { css, cx } from "emotion";
+import { InputHTMLProps, InputOptions } from "reakit/Input/Input";
+import { useBoxProps as usePaletteBoxProps } from "reakit-system-palette/Box";
+import { useContrast } from "reakit-system-palette/utils/contrast";
+import { useFade } from "reakit-system-palette/utils/fade";
+import { usePalette } from "reakit-system-palette/utils/palette";
+import { useLighten } from "reakit-system-palette/utils/lighten";
+import { BootstrapBoxOptions } from "./Box";
+
+export type BootstrapInputOptions = BootstrapBoxOptions & InputOptions;
+
+export function useInputProps(
+  { unstable_system }: BootstrapBoxOptions,
+  htmlProps: InputHTMLProps = {}
+): InputHTMLProps {
+  const {
+    style: { backgroundColor, borderColor: originalBorderColor },
+  } = usePaletteBoxProps({ unstable_system });
+
+  const foreground = useContrast(backgroundColor) || "black";
+  const color = useLighten(foreground, 0.3);
+  const primary = usePalette("primary");
+  const borderColor = useFade(foreground, 0.75);
+  const focusBorderColor = useLighten(primary, 0.4);
+
+  const formInput = css`
+    display: block;
+    width: 100%;
+    border-radius: 0.2rem;
+    padding: 0.5em 0.75em;
+    font-size: 100%;
+    border: 1px solid ${originalBorderColor || borderColor};
+    color: ${color};
+    margin: 0 !important;
+
+    &:focus {
+      border-color: ${originalBorderColor || focusBorderColor};
+    }
+  `;
+
+  return { ...htmlProps, className: cx(formInput, htmlProps.className) };
+}

--- a/packages/reakit-system-bootstrap/src/index.ts
+++ b/packages/reakit-system-bootstrap/src/index.ts
@@ -4,6 +4,7 @@ export * from "./Composite";
 export * from "./Dialog";
 export * from "./Form";
 export * from "./Group";
+export * from "./Input";
 export * from "./Menu";
 export * from "./palette";
 export * from "./Popover";

--- a/packages/reakit/.gitignore
+++ b/packages/reakit/.gitignore
@@ -9,6 +9,7 @@
 /Form
 /Group
 /Id
+/Input
 /Menu
 /Popover
 /Portal

--- a/packages/reakit/src/Form/FormInput.ts
+++ b/packages/reakit/src/Form/FormInput.ts
@@ -3,11 +3,7 @@ import { createComponent } from "reakit-system/createComponent";
 import { createHook } from "reakit-system/createHook";
 import { As, PropsWithAs } from "reakit-utils/types";
 import { useLiveRef } from "reakit-utils/useLiveRef";
-import {
-  TabbableOptions,
-  TabbableHTMLProps,
-  useTabbable,
-} from "../Tabbable/Tabbable";
+import { InputOptions, InputHTMLProps, useInput } from "../Input/Input";
 import { DeepPath } from "./__utils/types";
 import { getInputId } from "./__utils/getInputId";
 import { getMessageId } from "./__utils/getMessageId";
@@ -20,7 +16,7 @@ import { unstable_FormStateReturn, unstable_useFormState } from "./FormState";
 export type unstable_FormInputOptions<
   V,
   P extends DeepPath<V, P>
-> = TabbableOptions &
+> = InputOptions &
   Pick<
     unstable_FormStateReturn<V>,
     "baseId" | "values" | "touched" | "errors" | "update" | "blur"
@@ -31,7 +27,7 @@ export type unstable_FormInputOptions<
     name: P;
   };
 
-export type unstable_FormInputHTMLProps = TabbableHTMLProps &
+export type unstable_FormInputHTMLProps = InputHTMLProps &
   React.InputHTMLAttributes<any>;
 
 export type unstable_FormInputProps<
@@ -44,7 +40,7 @@ export const unstable_useFormInput = createHook<
   unstable_FormInputHTMLProps
 >({
   name: "FormInput",
-  compose: useTabbable,
+  compose: useInput,
   useState: unstable_useFormState,
   keys: ["name"],
 

--- a/packages/reakit/src/Form/README.md
+++ b/packages/reakit/src/Form/README.md
@@ -455,7 +455,7 @@ Learn more in [Accessibility](/docs/accessibility/).
 - `Form` uses [Box](/docs/box/).
 - `FormCheckbox` uses [Checkbox](/docs/checkbox/).
 - `FormGroup` uses [Group](/docs/group/).
-- `FormInput` uses [Tabbable](/docs/tabbable/).
+- `FormInput` uses [Input](/docs/input/).
 - `FormLabel` uses [Box](/docs/box/).
 - `FormMessage` uses [Box](/docs/box/).
 - `FormPushButton` uses [Button](/docs/button/).

--- a/packages/reakit/src/Input/Input.ts
+++ b/packages/reakit/src/Input/Input.ts
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { createComponent } from "reakit-system/createComponent";
+import { createHook } from "reakit-system/createHook";
+import {
+  TabbableOptions,
+  TabbableHTMLProps,
+  useTabbable,
+} from "../Tabbable/Tabbable";
+
+export type InputOptions = TabbableOptions;
+
+export type InputHTMLProps = TabbableHTMLProps & React.InputHTMLAttributes<any>;
+
+export type InputProps = InputOptions & InputHTMLProps;
+
+export const useInput = createHook<InputOptions, InputHTMLProps>({
+  name: "Input",
+  compose: useTabbable,
+});
+
+export const Input = createComponent({
+  as: "input",
+  memo: true,
+  useHook: useInput,
+});

--- a/packages/reakit/src/Input/README.md
+++ b/packages/reakit/src/Input/README.md
@@ -1,0 +1,86 @@
+---
+path: /docs/input/
+---
+
+# Input
+
+Base `Input` component that enables users to enter text values.
+Do not forget to provide accessible names for your inputs.
+Or consider using `FormInput` together with `FormLabel` within [Forms](/docs/form/).
+
+<carbon-ad></carbon-ad>
+
+## Installation
+
+```sh
+npm install reakit
+```
+
+Learn more in [Get started](/docs/get-started/).
+
+## Usage
+
+```jsx
+import { Input } from "reakit/Input";
+
+function Example() {
+  return <Input placeholder="input" />;
+}
+```
+
+## Styling
+
+Reakit components are unstyled by default. You're free to use whatever approach you want. Each component returns a single HTML element that accepts all HTML props, including `className` and `style`.
+
+> The example below uses [Emotion](https://emotion.sh/docs/introduction). But these styles can be reproduced using static CSS and other CSS-in-JS libraries, such as [styled-components](https://styled-components.com/).
+
+```jsx unstyled
+import { Input } from "reakit/Input";
+import { css } from "emotion";
+
+const className = css`
+  display: block;
+  width: 100%;
+  border-radius: 0.2rem;
+  padding: 0.5em 0.75em;
+  font-size: 100%;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  color: #4d4d4d;
+  margin: 0 !important;
+  box-sizing: border-box;
+
+  &:focus {
+    border-color: rgba(0, 0, 0, 0.25);
+  }
+`;
+
+function Example() {
+  return <Input className={className} value="value" placeholder="input" />;
+}
+```
+
+Learn more in [Styling](/docs/styling/).
+
+## Composition
+
+- `Input` uses [Tabbable](/docs/tabbable/), and is used by [FormInput](/docs/form/) and all their derivatives.
+
+Learn more in [Composition](/docs/composition/#props-hooks).
+
+## Props
+
+<!-- Automatically generated -->
+
+### `Input`
+
+- **`disabled`**
+  <code>boolean | undefined</code>
+
+  Same as the HTML attribute.
+
+- **`focusable`**
+  <code>boolean | undefined</code>
+
+  When an element is `disabled`, it may still be `focusable`. It works
+similarly to `readOnly` on form elements. In this case, only
+`aria-disabled` will be set.

--- a/packages/reakit/src/Input/__tests__/Input-test.tsx
+++ b/packages/reakit/src/Input/__tests__/Input-test.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+import { render } from "reakit-test-utils";
+import { Input } from "../Input";
+
+test("render", () => {
+  const { getByPlaceholderText } = render(<Input placeholder="input" />);
+  expect(getByPlaceholderText("input")).toMatchInlineSnapshot(`
+    <input
+      placeholder="input"
+    />
+  `);
+});

--- a/packages/reakit/src/Input/index.ts
+++ b/packages/reakit/src/Input/index.ts
@@ -1,0 +1,1 @@
+export * from "./Input";

--- a/packages/reakit/src/index.ts
+++ b/packages/reakit/src/index.ts
@@ -8,6 +8,7 @@ export * from "./Disclosure";
 export * from "./Form";
 export * from "./Group";
 export * from "./Id";
+export * from "./Input";
 export * from "./Menu";
 export * from "./Popover";
 export * from "./Portal";

--- a/packages/website/src/data/docs.yml
+++ b/packages/website/src/data/docs.yml
@@ -1,5 +1,5 @@
 - section: Guide
-  paths: 
+  paths:
     - /docs/get-started/
     - /docs/basic-concepts/
     - /docs/composition/
@@ -16,6 +16,7 @@
     - /docs/disclosure/
     - /docs/form/
     - /docs/group/
+    - /docs/input/
     - /docs/menu/
     - /docs/popover/
     - /docs/radio/


### PR DESCRIPTION
Closes #665

It doesn't introduce breaking changes in base package. One who used `useFormInputProps` hook still can continue to use it or migrate to use `useInputProps` instead.

It does introduce a small breaking change for `reakit-system-bootstrap` though. It doesn't export `useFormInputProps` hook anymore.