### PR TITLE
fix: Fix `Composite` with `shift` when using `PageUp`/`PageDown`

### DIFF
--- a/packages/reakit/src/Composite/CompositeState.ts
+++ b/packages/reakit/src/Composite/CompositeState.ts
@@ -319,11 +319,12 @@ function reducer(
     }
 
     case "down": {
+      const shouldShift = shift && !action.allTheWay;
       // First, we make sure groups have the same number of items by filling it
       // with disabled fake items. Then, we reorganize the items list so
       // [1-1, 1-2, 2-1, 2-2] becomes [1-1, 2-1, 1-2, 2-2].
       const verticalItems = verticalizeItems(
-        flatten(fillGroups(groupItems(items), currentId, shift))
+        flatten(fillGroups(groupItems(items), currentId, shouldShift))
       );
       const canLoop = loop && loop !== "horizontal";
       // Pressing down arrow key will only focus the composite element if loop
@@ -337,8 +338,9 @@ function reducer(
     }
 
     case "up": {
+      const shouldShift = shift && !action.allTheWay;
       const verticalItems = verticalizeItems(
-        reverse(flatten(fillGroups(groupItems(items), currentId, shift)))
+        reverse(flatten(fillGroups(groupItems(items), currentId, shouldShift)))
       );
       // If currentId is initially set to null, we'll always focus the
       // composite element when the up arrow key is pressed in the first row.

--- a/packages/reakit/src/Composite/__examples__/CompositeShift/__tests__/index-test.tsx
+++ b/packages/reakit/src/Composite/__examples__/CompositeShift/__tests__/index-test.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { render, press, axe } from "reakit-test-utils";
 import CompositeShift from "..";
 
-test("navigate through composite shift", () => {
+test("keyboard navigation", () => {
   const { getByText: text } = render(<CompositeShift />);
   press.Tab();
   expect(text("item-1-1")).toHaveFocus();
@@ -22,9 +22,19 @@ test("navigate through composite shift", () => {
   expect(text("item-3-4")).toHaveFocus();
   press.ArrowDown();
   expect(text("item-4-3")).toHaveFocus();
+  press.PageUp();
+  expect(text("item-1-3")).toHaveFocus();
+  press.ArrowDown();
+  press.ArrowDown();
+  press.End();
+  expect(text("item-3-4")).toHaveFocus();
+  press.PageDown();
+  expect(text("item-3-4")).toHaveFocus();
+  press.PageUp();
+  expect(text("item-3-4")).toHaveFocus();
 });
 
-test("renders with no a11y violations", async () => {
+test("a11y", async () => {
   const { baseElement } = render(<CompositeShift />);
   expect(await axe(baseElement)).toHaveNoViolations();
 });


### PR DESCRIPTION
This PR fixes the `shift` option on `useCompositeState`. On `master`/`next`, using `PageDown` and `PageUp` wouldn't work correctly.