### PR TITLE
Dev warning if disclosure stopAnimation uncalled

### DIFF
--- a/packages/reakit/src/Disclosure/DisclosureState.ts
+++ b/packages/reakit/src/Disclosure/DisclosureState.ts
@@ -98,6 +98,15 @@ export function useDisclosureState(
   React.useEffect(() => {
     if (typeof animated === "number" && animating) {
       setTimeout(() => setAnimating(false), animated);
+      return;
+    }
+    if (process.env.NODE_ENV === 'development' && animating) {
+      const timeout = setInterval(() => {
+        console.warn("[Reakit] It's been 8 seconds but stopAnimation has not been called. Does the discolusure element have a CSS transition?")
+      }, 8000)
+      return () => {
+        clearTimeout(timeout)
+      }
     }
   }, [animated, animating]);
 

--- a/packages/reakit/src/Disclosure/DisclosureState.ts
+++ b/packages/reakit/src/Disclosure/DisclosureState.ts
@@ -102,7 +102,8 @@ export function useDisclosureState(
     }
     if (process.env.NODE_ENV === 'development' && animating) {
       const timeout = setInterval(() => {
-        console.warn("[Reakit] It's been 8 seconds but stopAnimation has not been called. Does the discolusure element have a CSS transition?")
+        console.warn("[Reakit] It's been 8 seconds but stopAnimation has not been called. Does the discolusure element have a CSS transition?");
+        setAnimating(false);
       }, 8000)
       return () => {
         clearTimeout(timeout)

--- a/packages/reakit/src/Disclosure/DisclosureState.ts
+++ b/packages/reakit/src/Disclosure/DisclosureState.ts
@@ -4,6 +4,7 @@ import {
   SealedInitialState,
 } from "reakit-utils/useSealedState";
 import { useIsomorphicEffect } from "reakit-utils/useIsomorphicEffect";
+import { warning } from "reakit-warning";
 import {
   unstable_IdState,
   unstable_IdActions,
@@ -97,15 +98,17 @@ export function useDisclosureState(
 
   React.useEffect(() => {
     if (typeof animated === "number" && animating) {
-      setTimeout(() => setAnimating(false), animated);
-      return () => {};
+      const timeout = setTimeout(() => setAnimating(false), animated);
+      return () => {
+        clearTimeout(timeout);
+      };
     }
     if (animated && animating && process.env.NODE_ENV === "development") {
-      const timeout = setInterval(() => {
-        console.warn(
-          "[Reakit] It's been 8 seconds but stopAnimation has not been called. Does the discolusure element have a CSS transition?"
+      const timeout = setTimeout(() => {
+        warning(
+          animating,
+          "It's been 8 seconds but stopAnimation has not been called. Does the disclousure element have a CSS transition?"
         );
-        setAnimating(false);
       }, 8000);
       return () => {
         clearTimeout(timeout);

--- a/packages/reakit/src/Disclosure/DisclosureState.ts
+++ b/packages/reakit/src/Disclosure/DisclosureState.ts
@@ -100,15 +100,16 @@ export function useDisclosureState(
       setTimeout(() => setAnimating(false), animated);
       return;
     }
-    if (process.env.NODE_ENV === 'development' && animating) {
+    if (process.env.NODE_ENV === "development" && animating) {
       const timeout = setInterval(() => {
         console.warn("[Reakit] It's been 8 seconds but stopAnimation has not been called. Does the discolusure element have a CSS transition?");
         setAnimating(false);
-      }, 8000)
+      }, 8000);
       return () => {
-        clearTimeout(timeout)
-      }
+        clearTimeout(timeout);
+      };
     }
+    return;
   }, [animated, animating]);
 
   const show = React.useCallback(() => setVisible(true), []);

--- a/packages/reakit/src/Disclosure/DisclosureState.ts
+++ b/packages/reakit/src/Disclosure/DisclosureState.ts
@@ -98,18 +98,20 @@ export function useDisclosureState(
   React.useEffect(() => {
     if (typeof animated === "number" && animating) {
       setTimeout(() => setAnimating(false), animated);
-      return;
+      return () => {};
     }
-    if (process.env.NODE_ENV === "development" && animating) {
+    if (animated && animating && process.env.NODE_ENV === "development") {
       const timeout = setInterval(() => {
-        console.warn("[Reakit] It's been 8 seconds but stopAnimation has not been called. Does the discolusure element have a CSS transition?");
+        console.warn(
+          "[Reakit] It's been 8 seconds but stopAnimation has not been called. Does the discolusure element have a CSS transition?"
+        );
         setAnimating(false);
       }, 8000);
       return () => {
         clearTimeout(timeout);
       };
     }
-    return;
+    return () => {};
   }, [animated, animating]);
 
   const show = React.useCallback(() => setVisible(true), []);


### PR DESCRIPTION
Explain the motivation for making this change and try to link to an open issue for more information.

Example: Closes #698

No breaking changes, just an additional warning in dev environment

Super late night PR written in the GitHub editor. I'm sure that method for detecting env and copy for warning will need to be tweaked. I haven't tested it yet because it's late. Depending on the build process I'll see if I can make time tomorrow.