### PR TITLE
Adds a section on using css modules for styling

### DIFF
--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -35,6 +35,19 @@ function Example() {
 }
 ```
 
+## CSS Modules
+
+Assuming you've set up CSS modules (default in create-react-app but easy to hand roll via [css-loader](https://webpack.js.org/loaders/css-loader/#modules)), you can simply import your css module and apply to `className`.
+
+```jsx static
+import { Button } from "reakit";
+import styles from "./Example.module.css";
+
+function Example() {
+  return <Button className={styles.buttonStyles}>Button</Button>;
+}
+```
+
 ## CSS in JS
 
 Example with emotion:


### PR DESCRIPTION
Hi @diegohaz here's the PR for doc update that includes the markdown for styling to include CSS modules.

**Screenshots**
I ran `yarn website` to test manually:

![image](https://user-images.githubusercontent.com/142403/95642820-de23ef80-0a5f-11eb-8bed-90ff68460bcd.png)
