### PR TITLE
Expose Grid in the documentation

### DIFF
--- a/packages/website/src/data/docs.yml
+++ b/packages/website/src/data/docs.yml
@@ -15,6 +15,7 @@
     - /docs/dialog/
     - /docs/disclosure/
     - /docs/form/
+    - /docs/grid/
     - /docs/group/
     - /docs/input/
     - /docs/menu/


### PR DESCRIPTION
Expose `Grid` in the documentation. It's experimental but the documentation looks good to go. It was accessible through direct link anyway.

**How to test?**
- `yarn website`
- Open website
- Make sure `Grid` is available in the documentation

**Does this PR introduce breaking changes?**
No