### PR TITLE
chore: Allow manual triggering of react-next pipeline

### DIFF
--- a/.github/workflows/react-next.yml
+++ b/.github/workflows/react-next.yml
@@ -1,9 +1,10 @@
 name: react-next
 
 on:
+  workflow_dispatch: true
   schedule:
-    # Runs at 00:00 UTC every day
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *'  # Runs at 00:00 UTC every day
+  
 
 jobs:
   test:

--- a/.github/workflows/react-next.yml
+++ b/.github/workflows/react-next.yml
@@ -1,7 +1,7 @@
 name: react-next
 
 on:
-  workflow_dispatch: true
+  workflow_dispatch: {}
   schedule:
     - cron: '0 0 * * *'  # Runs at 00:00 UTC every day
   

--- a/.github/workflows/react-next.yml
+++ b/.github/workflows/react-next.yml
@@ -1,7 +1,7 @@
 name: react-next
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'  # Runs at 00:00 UTC every day
   


### PR DESCRIPTION
This _should_ show a button to allow you to manually trigger the workflow.

See https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/