### PR TITLE
feat: Add stable `composite.sort` method

### DIFF
--- a/packages/reakit/src/Composite/CompositeState.ts
+++ b/packages/reakit/src/Composite/CompositeState.ts
@@ -175,7 +175,7 @@ export type CompositeActions = unstable_IdActions & {
    * Sorts the composite items state. This is especially useful after modifying
    * the composite items order in the DOM.
    */
-  unstable_sort: () => void;
+  sort: () => void;
   /**
    * Sets `virtual`.
    */
@@ -690,7 +690,7 @@ export function useCompositeState(
     down: useAction((allTheWay) => dispatch({ type: "down", allTheWay })),
     first: useAction(() => dispatch({ type: "first" })),
     last: useAction(() => dispatch({ type: "last" })),
-    unstable_sort: useAction(() => dispatch({ type: "sort" })),
+    sort: useAction(() => dispatch({ type: "sort" })),
     unstable_setVirtual: useAction((value) =>
       dispatch({ type: "setVirtual", virtual: value })
     ),

--- a/packages/reakit/src/Composite/__examples__/DynamicComposite/index.tsx
+++ b/packages/reakit/src/Composite/__examples__/DynamicComposite/index.tsx
@@ -37,8 +37,8 @@ export default function DynamicComposite() {
   ]);
 
   React.useEffect(() => {
-    composite.unstable_sort();
-  }, [composite.unstable_sort, items]);
+    composite.sort();
+  }, [composite.sort, items]);
 
   const moveUp = (item: string) => setItems(move(item, -1));
   const moveDown = (item: string) => setItems(move(item, 1));

--- a/packages/reakit/src/Composite/__keys.ts
+++ b/packages/reakit/src/Composite/__keys.ts
@@ -25,7 +25,7 @@ const COMPOSITE_STATE_KEYS = [
   "down",
   "first",
   "last",
-  "unstable_sort",
+  "sort",
   "unstable_setVirtual",
   "setRTL",
   "setOrientation",

--- a/packages/reakit/src/Grid/__keys.ts
+++ b/packages/reakit/src/Grid/__keys.ts
@@ -25,7 +25,7 @@ const GRID_STATE_KEYS = [
   "down",
   "first",
   "last",
-  "unstable_sort",
+  "sort",
   "unstable_setVirtual",
   "setRTL",
   "setOrientation",

--- a/packages/reakit/src/Menu/__keys.ts
+++ b/packages/reakit/src/Menu/__keys.ts
@@ -26,7 +26,7 @@ const MENU_BAR_STATE_KEYS = [
   "down",
   "first",
   "last",
-  "unstable_sort",
+  "sort",
   "unstable_setVirtual",
   "setRTL",
   "setOrientation",

--- a/packages/reakit/src/Radio/__keys.ts
+++ b/packages/reakit/src/Radio/__keys.ts
@@ -26,7 +26,7 @@ const RADIO_STATE_KEYS = [
   "down",
   "first",
   "last",
-  "unstable_sort",
+  "sort",
   "unstable_setVirtual",
   "setRTL",
   "setOrientation",

--- a/packages/reakit/src/Tab/__keys.ts
+++ b/packages/reakit/src/Tab/__keys.ts
@@ -28,7 +28,7 @@ const TAB_STATE_KEYS = [
   "down",
   "first",
   "last",
-  "unstable_sort",
+  "sort",
   "unstable_setVirtual",
   "setRTL",
   "setOrientation",

--- a/packages/reakit/src/Toolbar/__keys.ts
+++ b/packages/reakit/src/Toolbar/__keys.ts
@@ -25,7 +25,7 @@ const TOOLBAR_STATE_KEYS = [
   "down",
   "first",
   "last",
-  "unstable_sort",
+  "sort",
   "unstable_setVirtual",
   "setRTL",
   "setOrientation",


### PR DESCRIPTION
This PR marks the `composite.unstable_sort` method as stable.

**Does this PR introduce a breaking change?**

No. But people relying on the unstable feature will have to update their code.
  
<!-- For new features, components, APIs use `next` branch as target. For bugfixes PR could be targeted to `master` directly -->