### PR TITLE
Examples: Checkbox

### DIFF
--- a/packages/reakit/src/Checkbox/__examples__/Checkbox/__tests__/index-test.tsx
+++ b/packages/reakit/src/Checkbox/__examples__/Checkbox/__tests__/index-test.tsx
@@ -1,0 +1,8 @@
+import * as React from "react";
+import { render, axe } from "reakit-test-utils";
+import Checkbox from "..";
+
+test("a11y", async () => {
+  const { baseElement } = render(<Checkbox />);
+  expect(await axe(baseElement)).toHaveNoViolations();
+});

--- a/packages/reakit/src/Checkbox/__examples__/Checkbox/index.tsx
+++ b/packages/reakit/src/Checkbox/__examples__/Checkbox/index.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { Checkbox as BaseCheckbox, useCheckboxState } from "reakit/Checkbox";
+
+import "./style.css";
+
+export default function Checkbox() {
+  const checkbox = useCheckboxState();
+
+  return (
+    <label className="checkbox">
+      <BaseCheckbox
+        {...checkbox}
+        as="button"
+        type="button"
+        className="checkbox-control"
+        aria-labelledby="checkbox-label"
+      >
+        <CheckIcon className="checkbox-check-icon" aria-hidden />
+      </BaseCheckbox>
+      <span id="checkbox-label">Checkbox</span>
+    </label>
+  );
+}
+
+type CheckIconProps = {
+  className?: string;
+};
+
+function CheckIcon({ className }: CheckIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      width="1em"
+      height="1em"
+      className={className}
+    >
+      <path
+        fillRule="evenodd"
+        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}

--- a/packages/reakit/src/Checkbox/__examples__/Checkbox/style.css
+++ b/packages/reakit/src/Checkbox/__examples__/Checkbox/style.css
@@ -1,0 +1,54 @@
+:root {
+  --font-family: var(--font-family-body, sans-serif);
+  --font-size: var(--font-size-body, 16px);
+  --checkbox-color: var(--color-white, #fff);
+  --checkbox-background: var(--color-white, #fff);
+  --checkbox-border: var(--color-gray-100, #eee);
+  --checkbox-background-checked: var(--color-primary-700, #1976d2);
+  --checkbox-border-checked: var(--color-primary-700, #1976d2);
+  --checkbox-border-hover: var(--color-primary-400, #51a8f0);
+  --checkbox-background-active: var(--color-primary-900, #0d5399);
+  --checkbox-border-active: var(--color-primary-900, #0d5399);
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-family);
+  font-size: var(--font-size);
+  cursor: pointer;
+}
+
+.checkbox-control {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 1.25rem;
+  width: 1.25rem;
+  padding: 0;
+  margin-right: 0.5rem;
+  appearance: none;
+  border: 2px solid var(--checkbox-border);
+  color: var(--checkbox-color);
+  background: var(--checkbox-background);
+  border-radius: 4px;
+  transition: all 0.2s;
+}
+
+.checkbox-control[aria-checked="true"] {
+  background: var(--checkbox-background-checked);
+  border-color: var(--checkbox-border-checked);
+}
+
+.checkbox-control:hover {
+  border-color: var(--checkbox-border-hover);
+}
+
+.checkbox-control:active {
+  background-color: var(--checkbox-background-active);
+  border-color: var(--checkbox-border-active);
+}
+
+.checkbox-check-icon {
+  font-size: 1rem;
+}


### PR DESCRIPTION
Adds a Storybook example for a checkbox component.

Unrelated to this PR, but would it make sense to add some base styles (a color palette, CSS reset) for the examples to use? Tailwind CSS could be nice as well (as mentioned before in https://github.com/reakit/reakit/pull/753). A downside of Tailwind is that you can't easily style attributes like `[aria-checked]`. You'll have to create a plugin for all those attributes or use `@apply` or `theme()` in CSS.

**Screenshots**

![2020-10-31 14 35 41](https://user-images.githubusercontent.com/876666/97780686-66407500-1b86-11eb-9e92-0f3e6faa3327.gif)