### PR TITLE
fix: Fix Composite `unstable_virtual` option on mobile devices

### DIFF
--- a/packages/reakit-test-utils/src/click.ts
+++ b/packages/reakit-test-utils/src/click.ts
@@ -142,16 +142,21 @@ export function click(element: Element, options?: MouseEventInit) {
 
   // Do not enter this if event.preventDefault() has been called on
   // pointerdown or mousedown.
-  if (defaultAllowed && isFocusable(element)) {
-    focus(element);
-  } else if (element.parentElement) {
-    // If the element is not focusable, focus the closest focusable parent
-    const closestFocusable = getClosestFocusable(element.parentElement);
-    if (closestFocusable) {
-      focus(closestFocusable);
-    } else {
-      // This will automatically set document.body as the activeElement
-      blur();
+  if (defaultAllowed) {
+    if (
+      isFocusable(element) &&
+      getComputedStyle(element).pointerEvents !== "none"
+    ) {
+      focus(element);
+    } else if (element.parentElement) {
+      // If the element is not focusable, focus the closest focusable parent
+      const closestFocusable = getClosestFocusable(element.parentElement);
+      if (closestFocusable) {
+        focus(closestFocusable);
+      } else {
+        // This will automatically set document.body as the activeElement
+        blur();
+      }
     }
   }
 

--- a/packages/reakit-test-utils/src/fireEvent.ts
+++ b/packages/reakit-test-utils/src/fireEvent.ts
@@ -26,11 +26,11 @@ for (const event of pointerEvents) {
       const style = getComputedStyle(element);
       if (style.pointerEvents === "none") {
         if (element.parentElement) {
-          // Recursive so we'll repeat the process the parent element also has
-          // pointerEvents: none
-          fireEvent[event](element.parentElement, options);
+          // Recursive so we'll repeat the process if the parent element also
+          // has pointerEvents: none
+          return fireEvent[event](element.parentElement, options);
         }
-        return false;
+        return true;
       }
     }
     return baseFireEvent(element, options);

--- a/packages/reakit/src/Composite/Composite.ts
+++ b/packages/reakit/src/Composite/Composite.ts
@@ -22,6 +22,7 @@ import { reverse } from "./__utils/reverse";
 import { getCurrentId } from "./__utils/getCurrentId";
 import { findEnabledItemById } from "./__utils/findEnabledItemById";
 import { COMPOSITE_KEYS } from "./__keys";
+import { userFocus } from "./__utils/userFocus";
 
 export type CompositeOptions = TabbableOptions &
   Pick<
@@ -119,6 +120,20 @@ function isItem(items: Item[], element?: Element | EventTarget | null) {
   return items?.some((item) => !!element && item.ref.current === element);
 }
 
+function useScheduleUserFocus(currentItem?: Item) {
+  const currentItemRef = useLiveRef(currentItem);
+  const [scheduled, schedule] = React.useReducer((n: number) => n + 1, 0);
+
+  React.useEffect(() => {
+    const currentElement = currentItemRef.current?.ref.current;
+    if (scheduled && currentElement) {
+      userFocus(currentElement);
+    }
+  }, [scheduled]);
+
+  return schedule;
+}
+
 export const useComposite = createHook<CompositeOptions, CompositeHTMLProps>({
   name: "Composite",
   compose: [useTabbable],
@@ -148,6 +163,7 @@ export const useComposite = createHook<CompositeOptions, CompositeHTMLProps>({
     const onFocusRef = useLiveRef(htmlOnFocus);
     const onBlurCaptureRef = useLiveRef(htmlOnBlurCapture);
     const onKeyDownRef = useLiveRef(htmlOnKeyDown);
+    const scheduleUserFocus = useScheduleUserFocus(currentItem);
     // IE 11 doesn't support event.relatedTarget, so we use the active element
     // ref instead.
     const activeElementRef = isIE11 ? useActiveElementRef(ref) : undefined;
@@ -208,7 +224,6 @@ export const useComposite = createHook<CompositeOptions, CompositeHTMLProps>({
         onFocusRef.current?.(event);
         if (event.defaultPrevented) return;
         if (options.unstable_virtual) {
-          const currentElement = currentItem?.ref.current || null;
           if (isSelfTarget(event)) {
             // This means that the composite element has been focused while the
             // composite item has not. For example, by clicking on the
@@ -218,7 +233,7 @@ export const useComposite = createHook<CompositeOptions, CompositeHTMLProps>({
             // When it receives focus, the composite item will put focus back
             // on the composite element, in which case hasItemWithFocus will be
             // true.
-            currentElement?.focus();
+            scheduleUserFocus();
           }
         } else if (isSelfTarget(event)) {
           // When the roving tabindex composite gets intentionally focused (for
@@ -228,7 +243,7 @@ export const useComposite = createHook<CompositeOptions, CompositeHTMLProps>({
           options.setCurrentId?.(null);
         }
       },
-      [options.unstable_virtual, currentItem, options.setCurrentId]
+      [options.unstable_virtual, options.setCurrentId]
     );
 
     const onBlurCapture = React.useCallback(
@@ -372,7 +387,7 @@ export const useComposite = createHook<CompositeOptions, CompositeHTMLProps>({
       // Composite will only be tabbable by default if the focus is managed
       // using aria-activedescendant, which requires DOM focus on the container
       // element (the composite)
-      return tabbableHTMLProps;
+      return { tabIndex: 0, ...tabbableHTMLProps };
     }
     return { ...htmlProps, ref: tabbableHTMLProps.ref };
   },

--- a/packages/reakit/src/Composite/__examples__/CompositeVirtualAsProp/__tests__/index-test.tsx
+++ b/packages/reakit/src/Composite/__examples__/CompositeVirtualAsProp/__tests__/index-test.tsx
@@ -11,13 +11,13 @@ test("navigate through composite items", () => {
       aria-label="events"
     >
       <li>
+        focus composite
+      </li>
+      <li>
         focus Item 1
       </li>
       <li>
         focus composite - Item 1
-      </li>
-      <li>
-        focus composite
       </li>
       <li>
         keyup composite (Tab)

--- a/packages/reakit/src/Composite/__utils/userFocus.ts
+++ b/packages/reakit/src/Composite/__utils/userFocus.ts
@@ -1,0 +1,15 @@
+type UserFocusElement = HTMLElement & { userFocus?: boolean };
+
+export function userFocus(element: UserFocusElement) {
+  element.userFocus = true;
+  element.focus();
+  element.userFocus = false;
+}
+
+export function hasUserFocus(element: UserFocusElement) {
+  return !!element.userFocus;
+}
+
+export function setUserFocus(element: UserFocusElement, value: boolean) {
+  element.userFocus = value;
+}

--- a/packages/reakit/src/Dialog/__examples__/DialogWithVirtualCompositeWithTooltip/__tests__/index-test.tsx
+++ b/packages/reakit/src/Dialog/__examples__/DialogWithVirtualCompositeWithTooltip/__tests__/index-test.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
-import { click, screen, render, wait, axe } from "reakit-test-utils";
+import { click, screen, render, axe } from "reakit-test-utils";
 import DialogWithVirtualCompositeWithTooltip from "..";
 
-test("open dialog with composite with tooltip", async () => {
+test("open dialog with composite with tooltip", () => {
   render(<DialogWithVirtualCompositeWithTooltip />);
   click(screen.getByText("Disclosure"));
   expect(screen.getByLabelText("Dialog")).toBeVisible();
   expect(screen.getByText("item1")).toHaveFocus();
-  await wait(expect(screen.getByLabelText("composite")).toHaveFocus);
+  expect(screen.getByLabelText("composite")).toHaveFocus();
   expect(screen.getByText("item1tooltip")).toBeVisible();
 });
 

--- a/packages/reakit/src/Dialog/__utils/useFocusOnHide.ts
+++ b/packages/reakit/src/Dialog/__utils/useFocusOnHide.ts
@@ -5,6 +5,7 @@ import { isTabbable } from "reakit-utils/tabbable";
 import { getActiveElement } from "reakit-utils/getActiveElement";
 import { contains } from "reakit-utils/contains";
 import { ensureFocus } from "reakit-utils/ensureFocus";
+import { getDocument } from "reakit-utils/getDocument";
 import { DialogOptions } from "../Dialog";
 
 function hidByFocusingAnotherElement(dialogRef: React.RefObject<HTMLElement>) {
@@ -39,7 +40,18 @@ export function useFocusOnHide(
     }
     const finalFocusEl =
       options.unstable_finalFocusRef?.current || disclosureRef.current;
+
     if (finalFocusEl) {
+      if (finalFocusEl.id) {
+        const document = getDocument(finalFocusEl);
+        const compositeElement = document.querySelector<HTMLElement>(
+          `[aria-activedescendant=${finalFocusEl.id}]`
+        );
+        if (compositeElement) {
+          ensureFocus(compositeElement);
+          return;
+        }
+      }
       ensureFocus(finalFocusEl);
       return;
     }

--- a/packages/reakit/src/Menu/MenuItem.tsx
+++ b/packages/reakit/src/Menu/MenuItem.tsx
@@ -112,9 +112,9 @@ export const useMenuItem = createHook<MenuItemOptions, MenuItemHTMLProps>({
         if (menu?.role === "menubar") return;
         if (isMouseInTransitToSubmenu(event)) return;
         if (hasFocusWithin(event.currentTarget)) return;
-        event.currentTarget.focus();
+        options.move?.(event.currentTarget.id);
       },
-      []
+      [options.move]
     );
 
     const onMouseLeave = React.useCallback(


### PR DESCRIPTION
Closes #755

This PR is an alternative to #755. Instead of turning `unstable_virtual` off on mobile, it disables focus forwarding when `element.focus()` is called, which is the function VoiceOver uses to focus on items.