### PR TITLE
docs: remove erroneous reference to modal Tooltip prop

### DIFF
--- a/packages/reakit/src/Tooltip/README.md
+++ b/packages/reakit/src/Tooltip/README.md
@@ -244,7 +244,7 @@ element.
 - **`unstable_portal`** <span title="Experimental">⚠️</span>
   <code>boolean | undefined</code>
 
-  Whether or not the dialog should be rendered within `Portal`.
+  Whether or not the tooltip should be rendered within `Portal`.
 
 <details><summary>5 state props</summary>
 

--- a/packages/reakit/src/Tooltip/README.md
+++ b/packages/reakit/src/Tooltip/README.md
@@ -245,7 +245,6 @@ element.
   <code>boolean | undefined</code>
 
   Whether or not the dialog should be rendered within `Portal`.
-It's `true` by default if `modal` is `true`.
 
 <details><summary>5 state props</summary>
 

--- a/packages/reakit/src/Tooltip/Tooltip.tsx
+++ b/packages/reakit/src/Tooltip/Tooltip.tsx
@@ -19,7 +19,7 @@ export type TooltipOptions = DisclosureContentOptions &
     "unstable_popoverRef" | "unstable_popoverStyles"
   > & {
     /**
-     * Whether or not the dialog should be rendered within `Portal`.
+     * Whether or not the tooltip should be rendered within `Portal`.
      */
     unstable_portal?: boolean;
   };

--- a/packages/reakit/src/Tooltip/Tooltip.tsx
+++ b/packages/reakit/src/Tooltip/Tooltip.tsx
@@ -20,7 +20,6 @@ export type TooltipOptions = DisclosureContentOptions &
   > & {
     /**
      * Whether or not the dialog should be rendered within `Portal`.
-     * It's `true` by default if `modal` is `true`.
      */
     unstable_portal?: boolean;
   };


### PR DESCRIPTION
As per our conversation on Twitter ✨ 

https://twitter.com/mattrothenberg/status/1311086235922857985