### PR TITLE
feat: Automatically sort composite items based on DOM position

### DIFF
--- a/packages/reakit/src/Composite/CompositeState.ts
+++ b/packages/reakit/src/Composite/CompositeState.ts
@@ -27,6 +27,7 @@ import { getItemsInGroup } from "./__utils/getItemsInGroup";
 import { getOppositeOrientation } from "./__utils/getOppositeOrientation";
 import { addItemAtIndex } from "./__utils/addItemAtIndex";
 import { sortBasedOnDOMPosition } from "./__utils/sortBasedOnDOMPosition";
+import { useSortBasedOnDOMPosition } from "./__utils/useSortBasedOnDOMPosition";
 
 export type CompositeState = unstable_IdState & {
   /**
@@ -274,7 +275,8 @@ type CompositeReducerAction =
       type: "setWrap";
       wrap: React.SetStateAction<CompositeState["wrap"]>;
     }
-  | { type: "reset" };
+  | { type: "reset" }
+  | { type: "setItems"; items: CompositeState["items"] };
 
 type CompositeReducerState = Omit<
   CompositeState,
@@ -588,6 +590,9 @@ function reducer(
         unstable_moves: 0,
         pastIds: [],
       };
+    case "setItems": {
+      return { ...state, items: action.items };
+    }
     default:
       throw new Error();
   }
@@ -659,6 +664,12 @@ export function useCompositeState(
   // This only happens in a very specific situation.
   // See https://github.com/reakit/reakit/issues/650
   const isUnmountedRef = useIsUnmountedRef();
+
+  const setItems = React.useCallback(
+    (items: Item[]) => dispatch({ type: "setItems", items }),
+    []
+  );
+  useSortBasedOnDOMPosition(state.items, setItems);
 
   return {
     ...idState,

--- a/packages/reakit/src/Composite/__examples__/DynamicComposite/__tests__/index-test.tsx
+++ b/packages/reakit/src/Composite/__examples__/DynamicComposite/__tests__/index-test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, press, screen } from "reakit-test-utils";
+import { render, press, screen, act } from "reakit-test-utils";
 import NestedCompositeItems from "..";
 
 function cell(name: string) {
@@ -34,7 +34,12 @@ test("change order of grid rows", () => {
   expect(cell("item2")).toHaveFocus();
   press.ArrowRight();
   expect(button("Move item2 up")).toHaveFocus();
+  jest.useFakeTimers();
   press.Enter();
+  act(() => {
+    jest.runAllTimers();
+  });
+  jest.useRealTimers();
   press.ArrowRight();
   expect(button("Move item2 down")).toHaveFocus();
   press.ArrowRight();

--- a/packages/reakit/src/Composite/__examples__/DynamicComposite/index.tsx
+++ b/packages/reakit/src/Composite/__examples__/DynamicComposite/index.tsx
@@ -36,10 +36,6 @@ export default function DynamicComposite() {
     "item4",
   ]);
 
-  React.useEffect(() => {
-    composite.sort();
-  }, [composite.sort, items]);
-
   const moveUp = (item: string) => setItems(move(item, -1));
   const moveDown = (item: string) => setItems(move(item, 1));
   const remove = (item: string) => setItems(exclude(item));

--- a/packages/reakit/src/Composite/__utils/useSortBasedOnDOMPosition.ts
+++ b/packages/reakit/src/Composite/__utils/useSortBasedOnDOMPosition.ts
@@ -11,6 +11,8 @@ function setItemsBasedOnDOMPosition(items: Item[], setItems: SetItems) {
   }
 }
 
+// istanbul ignore next: JSDOM doesn't support IntersectionObverser
+// See https://github.com/jsdom/jsdom/issues/2032
 function useIntersectionObserver(items: Item[], setItems: SetItems) {
   const previousItems = React.useRef<typeof items>([]);
 

--- a/packages/reakit/src/Composite/__utils/useSortBasedOnDOMPosition.ts
+++ b/packages/reakit/src/Composite/__utils/useSortBasedOnDOMPosition.ts
@@ -1,0 +1,54 @@
+import * as React from "react";
+import { sortBasedOnDOMPosition } from "./sortBasedOnDOMPosition";
+import { Item } from "./types";
+
+type SetItems = (items: Item[]) => void;
+
+function setItemsBasedOnDOMPosition(items: Item[], setItems: SetItems) {
+  const sortedItems = sortBasedOnDOMPosition(items);
+  if (items !== sortedItems) {
+    setItems(sortedItems);
+  }
+}
+
+function useIntersectionObserver(items: Item[], setItems: SetItems) {
+  const previousItems = React.useRef<typeof items>([]);
+
+  React.useEffect(() => {
+    const callback = () => {
+      const hasPreviousItems = !!previousItems.current.length;
+      // We don't want to sort items if items have been just registered.
+      if (hasPreviousItems) {
+        setItemsBasedOnDOMPosition(items, setItems);
+      }
+      previousItems.current = items;
+    };
+    const observer = new IntersectionObserver(callback, {
+      root: document.body,
+    });
+    for (const item of items) {
+      if (item.ref.current) {
+        observer.observe(item.ref.current);
+      }
+    }
+    return () => {
+      observer.disconnect();
+    };
+  }, [items]);
+}
+
+function useTimeoutObserver(items: Item[], setItems: SetItems) {
+  React.useEffect(() => {
+    const callback = () => setItemsBasedOnDOMPosition(items, setItems);
+    const timeout = setTimeout(callback, 250);
+    return () => clearTimeout(timeout);
+  });
+}
+
+export function useSortBasedOnDOMPosition(items: Item[], setItems: SetItems) {
+  if (typeof IntersectionObserver === "function") {
+    useIntersectionObserver(items, setItems);
+  } else {
+    useTimeoutObserver(items, setItems);
+  }
+}


### PR DESCRIPTION
This PR makes use of [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) (when it's available) to detect changes in the order of composite items in the DOM so it can automatically sort the array of items in the composite state.

See https://deploy-preview-696--reakit.netlify.app/storybook/?path=/story/composite--dynamic-composite

**Does this PR introduce a breaking change?**

No.
  
<!-- For new features, components, APIs use `next` branch as target. For bugfixes PR could be targeted to `master` directly -->