### PR TITLE
chore: Add registry to npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-exact = true
+registry = https://registry.yarnpkg.com


### PR DESCRIPTION
I just got caught out by this on my work machine as it's setup with our private registry configured in the global config.