### PR TITLE
Assert `focus` attribute exists on the target element

### DIFF
--- a/packages/reakit/src/Dialog/__utils/useDisclosureRef.ts
+++ b/packages/reakit/src/Dialog/__utils/useDisclosureRef.ts
@@ -14,9 +14,11 @@ export function useDisclosureRef(
     // focus back to it when the dialog closes.
     const onFocus = (event: FocusEvent) => {
       const target = event.target as HTMLElement;
-      ref.current = target;
-      if (options.unstable_disclosureRef) {
-        options.unstable_disclosureRef.current = target;
+      if ("focus" in target) {
+        ref.current = target;
+        if (options.unstable_disclosureRef) {
+          options.unstable_disclosureRef.current = target;
+        }
       }
     };
     const document = getDocument(dialogRef.current);


### PR DESCRIPTION
Fixes issue where Firefox users were encountering a `element.focus is not a function` error.

Ref: https://github.com/bumbag/bumbag-ui/issues/33 