### PR TITLE
Examples: Dialog Sidebar

### DIFF
--- a/packages/reakit/src/Dialog/__examples__/DialogSidebar/__tests__/index-test.tsx
+++ b/packages/reakit/src/Dialog/__examples__/DialogSidebar/__tests__/index-test.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { click, screen, render, axe } from "reakit-test-utils";
+import DialogSidebar from "..";
+
+test("open dialog", () => {
+  render(<DialogSidebar />);
+  click(screen.getByText("toggle"));
+  expect(screen.getByText("sidebar")).toBeVisible();
+});
+
+test("a11y", async () => {
+  const { baseElement } = render(<DialogSidebar />);
+  expect(await axe(baseElement)).toHaveNoViolations();
+});

--- a/packages/reakit/src/Dialog/__examples__/DialogSidebar/index.tsx
+++ b/packages/reakit/src/Dialog/__examples__/DialogSidebar/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Button, ButtonProps } from "reakit/Button";
+import { Button } from "reakit/Button";
 import { useDialogState, Dialog, DialogDisclosure } from "reakit/Dialog";
 import { DialogBackdrop } from "reakit/Dialog/DialogBackdrop";
 

--- a/packages/reakit/src/Dialog/__examples__/DialogSidebar/index.tsx
+++ b/packages/reakit/src/Dialog/__examples__/DialogSidebar/index.tsx
@@ -1,7 +1,11 @@
 import * as React from "react";
 import { Button } from "reakit/Button";
-import { useDialogState, Dialog, DialogDisclosure } from "reakit/Dialog";
-import { DialogBackdrop } from "reakit/Dialog/DialogBackdrop";
+import {
+  useDialogState,
+  Dialog,
+  DialogDisclosure,
+  DialogBackdrop,
+} from "reakit/Dialog";
 
 export default function DialogSidebar() {
   const dialog = useDialogState();

--- a/packages/reakit/src/Dialog/__examples__/DialogSidebar/index.tsx
+++ b/packages/reakit/src/Dialog/__examples__/DialogSidebar/index.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+import { Button, ButtonProps } from "reakit/Button";
+import { useDialogState, Dialog, DialogDisclosure } from "reakit/Dialog";
+import { DialogBackdrop } from "reakit/Dialog/DialogBackdrop";
+
+export default function DialogSidebar() {
+  const dialog = useDialogState();
+  return (
+    <>
+      <DialogDisclosure {...dialog} as={Button} aria-label="Toggle Sidebar">
+        toggle
+      </DialogDisclosure>
+
+      <DialogBackdrop
+        {...dialog}
+        style={{
+          position: "fixed",
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          zIndex: 997,
+          backgroundColor: "rgb(0,0,0, 0.6)",
+        }}
+      >
+        <Dialog
+          {...dialog}
+          preventBodyScroll
+          style={{
+            position: "fixed",
+            top: 0,
+            left: 0,
+            width: "20vw",
+            height: "100vh",
+            overflow: "auto",
+            zIndex: 998,
+            backgroundColor: "transparent",
+          }}
+          aria-label="Sidebar"
+        >
+          <nav>
+            <div
+              style={{
+                position: "absolute",
+                top: 0,
+                right: 0,
+                bottom: 0,
+                width: "100%",
+                background: "#fff",
+                zIndex: 997,
+              }}
+            />
+            <div
+              style={{
+                zIndex: 999,
+                position: "absolute",
+                top: 100,
+                padding: "1em",
+              }}
+            >
+              sidebar
+              <Button onClick={dialog.hide}>Close</Button>
+            </div>
+          </nav>
+        </Dialog>
+      </DialogBackdrop>
+    </>
+  );
+}


### PR DESCRIPTION
An example of a sidebar menu using `<Dialog />`

From #626 discussion.

**Screenshots**

![image](https://user-images.githubusercontent.com/14146176/96475559-8e38eb80-120a-11eb-879b-da7b0d4d8532.png)

![image](https://user-images.githubusercontent.com/14146176/96475361-4fa33100-120a-11eb-9e2a-b11edba0f375.png)