### PR TITLE
fix: Fix `Composite` state update on unmounted components

### DIFF
--- a/packages/reakit/src/Composite/CompositeState.ts
+++ b/packages/reakit/src/Composite/CompositeState.ts
@@ -4,6 +4,7 @@ import {
   useSealedState,
 } from "reakit-utils/useSealedState";
 import { applyState } from "reakit-utils/applyState";
+import { useIsomorphicEffect } from "reakit-utils/useIsomorphicEffect";
 import {
   unstable_IdState,
   unstable_IdActions,
@@ -581,12 +582,11 @@ function useAction<T extends (...args: any[]) => any>(fn: T) {
 
 function useIsUnmountedRef() {
   const isUnmountedRef = React.useRef(false);
-  React.useLayoutEffect(
-    () => () => {
+  useIsomorphicEffect(() => {
+    return () => {
       isUnmountedRef.current = true;
-    },
-    []
-  );
+    };
+  }, []);
   return isUnmountedRef;
 }
 

--- a/packages/reakit/src/Composite/__examples__/DrillUpComposite/__tests__/index-test.tsx
+++ b/packages/reakit/src/Composite/__examples__/DrillUpComposite/__tests__/index-test.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { render, click } from "reakit-test-utils";
+import DillUpComposite from "..";
+
+test("mount and unmount", () => {
+  const { getByText: text, queryByLabelText: label } = render(
+    <DillUpComposite />
+  );
+  expect(label("composite")).toBeInTheDocument();
+  click(text("Toggle Toolbar"));
+  expect(label("composite")).not.toBeInTheDocument();
+  click(text("Toggle Toolbar"));
+  expect(label("composite")).toBeInTheDocument();
+});

--- a/packages/reakit/src/Composite/__examples__/DrillUpComposite/index.tsx
+++ b/packages/reakit/src/Composite/__examples__/DrillUpComposite/index.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import { Button } from "reakit/Button";
+import {
+  unstable_useCompositeState as useCompositeState,
+  unstable_Composite as Composite,
+  unstable_CompositeItem as CompositeItem,
+  unstable_CompositeGroup as CompositeGroup,
+  unstable_CompositeStateReturn as CompositeStateReturn,
+} from "reakit/Composite";
+
+const CompositeContext = React.createContext<CompositeStateReturn | null>(null);
+const SetCompositeContext = React.createContext<React.Dispatch<
+  React.SetStateAction<CompositeStateReturn>
+> | null>(null);
+
+const Provider: React.FC = (props) => {
+  const [
+    composite,
+    setCompositeState,
+  ] = React.useState<CompositeStateReturn | null>(null);
+  return (
+    <SetCompositeContext.Provider value={setCompositeState}>
+      <CompositeContext.Provider value={composite}>
+        {props.children}
+      </CompositeContext.Provider>
+    </SetCompositeContext.Provider>
+  );
+};
+
+function Toolbar() {
+  const composite = useCompositeState();
+  const setCompositeContext = React.useContext(SetCompositeContext);
+  React.useEffect(() => setCompositeContext?.(composite));
+  return <Composite {...composite} role="toolbar" aria-label="composite" />;
+}
+
+function ToolbarItems() {
+  const composite = React.useContext(CompositeContext);
+  if (!composite) return null;
+  return (
+    <CompositeGroup {...composite}>
+      <CompositeItem {...composite}>Item 1</CompositeItem>
+      <CompositeItem {...composite}>Item 2</CompositeItem>
+    </CompositeGroup>
+  );
+}
+
+export default function DrillUpComposite() {
+  const [showToolbar, setShowToolbar] = React.useState(true);
+  return (
+    <Provider>
+      {showToolbar && <Toolbar />}
+      {showToolbar && <ToolbarItems />}
+      <Button onClick={() => setShowToolbar(!showToolbar)}>
+        Toggle Toolbar
+      </Button>
+    </Provider>
+  );
+}


### PR DESCRIPTION
Closes #650

This is a very specific case where the state lives in a component, and you try to update it from another component that is not a descendant right after the former has been unmounted. This is only possible if you pass the state up to a component higher in the tree.

**Does this PR introduce a breaking change?**

No