### PR TITLE
fix: Fix intermediate `focus`/`blur` event order in `Composite`

### DIFF
--- a/packages/reakit/src/Composite/Composite.ts
+++ b/packages/reakit/src/Composite/Composite.ts
@@ -140,7 +140,7 @@ export const useComposite = createHook<CompositeOptions, CompositeHTMLProps>({
   ) {
     const ref = React.useRef<HTMLElement>(null);
     const currentItem = findEnabledItemById(options.items, options.currentId);
-    const previousItem = React.useRef<HTMLElement | null>(null);
+    const previousElementRef = React.useRef<HTMLElement | null>(null);
     const onFocusRef = useLiveRef(htmlOnFocus);
     const onBlurRef = useLiveRef(htmlOnBlur);
     // IE 11 doesn't support event.relatedTarget, so we use the active element
@@ -262,16 +262,16 @@ export const useComposite = createHook<CompositeOptions, CompositeHTMLProps>({
               // on an item other than the current one doesn't end up here as
               // the currentItem state will be updated only after it.
               if (
-                previousItem.current &&
-                previousItem.current !== nextActiveElement
+                previousElementRef.current &&
+                previousElementRef.current !== nextActiveElement
               ) {
                 // If there's a previous active item and it's not a click
                 // action, then we fire a blur event on it so it will work just
                 // like if it had DOM focus before (like when using roving
                 // tabindex).
-                fireBlurEvent(previousItem.current, event);
+                fireBlurEvent(previousElementRef.current, event);
               }
-              previousItem.current = currentElement;
+              previousElementRef.current = currentElement;
             } else if (currentElement) {
               // This will be true when the next active element is not the
               // current element, but there's a current item. This will only
@@ -280,7 +280,7 @@ export const useComposite = createHook<CompositeOptions, CompositeHTMLProps>({
               // is the item that is getting blurred, and nextActiveElement is
               // the item that is being clicked.
               fireBlurEvent(currentElement, event);
-              previousItem.current = nextActiveElement;
+              previousElementRef.current = nextActiveElement;
             }
             // We want to ignore intermediate blur events, so we stop its
             // propagation and return early so onFocus will not be called.

--- a/packages/reakit/src/Composite/Composite.ts
+++ b/packages/reakit/src/Composite/Composite.ts
@@ -140,7 +140,7 @@ export const useComposite = createHook<CompositeOptions, CompositeHTMLProps>({
   ) {
     const ref = React.useRef<HTMLElement>(null);
     const currentItem = findEnabledItemById(options.items, options.currentId);
-    const previousItem = React.useRef<Item | undefined>(undefined);
+    const previousItem = React.useRef<HTMLElement | null>(null);
     const onFocusRef = useLiveRef(htmlOnFocus);
     const onBlurRef = useLiveRef(htmlOnBlur);
     // IE 11 doesn't support event.relatedTarget, so we use the active element
@@ -179,6 +179,7 @@ export const useComposite = createHook<CompositeOptions, CompositeHTMLProps>({
     const onFocus = React.useCallback(
       (event: React.FocusEvent) => {
         if (options.unstable_virtual) {
+          const currentElement = currentItem?.ref.current || null;
           // IE11 doesn't support event.relatedTarget, so we use the active
           // element ref instead.
           const previousActiveElement =
@@ -197,7 +198,7 @@ export const useComposite = createHook<CompositeOptions, CompositeHTMLProps>({
             // on the composite element, in which case hasItemWithFocus will be
             // true.
             onFocusRef.current?.(event);
-            currentItem?.ref.current?.focus();
+            currentElement?.focus();
             return;
           }
           if (previousActiveElementWasItem) {
@@ -240,7 +241,7 @@ export const useComposite = createHook<CompositeOptions, CompositeHTMLProps>({
         // confusing, so we ignore intermediate focus and blurs by stopping its
         // propagation and not calling the passed onBlur handler (htmlOnBlur).
         if (options.unstable_virtual) {
-          const targetIsItem = isItem(options.items, event.target);
+          const currentElement = currentItem?.ref.current || null;
           const nextActiveElement = getNextActiveElementOnBlur(event);
           const nextActiveElementIsItem = isItem(
             options.items,
@@ -248,28 +249,52 @@ export const useComposite = createHook<CompositeOptions, CompositeHTMLProps>({
           );
           if (isSelfTarget(event) && nextActiveElementIsItem) {
             // This is an intermediate blur event: blurring the composite
-            // container to focus an item (nextActiveElement). We ignore this
-            // event.
-            if (previousItem.current?.ref.current) {
-              // If there's a previous active item we fire a blur event on it
-              // so it will work just like if it had DOM focus before (like when
-              // using roving tabindex).
-              fireBlurEvent(previousItem.current.ref.current, event);
+            // container to focus an item (nextActiveElement).
+            if (nextActiveElement === currentElement) {
+              // The next active element will be the same as the current item
+              // in the state in two scenarios:
+              //   - Moving focus with keyboard: the state is updated before
+              // the blur event is triggered, so here the current item is
+              // already pointing to the next active element.
+              //   - Clicking on the current active item with a pointer: this
+              // will trigger blur on the composite element and then the next
+              // active element will be the same as the current item. Clicking
+              // on an item other than the current one doesn't end up here as
+              // the currentItem state will be updated only after it.
+              if (
+                previousItem.current &&
+                previousItem.current !== nextActiveElement
+              ) {
+                // If there's a previous active item and it's not a click
+                // action, then we fire a blur event on it so it will work just
+                // like if it had DOM focus before (like when using roving
+                // tabindex).
+                fireBlurEvent(previousItem.current, event);
+              }
+              previousItem.current = currentElement;
+            } else if (currentElement) {
+              // This will be true when the next active element is not the
+              // current element, but there's a current item. This will only
+              // happen when clicking with a pointer on a different item, when
+              // there's already an item selected, in which case currentElement
+              // is the item that is getting blurred, and nextActiveElement is
+              // the item that is being clicked.
+              fireBlurEvent(currentElement, event);
+              previousItem.current = nextActiveElement;
             }
-            previousItem.current = currentItem;
+            // We want to ignore intermediate blur events, so we stop its
+            // propagation and return early so onFocus will not be called.
             event.stopPropagation();
             return;
           }
-          if (!targetIsItem) {
-            // If target is another thing (probably something outside of the
-            // composite container), we don't ignore the event, but we should
-            // reset the previousItem reference.
-            if (currentItem?.ref.current) {
-              fireBlurEvent(currentItem.ref.current, event);
-            }
-            previousItem.current = undefined;
-          } else {
-            previousItem.current = currentItem;
+          const targetIsItem = isItem(options.items, event.target);
+          if (!targetIsItem && currentElement) {
+            // If target is not a composite item, it may be the composite
+            // element itself (isSelfTarget) or a tabbable element inside the
+            // composite widget. This may be triggered by clicking outside the
+            // composite widget or by tabbing out of it. In either cases we
+            // want to fire a blur event on the current item.
+            fireBlurEvent(currentElement, event);
           }
         }
         onBlurRef.current?.(event);

--- a/packages/reakit/src/Composite/__examples__/VirtualCompositeWithFocusBlur/__tests__/index-test.tsx
+++ b/packages/reakit/src/Composite/__examples__/VirtualCompositeWithFocusBlur/__tests__/index-test.tsx
@@ -1,0 +1,139 @@
+import * as React from "react";
+import { render, press, click, screen } from "reakit-test-utils";
+import VirtualCompositeWithFocusBlur from "..";
+
+test("focus/blur on virtual composite with mouse click", () => {
+  const { baseElement } = render(<VirtualCompositeWithFocusBlur />);
+  click(screen.getByText("item-2"));
+  click(screen.getByText("item-3"));
+  click(screen.getByText("item-6"));
+  click(screen.getByText("item-6"));
+  click(baseElement);
+  expect(screen.getByRole("log")).toMatchInlineSnapshot(`
+    <div
+      role="log"
+    >
+      <ul>
+        <li>
+          focus item-2
+        </li>
+        <li>
+          focus container - item-2
+        </li>
+        <li>
+          blur item-2
+        </li>
+        <li>
+          blur container - item-2
+        </li>
+        <li>
+          focus item-3
+        </li>
+        <li>
+          focus container - item-3
+        </li>
+        <li>
+          blur item-3
+        </li>
+        <li>
+          blur container - item-3
+        </li>
+        <li>
+          focus item-6
+        </li>
+        <li>
+          focus container - item-6
+        </li>
+        <li>
+          focus item-6
+        </li>
+        <li>
+          focus container - item-6
+        </li>
+        <li>
+          blur item-6
+        </li>
+        <li>
+          blur container - item-6
+        </li>
+        <li>
+          blur container
+        </li>
+      </ul>
+    </div>
+  `);
+});
+
+test("focus/blur on virtual composite with keyboard", () => {
+  render(<VirtualCompositeWithFocusBlur />);
+  press.Tab();
+  press.ArrowDown();
+  press.End();
+  press.ArrowUp();
+  press.Home();
+  expect(screen.getByRole("log")).toMatchInlineSnapshot(`
+    <div
+      role="log"
+    >
+      <ul>
+        <li>
+          focus container
+        </li>
+        <li>
+          focus item-0
+        </li>
+        <li>
+          focus container - item-0
+        </li>
+        <li>
+          blur item-0
+        </li>
+        <li>
+          blur container - item-0
+        </li>
+        <li>
+          focus item-1
+        </li>
+        <li>
+          focus container - item-1
+        </li>
+        <li>
+          blur item-1
+        </li>
+        <li>
+          blur container - item-1
+        </li>
+        <li>
+          focus item-9
+        </li>
+        <li>
+          focus container - item-9
+        </li>
+        <li>
+          blur item-9
+        </li>
+        <li>
+          blur container - item-9
+        </li>
+        <li>
+          focus item-8
+        </li>
+        <li>
+          focus container - item-8
+        </li>
+        <li>
+          blur item-8
+        </li>
+        <li>
+          blur container - item-8
+        </li>
+        <li>
+          focus item-0
+        </li>
+        <li>
+          focus container - item-0
+        </li>
+      </ul>
+    </div>
+  `);
+});

--- a/packages/reakit/src/Composite/__examples__/VirtualCompositeWithFocusBlur/index.tsx
+++ b/packages/reakit/src/Composite/__examples__/VirtualCompositeWithFocusBlur/index.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { useCompositeState, Composite, CompositeItem } from "reakit/Composite";
+
+export default function VirtualCompositeWithFocusBlur() {
+  const composite = useCompositeState({ unstable_virtual: true });
+  const [events, setEvents] = React.useState<string[]>([]);
+  const onContainerEvent = React.useCallback((event: React.FocusEvent) => {
+    const { type, currentTarget, target } = event;
+    const isContainer = currentTarget === target;
+    const textContent = isContainer ? "" : ` - ${target.textContent}`;
+    setEvents((prevEvents) => [
+      ...prevEvents,
+      `${type} container${textContent}`,
+    ]);
+  }, []);
+  const onItemEvent = React.useCallback((event: React.FocusEvent) => {
+    const { type, currentTarget } = event;
+    setEvents((prevEvents) => [
+      ...prevEvents,
+      `${type} ${currentTarget.textContent}`,
+    ]);
+  }, []);
+  return (
+    <>
+      <Composite
+        {...composite}
+        as="ul"
+        role="listbox"
+        aria-label="Items"
+        onFocus={onContainerEvent}
+        onBlur={onContainerEvent}
+      >
+        {Array.from({ length: 10 }).map((_, i) => (
+          <CompositeItem
+            {...composite}
+            onBlur={onItemEvent}
+            onFocus={onItemEvent}
+            key={i}
+            as="li"
+            role="option"
+          >{`item-${i}`}</CompositeItem>
+        ))}
+      </Composite>
+      <div role="log">
+        <ul>
+          {events.map((event, i) => (
+            <li key={i}>{event}</li>
+          ))}
+        </ul>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
While working on #711, I noticed that the order that `focus`/`blur` events were triggered on `Composite` elements (with `unstable_virtual` set to `true`) were incorrect when using a pointer to click.

This PR fixes it.

Failing test: https://github.com/reakit/reakit/runs/989811378#step:11:504

**Does this PR introduce a breaking change?**

No