### PR TITLE
fix: Fix Composite `unstable_virtual` option on mobile devices

### DIFF
--- a/packages/reakit/src/Composite/CompositeState.ts
+++ b/packages/reakit/src/Composite/CompositeState.ts
@@ -453,6 +453,9 @@ function useIsUnmountedRef() {
   return isUnmountedRef;
 }
 
+const isMobile =
+  typeof window !== "undefined" && /Mobi/i.test(window.navigator.userAgent);
+
 export function useCompositeState(
   initialState: SealedInitialState<CompositeInitialState> = {}
 ): CompositeStateReturn {
@@ -467,6 +470,7 @@ export function useCompositeState(
     unstable_includesBaseElement,
     ...sealed
   } = useSealedState(initialState);
+  const hasVirtualFocus = !isMobile && virtual;
   const idState = unstable_useIdState(sealed);
   const [
     {
@@ -483,7 +487,7 @@ export function useCompositeState(
     },
     dispatch,
   ] = React.useReducer(reducer, {
-    unstable_virtual: virtual,
+    unstable_virtual: hasVirtualFocus,
     rtl,
     orientation,
     items: [],
@@ -496,7 +500,7 @@ export function useCompositeState(
     pastIds: [],
     unstable_includesBaseElement:
       unstable_includesBaseElement ?? currentId === null,
-    initialVirtual: virtual,
+    initialVirtual: hasVirtualFocus,
     initialRTL: rtl,
     initialOrientation: orientation,
     initialCurrentId: currentId,


### PR DESCRIPTION
After reading @devongovett's [tweet](https://twitter.com/devongovett/status/1312150515220799489) and testing our experimental Combobox component using iOS 14 + VoiceOver, I noticed that it was pretty much unusable (see the first part of the video below).

This is happening for two reasons:

1. We're programmatically moving the focus onto the composite container (the combobox input) when an option receives focus.
2. VoiceOver on iOS 14 doesn't seem to support the `aria-activedescendant` attribute as it does on desktop, so the virtual focus is ignored, and swiping right to move focus to the next option will keep selecting the first one as VoiceOver thinks the input is the current focus.

This PR disables virtual focus (`aria-activedescendant`) for mobile on all composite widgets, including combobox. After all, this behavior isn't really useful on mobile. Thus, combobox options get real DOM focus (see the second part of the video).

I still want to explore detecting arrow keystrokes instead as I see value in having this behavior when a physical keyboard is connected to mobile. I'll do more tests.

https://www.youtube.com/watch?v=YRkcWN9FTQ4

This can be tested here: https://deploy-preview-755--reakit.netlify.app/storybook/?path=/story/examples--combobox-list