### PR TITLE
chore: Check build files are checked in as part of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,10 @@ jobs:
     - name: Test
       run: yarn test --coverage
 
+    - name: Check build output is checked in
+      run: node ./scripts/build/check.js
+
     - name: Upload coverage to Codecov
-      env: 
+      env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: bash <(curl -s https://codecov.io/bash)

--- a/scripts/build/check.js
+++ b/scripts/build/check.js
@@ -1,4 +1,5 @@
 const { execSync } = require("child_process");
+const log = require("../log");
 
 const ALLOW_LIST = ["yarn.lock"];
 
@@ -14,11 +15,11 @@ function getModifiedFiles() {
 const modifiedFiles = getModifiedFiles();
 
 if (modifiedFiles.length === 0) {
-  console.log("Looks great!");
+  log("Looks great!");
   process.exit(0);
 }
 
-console.error(
+log(
   `${
     "here are modified files after running the build, did you forget to checkin after building?\n\n" +
     "Files changed:\n"

--- a/scripts/build/check.js
+++ b/scripts/build/check.js
@@ -1,0 +1,28 @@
+const { execSync } = require("child_process");
+
+const ALLOW_LIST = ["yarn.lock"];
+
+function getModifiedFiles() {
+  const statusOutput = execSync("git status --short").toString();
+
+  return statusOutput
+    .split("\n")
+    .filter((file) => file.length > 0 && !ALLOW_LIST.includes(file))
+    .map((file) => file.slice(3));
+}
+
+const modifiedFiles = getModifiedFiles();
+
+if (modifiedFiles.length === 0) {
+  console.log("Looks great!");
+  process.exit(0);
+}
+
+console.error(
+  `${
+    "here are modified files after running the build, did you forget to checkin after building?\n\n" +
+    "Files changed:\n"
+  }${modifiedFiles.join("\n")}`
+);
+
+process.exit(1);

--- a/scripts/build/check.js
+++ b/scripts/build/check.js
@@ -6,10 +6,14 @@ const ALLOW_LIST = ["yarn.lock"];
 function getModifiedFiles() {
   const statusOutput = execSync("git status --short").toString();
 
-  return statusOutput
-    .split("\n")
-    .filter((file) => file.length > 0 && !ALLOW_LIST.includes(file))
-    .map((file) => file.slice(3));
+  return (
+    statusOutput
+      .split("\n")
+      .filter((file) => file.length > 0 && !ALLOW_LIST.includes(file))
+      // First two characters are flags to indicate what kind of change we are dealing with (added, modified, untracked)
+      // Third character is a space. We discard all three to just get the file path.
+      .map((file) => file.slice(3))
+  );
 }
 
 const modifiedFiles = getModifiedFiles();


### PR DESCRIPTION
From https://github.com/reakit/reakit/pull/717#pullrequestreview-470768441

I've added a quick script for checking if there are any modified files. Modified files indicate that `yarn build` was not run before pushing changes to exported modules.

I added a new module to reakit-utils and pushed the changes without running the build step, looks like it's working as intended: https://github.com/reakit/reakit/pull/718/checks?check_run_id=1005209400#step:12:6