### PR TITLE
fix: Change SSR-check to test the same way React does

### DIFF
--- a/packages/reakit-playground/src/PlaygroundEditor.tsx
+++ b/packages/reakit-playground/src/PlaygroundEditor.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Controlled as CodeMirror } from "react-codemirror2";
 import { useOptions, useProps } from "reakit-system";
-import { useLiveRef } from "reakit-utils";
+import { useLiveRef, canUseDOM } from "reakit-utils";
 import { PlaygroundActions, PlaygroundStateReturn } from "./usePlaygroundState";
 
 if (typeof navigator !== "undefined") {
@@ -96,7 +96,7 @@ export function PlaygroundEditor({
 
   const value = options.readOnly ? options.code.trim() : options.code;
 
-  if (typeof window === "undefined" || !ready) {
+  if (!canUseDOM || !ready) {
     return (
       <pre className={className}>{options.readOnly ? value : `${value}\n`}</pre>
     );

--- a/packages/reakit-playground/src/__deps/reakit-utils.ts
+++ b/packages/reakit-playground/src/__deps/reakit-utils.ts
@@ -3,6 +3,7 @@
 export default {
   "reakit-utils": require("reakit-utils"),
   "reakit-utils/applyState": require("reakit-utils/applyState"),
+  "reakit-utils/canUseDOM": require("reakit-utils/canUseDOM"),
   "reakit-utils/closest": require("reakit-utils/closest"),
   "reakit-utils/contains": require("reakit-utils/contains"),
   "reakit-utils/createEvent": require("reakit-utils/createEvent"),

--- a/packages/reakit-utils/.gitignore
+++ b/packages/reakit-utils/.gitignore
@@ -1,5 +1,6 @@
 # Automatically generated
 /applyState
+/canUseDOM
 /closest
 /contains
 /createEvent

--- a/packages/reakit-utils/README.md
+++ b/packages/reakit-utils/README.md
@@ -25,6 +25,7 @@ yarn add reakit-utils
 #### Table of Contents
 
 -   [applyState](#applystate)
+-   [canUseDOM](#canusedom)
 -   [closest](#closest)
 -   [contains](#contains)
 -   [createEvent](#createevent)
@@ -82,6 +83,18 @@ import { applyState } from "reakit-utils";
 
 applyState((value) => value + 1, 1); // 2
 applyState(2, 1); // 2
+```
+
+### canUseDOM
+
+Returns `true` if it is running in a browser environment or `false` if it is not (SSR).
+
+#### Examples
+
+```javascript
+import { canUseDOM } from "reakit-utils";
+
+const title = canUseDOM ? document.title : "";
 ```
 
 ### closest

--- a/packages/reakit-utils/README.md
+++ b/packages/reakit-utils/README.md
@@ -89,6 +89,8 @@ applyState(2, 1); // 2
 
 Returns `true` if it is running in a browser environment or `false` if it is not (SSR).
 
+Type: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)
+
 #### Examples
 
 ```javascript

--- a/packages/reakit-utils/README.md
+++ b/packages/reakit-utils/README.md
@@ -87,7 +87,7 @@ applyState(2, 1); // 2
 
 ### canUseDOM
 
-Returns `true` if it is running in a browser environment or `false` if it is not (SSR).
+It's `true` if it is running in a browser environment or `false` if it is not (SSR).
 
 Type: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)
 

--- a/packages/reakit-utils/src/canUseDOM.ts
+++ b/packages/reakit-utils/src/canUseDOM.ts
@@ -1,5 +1,5 @@
 /**
- * Returns `true` if it is running in a browser environment or `false` if it is not (SSR).
+ * It's `true` if it is running in a browser environment or `false` if it is not (SSR).
  *
  * @example
  * import { canUseDOM } from "reakit-utils";

--- a/packages/reakit-utils/src/canUseDOM.ts
+++ b/packages/reakit-utils/src/canUseDOM.ts
@@ -1,3 +1,11 @@
+/**
+ * Returns `true` if it is running in a browser environment or `false` if it is not (SSR).
+ *
+ * @example
+ * import { canUseDOM } from "reakit-utils";
+ *
+ * const title = canUseDOM ? document.title : "";
+ */
 export const canUseDOM: boolean = !!(
   typeof window !== "undefined" &&
   typeof window.document !== "undefined" &&

--- a/packages/reakit-utils/src/canUseDOM.ts
+++ b/packages/reakit-utils/src/canUseDOM.ts
@@ -1,0 +1,5 @@
+export const canUseDOM: boolean = !!(
+  typeof window !== "undefined" &&
+  typeof window.document !== "undefined" &&
+  typeof window.document.createElement !== "undefined"
+);

--- a/packages/reakit-utils/src/getNextActiveElementOnBlur.ts
+++ b/packages/reakit-utils/src/getNextActiveElementOnBlur.ts
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { getActiveElement } from "./getActiveElement";
+import { canUseDOM } from "./canUseDOM";
 
-const isIE11 = typeof window !== "undefined" && "msCrypto" in window;
+const isIE11 = canUseDOM && "msCrypto" in window;
 
 /**
  * Cross-browser method that returns the next active element (the element that

--- a/packages/reakit-utils/src/index.ts
+++ b/packages/reakit-utils/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./applyState";
+export * from "./canUseDOM";
 export * from "./closest";
 export * from "./contains";
 export * from "./createEvent";

--- a/packages/reakit-utils/src/useIsomorphicEffect.ts
+++ b/packages/reakit-utils/src/useIsomorphicEffect.ts
@@ -1,8 +1,10 @@
 import * as React from "react";
+import { canUseDOM } from "./canUseDOM";
 
 /**
  * `React.useLayoutEffect` that fallbacks to `React.useEffect` on server side
  * rendering.
  */
-export const useIsomorphicEffect =
-  typeof window === "undefined" ? React.useEffect : React.useLayoutEffect;
+export const useIsomorphicEffect = !canUseDOM
+  ? React.useEffect
+  : React.useLayoutEffect;

--- a/packages/reakit/src/Composite/Composite.ts
+++ b/packages/reakit/src/Composite/Composite.ts
@@ -10,6 +10,7 @@ import { fireBlurEvent } from "reakit-utils/fireBlurEvent";
 import { fireKeyboardEvent } from "reakit-utils/fireKeyboardEvent";
 import { isSelfTarget } from "reakit-utils/isSelfTarget";
 import { useLiveRef } from "reakit-utils/useLiveRef";
+import { canUseDOM } from "reakit-utils/canUseDOM";
 import { getNextActiveElementOnBlur } from "reakit-utils/getNextActiveElementOnBlur";
 import { useTabbable, TabbableOptions, TabbableHTMLProps } from "../Tabbable";
 import { useBox } from "../Box/Box";
@@ -56,7 +57,7 @@ const validCompositeRoles = [
   "treegrid",
 ];
 
-const isIE11 = typeof window !== "undefined" && "msCrypto" in window;
+const isIE11 = canUseDOM && "msCrypto" in window;
 
 function canProxyKeyboardEvent(event: React.KeyboardEvent) {
   if (!isSelfTarget(event)) return false;

--- a/packages/reakit/src/Portal/Portal.tsx
+++ b/packages/reakit/src/Portal/Portal.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { useIsomorphicEffect } from "reakit-utils/useIsomorphicEffect";
+import { canUseDOM } from "reakit-utils/canUseDOM";
 
 export type PortalProps = {
   /**
@@ -10,7 +11,7 @@ export type PortalProps = {
 };
 
 function getBodyElement() {
-  return typeof document !== "undefined" ? document.body : null;
+  return canUseDOM ? document.body : null;
 }
 
 export const PortalContext = React.createContext<HTMLElement | null>(
@@ -23,7 +24,7 @@ export function Portal({ children }: PortalProps) {
   // https://github.com/reakit/reakit/issues/513
   const context = React.useContext(PortalContext) || getBodyElement();
   const [hostNode] = React.useState(() => {
-    if (typeof document !== "undefined") {
+    if (canUseDOM) {
       const element = document.createElement("div");
       element.className = Portal.__className;
       return element;

--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -9,6 +9,7 @@ import { hasFocusWithin } from "reakit-utils/hasFocusWithin";
 import { isButton } from "reakit-utils/isButton";
 import { isPortalEvent } from "reakit-utils/isPortalEvent";
 import { getActiveElement } from "reakit-utils/getActiveElement";
+import { canUseDOM } from "reakit-utils/canUseDOM";
 import { getClosestFocusable } from "reakit-utils/tabbable";
 import { BoxOptions, BoxHTMLProps, useBox } from "../Box/Box";
 import { TABBABLE_KEYS } from "./__keys";
@@ -33,7 +34,7 @@ export type TabbableHTMLProps = BoxHTMLProps & {
 export type TabbableProps = TabbableOptions & TabbableHTMLProps;
 
 function isUA(string: string) {
-  if (typeof window === "undefined") return false;
+  if (!canUseDOM) return false;
   return window.navigator.userAgent.indexOf(string) !== -1;
 }
 


### PR DESCRIPTION
Add a new utils called `canUseDOM` that uses the same SSR check that React does:
https://github.com/facebook/react/blob/1eb2b892dfffedfdb57039ef715fc7049f4d538a/packages/shared/ExecutionEnvironment.js

I had some issues with SSR with the current check (`typeof window === 'undefined'`), changing to this made it work. 


**Screenshots**

n/a

**How to test?**

I didn't manage to create a standalone repo to reproduce the issue. I've tried to use Next but it didn't happen in its SSR, might be due to some Webpack config I have. 

**Does this PR introduce breaking changes?**

Nope.
