### PR TITLE
Add state prop with backward compatibility

### DIFF
--- a/packages/reakit-playground/src/__deps/reakit-utils.ts
+++ b/packages/reakit-playground/src/__deps/reakit-utils.ts
@@ -29,6 +29,7 @@ export default {
   "reakit-utils/isSelfTarget": require("reakit-utils/isSelfTarget"),
   "reakit-utils/isTextField": require("reakit-utils/isTextField"),
   "reakit-utils/matches": require("reakit-utils/matches"),
+  "reakit-utils/normalizePropsAreEqual": require("reakit-utils/normalizePropsAreEqual"),
   "reakit-utils/omit": require("reakit-utils/omit"),
   "reakit-utils/pick": require("reakit-utils/pick"),
   "reakit-utils/removeIndexFromArray": require("reakit-utils/removeIndexFromArray"),

--- a/packages/reakit-system/src/__tests__/state-createComponent-test.tsx
+++ b/packages/reakit-system/src/__tests__/state-createComponent-test.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+import { render } from "reakit-test-utils";
+import { createComponent } from "../createComponent";
+
+test("as string", () => {
+  const useA = ({ a }: { a: string }) => ({ children: a });
+  const A = createComponent({ as: "div", useHook: useA });
+  const { getByText } = render(<A as="span" state={{ a: "a" }} />);
+  expect(getByText("a")).toMatchInlineSnapshot(`
+    <span>
+      a
+    </span>
+  `);
+});
+
+test("as component", () => {
+  const useA = ({ a }: { a: string }, htmlProps: any) => ({
+    children: a,
+    ...htmlProps,
+  });
+  const A = createComponent({ as: "div", useHook: useA });
+  const B = ({ b, state, ...props }: { state: any; b: string }) => (
+    <div id={b} {...props} />
+  );
+  const { getByText } = render(<A as={B} state={{ a: "a" }} b="b" />);
+  expect(getByText("a")).toMatchInlineSnapshot(`
+    <div
+      id="b"
+    >
+      a
+    </div>
+  `);
+});
+
+test("as generic component", () => {
+  const useA = ({ a }: { a: string }, htmlProps: any) => ({
+    children: a,
+    ...htmlProps,
+  });
+  const A = createComponent({ as: "div", useHook: useA });
+  function B<T extends string>({ b, state, ...props }: { state: any; b: T }) {
+    return <div id={b} {...props} />;
+  }
+  const { getByText } = render(<A as={B} state={{ a: "a" }} b="b" />);
+  expect(getByText("a")).toMatchInlineSnapshot(`
+    <div
+      id="b"
+    >
+      a
+    </div>
+  `);
+});
+
+test("as other component created with createComponent", () => {
+  const useA = ({ a }: { a: string }, h: any) => ({ children: a, ...h });
+  const A = createComponent({ as: "div", useHook: useA });
+
+  const useB = ({ b }: { b: string }, h: any) => ({ id: b, ...h });
+  const B = createComponent({ as: "div", useHook: useB });
+
+  const { getByText } = render(<A as={B} state={{ a: "a", b: "b" }} />);
+  expect(getByText("a")).toMatchInlineSnapshot(`
+            <div
+              id="b"
+            >
+              a
+            </div>
+      `);
+});
+
+test("wrap", () => {
+  const useA = (_: any, h: any) => ({
+    wrapElement: (element: React.ReactNode) => (
+      <div id="wrapper">{element}</div>
+    ),
+    ...h,
+  });
+  const A = createComponent({ as: "span", useHook: useA });
+  const { baseElement } = render(<A id="a">a</A>);
+  expect(baseElement).toMatchInlineSnapshot(`
+    <body>
+      <div>
+        <div
+          id="wrapper"
+        >
+          <span
+            id="a"
+          >
+            a
+          </span>
+        </div>
+      </div>
+    </body>
+  `);
+});

--- a/packages/reakit-system/src/createComponent.ts
+++ b/packages/reakit-system/src/createComponent.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import { As, PropsWithAs } from "reakit-utils/types";
 import { splitProps } from "reakit-utils/splitProps";
 import { shallowEqual } from "reakit-utils/shallowEqual";
+import { isPlainObject, normalizePropsAreEqual } from "reakit-utils";
 import { forwardRef } from "./__utils/forwardRef";
 import { useCreateElement as defaultUseCreateElement } from "./useCreateElement";
 import { memo } from "./__utils/memo";
@@ -72,9 +73,16 @@ export function createComponent<T extends As, O>({
       // @ts-ignore
       const asKeys = as.render?.__keys || as.__keys;
       const asOptions = asKeys && splitProps(props, asKeys)[0];
-      const allProps = asOptions
-        ? { ...elementProps, ...asOptions }
-        : elementProps;
+      const allProps =
+        // If `as` is a string, then that means it's an element not a component
+        // we don't need to pass the state in this case.
+        // If a component is passed, then the component can decide
+        // what should happen with the state prop.
+        isPlainObject(props.state) && typeof as !== "string"
+          ? { state: props.state, ...elementProps }
+          : asOptions
+          ? { ...elementProps, ...asOptions }
+          : elementProps;
       const element = useCreateElement(as, allProps as typeof props);
       if (wrapElement) {
         return wrapElement(element);
@@ -91,12 +99,14 @@ export function createComponent<T extends As, O>({
   Comp = forwardRef(Comp);
 
   if (shouldMemo) {
-    Comp = memo(Comp, propsAreEqual);
+    Comp = memo(Comp, propsAreEqual && normalizePropsAreEqual(propsAreEqual));
   }
 
   Comp.__keys = keys;
 
-  Comp.unstable_propsAreEqual = propsAreEqual || shallowEqual;
+  Comp.unstable_propsAreEqual = normalizePropsAreEqual(
+    propsAreEqual || shallowEqual
+  );
 
   return Comp;
 }

--- a/packages/reakit-utils/.gitignore
+++ b/packages/reakit-utils/.gitignore
@@ -29,6 +29,7 @@
 /isTextField
 /lib
 /matches
+/normalizePropsAreEqual
 /omit
 /pick
 /removeIndexFromArray

--- a/packages/reakit-utils/README.md
+++ b/packages/reakit-utils/README.md
@@ -51,11 +51,13 @@ yarn add reakit-utils
 -   [isSelfTarget](#isselftarget)
 -   [isTextField](#istextfield)
 -   [matches](#matches)
+-   [normalizePropsAreEqual](#normalizepropsareequal)
 -   [omit](#omit)
 -   [pick](#pick)
 -   [removeIndexFromArray](#removeindexfromarray)
 -   [removeItemFromArray](#removeitemfromarray)
 -   [shallowEqual](#shallowequal)
+-   [\_\_deprecatedSplitProps](#__deprecatedsplitprops)
 -   [splitProps](#splitprops)
 -   [tabbable](#tabbable)
 -   [toArray](#toarray)
@@ -523,6 +525,26 @@ Ponyfill for `Element.prototype.matches`
 
 Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
+### normalizePropsAreEqual
+
+This higher order functions take `propsAreEqual` function and
+returns a new function which normalizes the props.
+
+Normalizing in our case is making sure the `propsAreEqual` works with
+both version 1 (object spreading) and version 2 (state object) state passing.
+
+To achieve this, the returned function in case of a state object
+will spread the state object in both `prev` and \`next props.
+
+Other case it just returns the function as is which makes sure
+that we are still backward compatible
+
+#### Parameters
+
+-   `propsAreEqual` **function (prev: O, next: O): [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **function (prev: PropsWithAs&lt;O, T>, next: PropsWithAs&lt;O, T>): [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
 ### omit
 
 Omits specific keys from an object.
@@ -624,7 +646,7 @@ shallowEqual({ a: "a" }, { a: "a", b: "b" }); // false
 
 Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
-### splitProps
+### \_\_deprecatedSplitProps
 
 Splits an object (`props`) into a tuple where the first item is an object
 with the passed `keys`, and the second item is an object with these keys
@@ -641,6 +663,42 @@ omitted.
 import { splitProps } from "reakit-utils";
 
 splitProps({ a: "a", b: "b" }, ["a"]); // [{ a: "a" }, { b: "b" }]
+```
+
+Returns **\[any, Omit&lt;T, K>]** 
+
+**Meta**
+
+-   **deprecated**: will be removed in version 2
+
+
+### splitProps
+
+Splits an object (`props`) into a tuple where the first item
+is the `state` property, and the second item is the rest of the properties.
+
+It is also backward compatible with version 1. If `keys` are passed then
+splits an object (`props`) into a tuple where the first item is an object
+with the passed `keys`, and the second item is an object with these keys
+omitted.
+
+#### Parameters
+
+-   `props` **T** 
+-   `keys` **(ReadonlyArray&lt;K> | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;K>)?** 
+
+#### Examples
+
+```javascript
+import { splitProps } from "reakit-utils";
+
+splitProps({ a: "a", b: "b" }, ["a"]); // [{ a: "a" }, { b: "b" }]
+```
+
+```javascript
+import { splitProps } from "reakit-utils";
+
+splitProps({ state: { a: "a" }, b: "b" }); // [{ a: "a" }, { b: "b" }]
 ```
 
 Returns **\[any, Omit&lt;T, K>]** 

--- a/packages/reakit-utils/src/__tests__/normalizePropsAreEqual-test.ts
+++ b/packages/reakit-utils/src/__tests__/normalizePropsAreEqual-test.ts
@@ -10,6 +10,9 @@ function propsAreEqual(
 const normalized = normalizePropsAreEqual(propsAreEqual);
 
 test("normalizePropsAreEqual", () => {
+  expect(propsAreEqual).not.toStrictEqual(normalized);
+  expect(normalizePropsAreEqual(normalized)).toStrictEqual(normalized);
+
   expect(propsAreEqual({ a: "a" }, { a: "a" })).toBe(true);
   expect(propsAreEqual({ a: "a" }, { a: "b" })).toBe(false);
 

--- a/packages/reakit-utils/src/__tests__/normalizePropsAreEqual-test.ts
+++ b/packages/reakit-utils/src/__tests__/normalizePropsAreEqual-test.ts
@@ -1,0 +1,21 @@
+import { normalizePropsAreEqual } from "reakit-utils/normalizePropsAreEqual";
+
+function propsAreEqual(
+  prev?: Record<any, any>,
+  next?: Record<any, any>
+): boolean {
+  return prev?.a === next?.a;
+}
+
+const normalized = normalizePropsAreEqual(propsAreEqual);
+
+test("normalizePropsAreEqual", () => {
+  expect(propsAreEqual({ a: "a" }, { a: "a" })).toBe(true);
+  expect(propsAreEqual({ a: "a" }, { a: "b" })).toBe(false);
+
+  expect(normalized({ a: "a" }, { a: "a" })).toBe(true);
+  expect(normalized({ a: "a" }, { a: "b" })).toBe(false);
+
+  expect(normalized({ state: { a: "a" } }, { state: { a: "a" } })).toBe(true);
+  expect(normalized({ state: { a: "a" } }, { state: { a: "b" } })).toBe(false);
+});

--- a/packages/reakit-utils/src/__tests__/splitProps-test.ts
+++ b/packages/reakit-utils/src/__tests__/splitProps-test.ts
@@ -1,8 +1,14 @@
 import { splitProps } from "../splitProps";
 
-test("splitProps", () => {
+test("splitProps backward compatibility", () => {
   expect(splitProps({ a: "a", b: "b", c: "c" }, ["b"])).toEqual([
     { b: "b" },
     { a: "a", c: "c" },
   ]);
+});
+
+test("splitProps options passed as state object", () => {
+  expect(
+    splitProps({ state: { a: "aa" }, a: "a", b: "b", c: "c" }, ["b"])
+  ).toEqual([{ a: "aa" }, { a: "a", b: "b", c: "c" }]);
 });

--- a/packages/reakit-utils/src/__tests__/splitProps-test.ts
+++ b/packages/reakit-utils/src/__tests__/splitProps-test.ts
@@ -12,3 +12,36 @@ test("splitProps options passed as state object", () => {
     splitProps({ state: { a: "aa" }, a: "a", b: "b", c: "c" }, ["b"])
   ).toEqual([{ a: "aa" }, { a: "a", b: "b", c: "c" }]);
 });
+
+test("splitProps should fallback to the deprecated version if state is not a plain object", () => {
+  expect(
+    splitProps({ state: true, a: "a", b: "b", c: "c" }, ["state"])
+  ).toEqual([{ state: true }, { a: "a", b: "b", c: "c" }]);
+
+  expect(
+    splitProps({ state: true, a: "a", b: "b", c: "c" }, ["state", "a"])
+  ).toEqual([
+    { state: true, a: "a" },
+    { b: "b", c: "c" },
+  ]);
+
+  expect(
+    splitProps({ state: "indeterminate", a: "a", b: "b", c: "c" }, [
+      "state",
+      "a",
+    ])
+  ).toEqual([
+    { state: "indeterminate", a: "a" },
+    { b: "b", c: "c" },
+  ]);
+
+  expect(
+    splitProps({ state: "indeterminate", a: "a", b: "b", c: "c" }, ["a", "b"])
+  ).toEqual([
+    {
+      a: "a",
+      b: "b",
+    },
+    { state: "indeterminate", c: "c" },
+  ]);
+});

--- a/packages/reakit-utils/src/index.ts
+++ b/packages/reakit-utils/src/index.ts
@@ -24,6 +24,7 @@ export * from "./isPortalEvent";
 export * from "./isPromise";
 export * from "./isSelfTarget";
 export * from "./isTextField";
+export * from "./normalizePropsAreEqual";
 export * from "./matches";
 export * from "./omit";
 export * from "./pick";

--- a/packages/reakit-utils/src/normalizePropsAreEqual.ts
+++ b/packages/reakit-utils/src/normalizePropsAreEqual.ts
@@ -4,6 +4,13 @@ import { As, PropsWithAs } from "./types";
 export function normalizePropsAreEqual<O, T extends As>(
   propsAreEqual: (prev: O, next: O) => boolean
 ): (prev: PropsWithAs<O, T>, next: PropsWithAs<O, T>) => boolean {
+  if (propsAreEqual.name === "normalizePropsAreEqualInner") {
+    return (propsAreEqual as unknown) as (
+      prev: PropsWithAs<O, T>,
+      next: PropsWithAs<O, T>
+    ) => boolean;
+  }
+
   return function normalizePropsAreEqualInner(
     prev: PropsWithAs<O, T>,
     next: PropsWithAs<O, T>

--- a/packages/reakit-utils/src/normalizePropsAreEqual.ts
+++ b/packages/reakit-utils/src/normalizePropsAreEqual.ts
@@ -1,6 +1,19 @@
 import { isPlainObject } from "./isPlainObject";
 import { As, PropsWithAs } from "./types";
 
+/**
+ * This higher order functions take `propsAreEqual` function and
+ * returns a new function which normalizes the props.
+ *
+ * Normalizing in our case is making sure the `propsAreEqual` works with
+ * both version 1 (object spreading) and version 2 (state object) state passing.
+ *
+ * To achieve this, the returned function in case of a state object
+ * will spread the state object in both `prev` and `next props.
+ *
+ * Other case it just returns the function as is which makes sure
+ * that we are still backward compatible
+ */
 export function normalizePropsAreEqual<O, T extends As>(
   propsAreEqual: (prev: O, next: O) => boolean
 ): (prev: PropsWithAs<O, T>, next: PropsWithAs<O, T>) => boolean {

--- a/packages/reakit-utils/src/normalizePropsAreEqual.ts
+++ b/packages/reakit-utils/src/normalizePropsAreEqual.ts
@@ -1,0 +1,23 @@
+import { isPlainObject } from "./isPlainObject";
+import { As, PropsWithAs } from "./types";
+
+export function normalizePropsAreEqual<O, T extends As>(
+  propsAreEqual: (prev: O, next: O) => boolean
+): (prev: PropsWithAs<O, T>, next: PropsWithAs<O, T>) => boolean {
+  return function normalizePropsAreEqualInner(
+    prev: PropsWithAs<O, T>,
+    next: PropsWithAs<O, T>
+  ) {
+    if (!isPlainObject(prev.state) || !isPlainObject(next.state)) {
+      return propsAreEqual((prev as unknown) as O, (next as unknown) as O);
+    }
+
+    return propsAreEqual(
+      ({ ...prev.state, ...prev } as unknown) as O,
+      ({
+        ...next.state,
+        ...next,
+      } as unknown) as O
+    );
+  };
+}

--- a/packages/reakit-utils/src/splitProps.ts
+++ b/packages/reakit-utils/src/splitProps.ts
@@ -1,14 +1,9 @@
-/**
- * Splits an object (`props`) into a tuple where the first item is an object
- * with the passed `keys`, and the second item is an object with these keys
- * omitted.
- *
- * @example
- * import { splitProps } from "reakit-utils";
- *
- * splitProps({ a: "a", b: "b" }, ["a"]); // [{ a: "a" }, { b: "b" }]
- */
-export function splitProps<T extends Record<string, any>, K extends keyof T>(
+import { isPlainObject } from "./isPlainObject";
+
+function __deprecatedSplitProps<
+  T extends Record<string, any>,
+  K extends keyof T
+>(
   props: T,
   keys: ReadonlyArray<K> | Array<K>
 ): [{ [P in K]: T[P] }, Omit<T, K>] {
@@ -25,4 +20,29 @@ export function splitProps<T extends Record<string, any>, K extends keyof T>(
   }
 
   return [picked, omitted];
+}
+
+/**
+ * Splits an object (`props`) into a tuple where the first item is an object
+ * with the passed `keys`, and the second item is an object with these keys
+ * omitted.
+ *
+ * @example
+ * import { splitProps } from "reakit-utils";
+ *
+ * splitProps({ a: "a", b: "b" }, ["a"]); // [{ a: "a" }, { b: "b" }]
+ */
+export function splitProps<T extends Record<string, any>, K extends keyof T>(
+  props: T,
+  keys: ReadonlyArray<K> | Array<K>
+): [{ [P in K]: T["state"][P] }, Omit<T, K>] {
+  if (!isPlainObject(props.state)) {
+    return __deprecatedSplitProps(props, keys);
+  }
+
+  const { state, ...restProps } = props;
+  return [
+    props.state as { [P in K]: T["state"][P] },
+    (restProps as unknown) as Omit<T, K>,
+  ];
 }

--- a/packages/reakit-utils/src/splitProps.ts
+++ b/packages/reakit-utils/src/splitProps.ts
@@ -34,9 +34,9 @@ function __deprecatedSplitProps<
  */
 export function splitProps<T extends Record<string, any>, K extends keyof T>(
   props: T,
-  keys: ReadonlyArray<K> | Array<K>
+  keys?: ReadonlyArray<K> | Array<K>
 ): [{ [P in K]: T["state"][P] }, Omit<T, K>] {
-  if (!isPlainObject(props.state)) {
+  if (!isPlainObject(props.state) && keys) {
     return __deprecatedSplitProps(props, keys);
   }
 

--- a/packages/reakit-utils/src/splitProps.ts
+++ b/packages/reakit-utils/src/splitProps.ts
@@ -1,5 +1,17 @@
 import { isPlainObject } from "./isPlainObject";
 
+/**
+ * Splits an object (`props`) into a tuple where the first item is an object
+ * with the passed `keys`, and the second item is an object with these keys
+ * omitted.
+ *
+ * @deprecated will be removed in version 2
+ *
+ * @example
+ * import { splitProps } from "reakit-utils";
+ *
+ * splitProps({ a: "a", b: "b" }, ["a"]); // [{ a: "a" }, { b: "b" }]
+ */
 function __deprecatedSplitProps<
   T extends Record<string, any>,
   K extends keyof T
@@ -23,7 +35,11 @@ function __deprecatedSplitProps<
 }
 
 /**
- * Splits an object (`props`) into a tuple where the first item is an object
+ * Splits an object (`props`) into a tuple where the first item
+ * is the `state` property, and the second item is the rest of the properties.
+ *
+ * It is also backward compatible with version 1. If `keys` are passed then
+ * splits an object (`props`) into a tuple where the first item is an object
  * with the passed `keys`, and the second item is an object with these keys
  * omitted.
  *
@@ -31,6 +47,11 @@ function __deprecatedSplitProps<
  * import { splitProps } from "reakit-utils";
  *
  * splitProps({ a: "a", b: "b" }, ["a"]); // [{ a: "a" }, { b: "b" }]
+ *
+ * @example
+ * import { splitProps } from "reakit-utils";
+ *
+ * splitProps({ state: { a: "a" }, b: "b" }); // [{ a: "a" }, { b: "b" }]
  */
 export function splitProps<T extends Record<string, any>, K extends keyof T>(
   props: T,

--- a/packages/reakit-utils/src/types.ts
+++ b/packages/reakit-utils/src/types.ts
@@ -53,8 +53,12 @@ export type UnionToIntersection<U> = (
  * @template P Additional props
  * @template T React component or string element
  */
-export type PropsWithAs<P, T extends As> = P &
-  Omit<React.ComponentProps<T>, "as" | keyof P> & {
+export type PropsWithAs<P, T extends As> = {
+  // Some components (Checkbox) are using `state` as a prop
+  // to avoid type checking errors, we also allow `unknown`
+  state?: P | unknown;
+} & Partial<P> &
+  Omit<React.ComponentProps<T>, "as" | "state" | keyof P> & {
     as?: T;
     children?: React.ReactNode | RenderProp<ExtractHTMLAttributes<any>>;
   };


### PR DESCRIPTION
This PR tries to implement this issue: https://github.com/reakit/reakit/issues/744

Allow the use of `state` prop instead of object spreading. 

## How it works

Since all components are created with `createComponent`, this implementation modifies this function to allow either `state` object or `state` object spreading.

`createComponent` uses two functions that are related to the props: `splitProps` and `propsAreEqual`.

If `splitProps` finds a `state` **plain object** in the `props` then it returns the `state` object instead of using the `keys` to split the props. If the `props` doesn't have a `state` that is **plain object** then it split the props using the `keys`.

Since we are trying to move the `state` into the `state` object, `propsAreEqual` need to make sure it takes the `state` object into account. In our case, we have a new higher-order function called `normalizePropsAreEqual` which takes care of normalizing the `prev` and `next` inputs. It works by checking for the existence of `state` **plain object** property on both `prev` and `next` object. If it exists on both objects then it spreads the `state` into the props. Which means it's fully backward compatible with all of our existing `propsAreEqual` functions. 

## Example

```jsx
<MenuButton state={menu}>Preferences</MenuButton>
<Menu state={menu} aria-label="Preferences">
        <MenuItem state={menu}>Settings</MenuItem>
        <MenuItem state={menu}>Extensions</MenuItem>
        <MenuItem state={menu}>Keyboard shortcuts</MenuItem>
</Menu>
```

## Does this PR introduce breaking changes?

No, it is supposed to be 100% backward compatible.