### PR TITLE
fix: canUseDOM to support IE11 window object

### DIFF
--- a/packages/reakit-playground/src/__deps/reakit-utils.ts
+++ b/packages/reakit-playground/src/__deps/reakit-utils.ts
@@ -17,6 +17,7 @@ export default {
   "reakit-utils/getDefaultView": require("reakit-utils/getDefaultView"),
   "reakit-utils/getDocument": require("reakit-utils/getDocument"),
   "reakit-utils/getNextActiveElementOnBlur": require("reakit-utils/getNextActiveElementOnBlur"),
+  "reakit-utils/getWindow": require("reakit-utils/getWindow"),
   "reakit-utils/hasFocus": require("reakit-utils/hasFocus"),
   "reakit-utils/hasFocusWithin": require("reakit-utils/hasFocusWithin"),
   "reakit-utils/isButton": require("reakit-utils/isButton"),

--- a/packages/reakit-utils/.gitignore
+++ b/packages/reakit-utils/.gitignore
@@ -16,6 +16,7 @@
 /getDefaultView
 /getDocument
 /getNextActiveElementOnBlur
+/getWindow
 /hasFocus
 /hasFocusWithin
 /isButton

--- a/packages/reakit-utils/src/canUseDOM.ts
+++ b/packages/reakit-utils/src/canUseDOM.ts
@@ -1,3 +1,18 @@
+import { getWindow } from "./getWindow";
+
+/**
+ * Check if we can use the DOM. Useful for SSR purposes
+ */
+function checkIsBrowser() {
+  const _window = getWindow();
+
+  return Boolean(
+    typeof _window !== "undefined" &&
+      _window.document &&
+      _window.document.createElement
+  );
+}
+
 /**
  * It's `true` if it is running in a browser environment or `false` if it is not (SSR).
  *
@@ -6,8 +21,4 @@
  *
  * const title = canUseDOM ? document.title : "";
  */
-export const canUseDOM: boolean = !!(
-  typeof window !== "undefined" &&
-  typeof window.document !== "undefined" &&
-  typeof window.document.createElement !== "undefined"
-);
+export const canUseDOM = checkIsBrowser();

--- a/packages/reakit-utils/src/getWindow.ts
+++ b/packages/reakit-utils/src/getWindow.ts
@@ -1,0 +1,29 @@
+// Thanks to Fluent UI for doing the [research on IE11 memery leak](https://github.com/microsoft/fluentui/pull/9010#issuecomment-490768427)
+// and for creating this [utils](https://github.com/microsoft/fluentui/blob/f6af0479a54f17fd16b9616a62d6be38686a5c1e/packages/utilities/src/dom/getWindow.ts)
+
+let _window: Window | undefined;
+
+// Note: Accessing "window" in IE11 is somewhat expensive, and calling "typeof window"
+// hits a memory leak, whereas aliasing it and calling "typeof _window" does not.
+// Caching the window value at the file scope lets us minimize the impact.
+try {
+  _window = window;
+} catch (e) {
+  /* no-op */
+}
+
+/**
+ * Helper to get the window object. The helper will make sure to use a cached variable
+ * of "window", to avoid overhead and memory leaks in IE11. Note that in popup scenarios the
+ * window object won't match the "global" window object, and for these scenarios, you should
+ * pass in an element hosted within the popup.
+ *
+ * @public
+ */
+export function getWindow(element?: Element | null): Window | undefined {
+  if (typeof _window === "undefined") {
+    return undefined;
+  }
+
+  return element?.ownerDocument?.defaultView ?? _window;
+}


### PR DESCRIPTION
Add a new utils called `getWindow` that checks for `window` object including IE11 optimization as per [this discussion](https://github.com/reakit/reakit/pull/717#issuecomment-677644026)

**Screenshots**

n/a

**How to test?**

No IE to test, but this improvement is based on [testing done by others](https://github.com/microsoft/fluentui/pull/9010#issuecomment-490768427)

**Does this PR introduce breaking changes?**
