### PR TITLE
feat: Focus `Radio` on click on Safari/Firefox

### DIFF
--- a/packages/reakit-utils/src/__tests__/isLabelForRadio-test.tsx
+++ b/packages/reakit-utils/src/__tests__/isLabelForRadio-test.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { render } from "reakit-test-utils";
+import { isLabelForRadio } from "../isLabelForRadio";
+
+test("isLabelForRadio", () => {
+  const { getByText, getByLabelText } = render(
+    <>
+      <input type="radio" aria-label="item1" />
+      <label>
+        <input type="radio" />
+        <span aria-label="item2" />
+      </label>
+      <div>
+        <input id="radio1" type="radio" />
+        <label htmlFor="radio1">item3</label>
+      </div>
+      <div>
+        <label htmlFor="radio2">item4</label>
+        <input id="radio2" type="radio" />
+      </div>
+    </>
+  );
+
+  expect(isLabelForRadio(getByLabelText("item1"))).toBe(false);
+  expect(isLabelForRadio(getByLabelText("item2"))).toBe(true);
+  expect(isLabelForRadio(getByText("item3"))).toBe(true);
+  expect(isLabelForRadio(getByText("item4"))).toBe(true);
+});

--- a/packages/reakit-utils/src/__tests__/isRadio-test.tsx
+++ b/packages/reakit-utils/src/__tests__/isRadio-test.tsx
@@ -3,13 +3,28 @@ import { render } from "reakit-test-utils";
 import { isRadio } from "../isRadio";
 
 test("isRadio", () => {
-  const { getByLabelText } = render(
+  const { getByText, getByLabelText } = render(
     <>
       <input type="radio" aria-label="item1" />
       <input type="text" aria-label="item2" />
+      <label>
+        <input type="radio" />
+        <span aria-label="item3" />
+      </label>
+      <div>
+        <input id="radio1" type="radio" />
+        <label htmlFor="radio1">item4</label>
+      </div>
+      <div>
+        <label htmlFor="radio2">item5</label>
+        <input id="radio2" type="radio" />
+      </div>
     </>
   );
 
   expect(isRadio(getByLabelText("item1"))).toBe(true);
   expect(isRadio(getByLabelText("item2"))).toBe(false);
+  expect(isRadio(getByLabelText("item3"))).toBe(true);
+  expect(isRadio(getByText("item4"))).toBe(true);
+  expect(isRadio(getByText("item5"))).toBe(true);
 });

--- a/packages/reakit-utils/src/__tests__/isRadio-test.tsx
+++ b/packages/reakit-utils/src/__tests__/isRadio-test.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { render } from "reakit-test-utils";
+import { isRadio } from "../isRadio";
+
+test("isRadio", () => {
+  const { getByLabelText } = render(
+    <>
+      <input type="radio" aria-label="item1" />
+      <input type="text" aria-label="item2" />
+    </>
+  );
+
+  expect(isRadio(getByLabelText("item1"))).toBe(true);
+  expect(isRadio(getByLabelText("item2"))).toBe(false);
+});

--- a/packages/reakit-utils/src/__tests__/isRadio-test.tsx
+++ b/packages/reakit-utils/src/__tests__/isRadio-test.tsx
@@ -3,28 +3,13 @@ import { render } from "reakit-test-utils";
 import { isRadio } from "../isRadio";
 
 test("isRadio", () => {
-  const { getByText, getByLabelText } = render(
+  const { getByLabelText } = render(
     <>
       <input type="radio" aria-label="item1" />
       <input type="text" aria-label="item2" />
-      <label>
-        <input type="radio" />
-        <span aria-label="item3" />
-      </label>
-      <div>
-        <input id="radio1" type="radio" />
-        <label htmlFor="radio1">item4</label>
-      </div>
-      <div>
-        <label htmlFor="radio2">item5</label>
-        <input id="radio2" type="radio" />
-      </div>
     </>
   );
 
   expect(isRadio(getByLabelText("item1"))).toBe(true);
   expect(isRadio(getByLabelText("item2"))).toBe(false);
-  expect(isRadio(getByLabelText("item3"))).toBe(true);
-  expect(isRadio(getByText("item4"))).toBe(true);
-  expect(isRadio(getByText("item5"))).toBe(true);
 });

--- a/packages/reakit-utils/src/index.ts
+++ b/packages/reakit-utils/src/index.ts
@@ -18,6 +18,7 @@ export * from "./isObject";
 export * from "./isPlainObject";
 export * from "./isPortalEvent";
 export * from "./isPromise";
+export * from "./isRadio";
 export * from "./isSelfTarget";
 export * from "./isTextField";
 export * from "./matches";

--- a/packages/reakit-utils/src/index.ts
+++ b/packages/reakit-utils/src/index.ts
@@ -14,6 +14,7 @@ export * from "./hasFocusWithin";
 export * from "./isButton";
 export * from "./isEmpty";
 export * from "./isInteger";
+export * from "./isLabelForRadio";
 export * from "./isObject";
 export * from "./isPlainObject";
 export * from "./isPortalEvent";

--- a/packages/reakit-utils/src/isLabelForRadio.ts
+++ b/packages/reakit-utils/src/isLabelForRadio.ts
@@ -14,7 +14,9 @@ import { closest } from "./closest";
 export function isLabelForRadio(element: Element): element is HTMLLabelElement {
   const label = element as HTMLLabelElement;
   if (label.tagName === "LABEL") {
-    const input = document.getElementById(label.htmlFor) as HTMLInputElement | any;
+    const input = document.getElementById(label.htmlFor) as
+      | HTMLInputElement
+      | any;
     if (input) {
       return input.type === "radio";
     }

--- a/packages/reakit-utils/src/isLabelForRadio.ts
+++ b/packages/reakit-utils/src/isLabelForRadio.ts
@@ -12,19 +12,18 @@ import { closest } from "./closest";
  * @returns {boolean}
  */
 export function isLabelForRadio(element: Element): element is HTMLLabelElement {
-  let label = element as HTMLLabelElement;
-  if (label.tagName !== "LABEL") {
-    return false;
-  }
-  let input = document.getElementById(label.htmlFor) as HTMLInputElement | any;
-  if (input) {
-    return input.type === "radio";
-  }
-  label = closest(element, "label");
-  if (label) {
-    input = label.querySelector<HTMLInputElement>("input");
+  const label = element as HTMLLabelElement;
+  if (label.tagName === "LABEL") {
+    const input = document.getElementById(label.htmlFor) as HTMLInputElement | any;
     if (input) {
       return input.type === "radio";
+    }
+  }
+  const labelAsParent = closest(element, "label") as HTMLLabelElement;
+  if (labelAsParent) {
+    const inputInside = labelAsParent.querySelector<HTMLInputElement>("input");
+    if (inputInside) {
+      return inputInside.type === "radio";
     }
   }
   return false;

--- a/packages/reakit-utils/src/isLabelForRadio.ts
+++ b/packages/reakit-utils/src/isLabelForRadio.ts
@@ -4,10 +4,10 @@ import { closest } from "./closest";
  * Checks whether `element` is a label targeting a native HTML radio element or not.
  *
  * @example
- * import { isLabelOfRadio } from "reakit-utils";
+ * import { isLabelForRadio } from "reakit-utils";
  *
- * isLabelOfRadio(document.querySelector("label[for='radio']")); // true
- * isLabelOfRadio(document.querySelector("label[for='email']")); // false
+ * isLabelForRadio(document.querySelector("label[for='radio']")); // true
+ * isLabelForRadio(document.querySelector("label[for='email']")); // false
  *
  * @returns {boolean}
  */

--- a/packages/reakit-utils/src/isLabelForRadio.ts
+++ b/packages/reakit-utils/src/isLabelForRadio.ts
@@ -1,0 +1,31 @@
+import { closest } from "./closest";
+
+/**
+ * Checks whether `element` is a label targeting a native HTML radio element or not.
+ *
+ * @example
+ * import { isLabelOfRadio } from "reakit-utils";
+ *
+ * isLabelOfRadio(document.querySelector("label[for='radio']")); // true
+ * isLabelOfRadio(document.querySelector("label[for='email']")); // false
+ *
+ * @returns {boolean}
+ */
+export function isLabelForRadio(element: Element): element is HTMLLabelElement {
+  let label = element as HTMLLabelElement;
+  if (label.tagName !== "LABEL") {
+    return false;
+  }
+  let input = document.getElementById(label.htmlFor) as HTMLInputElement | any;
+  if (input) {
+    return input.type === "radio";
+  }
+  label = closest(element, "label");
+  if (label) {
+    input = label.querySelector<HTMLInputElement>("input");
+    if (input) {
+      return input.type === "radio";
+    }
+  }
+  return false;
+}

--- a/packages/reakit-utils/src/isRadio.ts
+++ b/packages/reakit-utils/src/isRadio.ts
@@ -1,5 +1,3 @@
-import { closest } from "./closest";
-
 /**
  * Checks whether `element` is a native HTML radio element or not.
  *
@@ -14,23 +12,6 @@ import { closest } from "./closest";
 export function isRadio(
   element: Element
 ): element is HTMLButtonElement | HTMLInputElement {
-  let input = element as HTMLInputElement | any;
-  if (element.tagName === "INPUT") {
-    return input.type === "radio";
-  }
-  let label = element as HTMLLabelElement;
-  if (element.tagName === "LABEL") {
-    input = document.getElementById(label.htmlFor);
-    if (input) {
-      return input.type === "radio";
-    }
-  }
-  label = closest(element, "label");
-  if (label) {
-    input = label.querySelector<HTMLInputElement>("input");
-    if (input) {
-      return input.type === "radio";
-    }
-  }
-  return false;
+  const input = element as HTMLInputElement | any;
+  return element.tagName === "INPUT" && input.type === "radio";
 }

--- a/packages/reakit-utils/src/isRadio.ts
+++ b/packages/reakit-utils/src/isRadio.ts
@@ -1,21 +1,36 @@
+import { closest } from "./closest";
+
 /**
  * Checks whether `element` is a native HTML radio element or not.
  *
  * @example
  * import { isRadio } from "reakit-utils";
  *
- * isButton(document.querySelector("input[type='radio']")); // true
- * isButton(document.querySelector("div")); // false
+ * isRadio(document.querySelector("input[type='radio']")); // true
+ * isRadio(document.querySelector("div")); // false
  *
  * @returns {boolean}
  */
 export function isRadio(
   element: Element
 ): element is HTMLButtonElement | HTMLInputElement {
+  let input = element as HTMLInputElement | any;
   if (element.tagName === "INPUT") {
-    const input = element as HTMLInputElement;
     return input.type === "radio";
   }
-
+  let label = element as HTMLLabelElement;
+  if (element.tagName === "LABEL") {
+    input = document.getElementById(label.htmlFor);
+    if (input) {
+      return input.type === "radio";
+    }
+  }
+  label = closest(element, "label");
+  if (label) {
+    input = label.querySelector<HTMLInputElement>("input");
+    if (input) {
+      return input.type === "radio";
+    }
+  }
   return false;
 }

--- a/packages/reakit-utils/src/isRadio.ts
+++ b/packages/reakit-utils/src/isRadio.ts
@@ -1,0 +1,21 @@
+/**
+ * Checks whether `element` is a native HTML radio element or not.
+ *
+ * @example
+ * import { isRadio } from "reakit-utils";
+ *
+ * isButton(document.querySelector("input[type='radio']")); // true
+ * isButton(document.querySelector("div")); // false
+ *
+ * @returns {boolean}
+ */
+export function isRadio(
+  element: Element
+): element is HTMLButtonElement | HTMLInputElement {
+  if (element.tagName === "INPUT") {
+    const input = element as HTMLInputElement;
+    return input.type === "radio";
+  }
+
+  return false;
+}

--- a/packages/reakit/src/Radio/__examples__/RadioAsTappable/__tests__/index-test.tsx
+++ b/packages/reakit/src/Radio/__examples__/RadioAsTappable/__tests__/index-test.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { click, render } from "reakit-test-utils";
+import RadioGroup from "../index";
+
+test("should change the focus", async () => {
+  const { getByTestId, getByText } = render(<RadioGroup />);
+  const banana = getByText("banana");
+  expect(banana).toBeVisible();
+  click(banana);
+  expect(getByTestId("banana")).toHaveFocus();
+
+  const apple = getByText("apple");
+  click(apple);
+  expect(getByTestId("apple")).toHaveFocus();
+});

--- a/packages/reakit/src/Radio/__examples__/RadioAsTappable/index.tsx
+++ b/packages/reakit/src/Radio/__examples__/RadioAsTappable/index.tsx
@@ -31,11 +31,11 @@ export default function RadioAsTappable() {
         <label htmlFor="orange">orange</label>
         <Radio {...radio} value="orange" id="orange" />
         <label>
-          <Radio {...radio} value="apple" />
+          <Radio {...radio} value="apple" data-testid="apple" />
           apple
         </label>
         <label>
-          <Radio {...radio} value="banana" />
+          <Radio {...radio} value="banana" data-testid="banana" />
           <span>banana</span>
         </label>
         <Radio {...radio} value="watermelon" id="watermelon" />

--- a/packages/reakit/src/Radio/__examples__/RadioAsTappable/index.tsx
+++ b/packages/reakit/src/Radio/__examples__/RadioAsTappable/index.tsx
@@ -26,7 +26,7 @@ export default function RadioAsTappable() {
   return (
     <>
       <p>{radio.currentId} has been checked</p>
-      <p> {focusedElement.id || "body"} has the focus</p>
+      <p> {focusedElement?.id || "body"} has the focus</p>
       <RadioGroup {...radio} aria-label="fruits">
         <label htmlFor="orange">orange</label>
         <Radio {...radio} value="orange" id="orange" />

--- a/packages/reakit/src/Radio/__examples__/RadioAsTappable/index.tsx
+++ b/packages/reakit/src/Radio/__examples__/RadioAsTappable/index.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { useRadioState, Radio, RadioGroup } from "reakit/Radio";
+
+const useActiveElement = () => {
+  const [active, setActive] = React.useState(document.activeElement);
+
+  const handleFocusIn = () => {
+    setActive(document.activeElement);
+  };
+
+  React.useEffect(() => {
+    document.addEventListener("focusin", handleFocusIn);
+    return () => {
+      document.removeEventListener("focusin", handleFocusIn);
+    };
+  }, []);
+
+  return active;
+};
+
+export default function RadioAsTappable() {
+  const radio = useRadioState({ state: "orange" });
+
+  const focusedElement = useActiveElement();
+
+  return (
+    <>
+      <p>{radio.currentId} has been checked</p>
+      <p> {focusedElement.id || "body"} has the focus</p>
+      <RadioGroup {...radio} aria-label="fruits">
+        <label htmlFor="orange">orange</label>
+        <Radio {...radio} value="orange" id="orange" />
+        <label>
+          <Radio {...radio} value="apple" />
+          apple
+        </label>
+        <label>
+          <Radio {...radio} value="banana" />
+          <span>banana</span>
+        </label>
+        <Radio {...radio} value="watermelon" id="watermelon" />
+        <label htmlFor="watermelon">watermelon</label>
+      </RadioGroup>
+    </>
+  );
+}

--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -7,6 +7,7 @@ import { useLiveRef } from "reakit-utils/useLiveRef";
 import { warning } from "reakit-warning";
 import { hasFocusWithin } from "reakit-utils/hasFocusWithin";
 import { isButton } from "reakit-utils/isButton";
+import { isRadio } from "reakit-utils/isRadio";
 import { isPortalEvent } from "reakit-utils/isPortalEvent";
 import { getActiveElement } from "reakit-utils/getActiveElement";
 import { getClosestFocusable } from "reakit-utils/tabbable";
@@ -65,7 +66,7 @@ function useFocusOnMouseDown() {
     (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
       const element = event.currentTarget;
       if (isPortalEvent(event)) return;
-      if (!isButton(element)) return;
+      if (!(isButton(element) || isRadio(element))) return;
       const activeElement = getActiveElement(element);
       if (!activeElement) return;
       const activeElementIsBody = activeElement.tagName === "BODY";

--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -128,7 +128,7 @@ function useFocusOnClick() {
       let elementToFocus;
 
       const input = element as HTMLInputElement;
-      if (input.tagName === "INPUT" && input.type === "radio") {
+      if (isRadio(input)) {
         elementToFocus = element;
       }
 

--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -11,9 +11,9 @@ import { isRadio } from "reakit-utils/isRadio";
 import { isPortalEvent } from "reakit-utils/isPortalEvent";
 import { getActiveElement } from "reakit-utils/getActiveElement";
 import { getClosestFocusable } from "reakit-utils/tabbable";
-import { BoxOptions, BoxHTMLProps, useBox } from "../Box/Box";
 import { isLabelForRadio } from "reakit-utils/isLabelForRadio";
 import { closest } from "reakit-utils/closest";
+import { BoxOptions, BoxHTMLProps, useBox } from "../Box/Box";
 
 export type TabbableOptions = BoxOptions & {
   /**
@@ -217,7 +217,7 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
     }, []);
 
     const onClick = React.useCallback(
-      (event: React.MouseEvent) => {
+      (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
         if (options.disabled) {
           event.stopPropagation();
           event.preventDefault();

--- a/packages/reakit/src/Tabbable/__tests__/Tabbable-test.tsx
+++ b/packages/reakit/src/Tabbable/__tests__/Tabbable-test.tsx
@@ -78,6 +78,14 @@ test("native button focus", () => {
   expect(tabbable).toHaveFocus();
 });
 
+test("native radio focus", () => {
+  const { getByLabelText } = render(<Tabbable as="input" type="radio" aria-label="tabbable" />);
+  const tabbable = getByLabelText("tabbable");
+  expect(tabbable).not.toHaveFocus();
+  focus(tabbable);
+  expect(tabbable).toHaveFocus();
+});
+
 test("native button focus disabled", () => {
   const { getByText } = render(
     <Tabbable as="button" disabled>

--- a/packages/reakit/src/Tabbable/__tests__/Tabbable-test.tsx
+++ b/packages/reakit/src/Tabbable/__tests__/Tabbable-test.tsx
@@ -79,7 +79,9 @@ test("native button focus", () => {
 });
 
 test("native radio focus", () => {
-  const { getByLabelText } = render(<Tabbable as="input" type="radio" aria-label="tabbable" />);
+  const { getByLabelText } = render(
+    <Tabbable as="input" type="radio" aria-label="tabbable" />
+  );
   const tabbable = getByLabelText("tabbable");
   expect(tabbable).not.toHaveFocus();
   focus(tabbable);


### PR DESCRIPTION
Safari and Firefox web browsers don't put the focus on a radio button when its value has changed, so we need to force this behavior to update the `RadioGroup` state.

Closes #681
