### PR TITLE
fix: Stop warning when using invalid composite roles on `Composite`

### DIFF
--- a/packages/reakit/src/Composite/Composite.ts
+++ b/packages/reakit/src/Composite/Composite.ts
@@ -43,19 +43,6 @@ export type CompositeHTMLProps = TabbableHTMLProps;
 
 export type CompositeProps = CompositeOptions & CompositeHTMLProps;
 
-const validCompositeRoles = [
-  "combobox",
-  "grid",
-  "tablist",
-  "listbox",
-  "menu",
-  "menubar",
-  "toolbar",
-  "radiogroup",
-  "tree",
-  "treegrid",
-];
-
 const isIE11 = canUseDOM && "msCrypto" in window;
 
 function canProxyKeyboardEvent(event: React.KeyboardEvent) {
@@ -382,11 +369,6 @@ export const Composite = createComponent({
   as: "div",
   useHook: useComposite,
   useCreateElement: (type, props, children) => {
-    useWarning(
-      !props.role || validCompositeRoles.indexOf(props.role) === -1,
-      "You should provide a valid `role` attribute to composite components.",
-      "See https://reakit.io/docs/composite"
-    );
     useWarning(
       !props["aria-label"] && !props["aria-labelledby"],
       "You should provide either `aria-label` or `aria-labelledby` props.",

--- a/packages/reakit/src/Composite/__tests__/index-test.tsx
+++ b/packages/reakit/src/Composite/__tests__/index-test.tsx
@@ -44,21 +44,6 @@ function template(value: string) {
 
 [true, false].forEach((virtual) => {
   describe(virtual ? "aria-activedescendant" : "roving-tabindex", () => {
-    test("warning when there's no composite role", () => {
-      const Test = () => {
-        const composite = useCompositeState({ unstable_virtual: virtual });
-        return (
-          <Composite {...composite} role="button" aria-label="composite">
-            <CompositeItem {...composite}>item1</CompositeItem>
-            <CompositeItem {...composite}>item2</CompositeItem>
-            <CompositeItem {...composite}>item3</CompositeItem>
-          </Composite>
-        );
-      };
-      render(<Test />);
-      expect(console).toHaveWarned();
-    });
-
     test("warning when there's no label", () => {
       const Test = () => {
         const composite = useCompositeState({ unstable_virtual: virtual });


### PR DESCRIPTION
This PR removes the warning that `Composite` shows when the developer doesn't pass any role prop or pass an invalid composite role prop to the `Composite` component.

```jsx
// Will not warn anymore
<Composite />
```

The reason is that there are valid use cases for omitting the role prop. For example, we could create multiple connected listbox elements to implement the ARIA 1.2 listbox group pattern for screen readers that still don't support it, like VoiceOver. This use case is better explained on https://github.com/WordPress/gutenberg/issues/24975#issuecomment-722481740.

With the Reakit Composite module, the implementation would be something like this, where the `listbox` role is not passed to the `Composite` component.

```jsx
const composite = useCompositeState();
<Composite {...composite}>
  <div role="listbox" aria-label="Group 1">
    <CompositeItem {...composite} role="option">Item</CompositeItem>
    <CompositeItem {...composite} role="option">Item</CompositeItem>
    <CompositeItem {...composite} role="option">Item</CompositeItem>
  </div>
  <div role="listbox" aria-label="Group 2">
    <CompositeItem {...composite} role="option">Item</CompositeItem>
    <CompositeItem {...composite} role="option">Item</CompositeItem>
    <CompositeItem {...composite} role="option">Item</CompositeItem>
  </div>
  <div role="listbox" aria-label="Group 3">
    <CompositeItem {...composite} role="option">Item</CompositeItem>
    <CompositeItem {...composite} role="option">Item</CompositeItem>
    <CompositeItem {...composite} role="option">Item</CompositeItem>
  </div>
</Composite>
```