### PR TITLE
fix: Native radio input firing onChange callback twice on click

### DIFF
--- a/packages/reakit/src/Radio/Radio.ts
+++ b/packages/reakit/src/Radio/Radio.ts
@@ -125,9 +125,10 @@ export const useRadio = createHook<RadioOptions, RadioHTMLProps>({
       (event: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
         onClickRef.current?.(event);
         if (event.defaultPrevented) return;
+        if (isNativeRadio) return;
         fireChange(event.currentTarget, onChange);
       },
-      [onChange]
+      [onChange, isNativeRadio]
     );
 
     React.useEffect(() => {

--- a/packages/reakit/src/Radio/__tests__/index-test.tsx
+++ b/packages/reakit/src/Radio/__tests__/index-test.tsx
@@ -50,6 +50,33 @@ test("onChange", () => {
   expect(radio.checked).toBe(true);
 });
 
+test("Native radio onChange called only once when clicked", async () => {
+  const Test = () => {
+    const { state, setState, ...radio } = useRadioState();
+    const [checked, setChecked] = React.useState(false);
+    const [counter, setCounter] = React.useState(0);
+    const toggle = () => {
+      setCounter((s) => s + 1);
+      setChecked(!checked);
+    };
+    return (
+      <>
+        <label>
+          <Radio {...radio} value="radio" onChange={toggle} checked={checked} />
+          radio
+        </label>
+        <p data-testid="counter">{counter}</p>
+      </>
+    );
+  };
+  const { getByLabelText, getByTestId } = render(<Test />);
+  const radio = getByLabelText("radio") as HTMLInputElement;
+  click(radio);
+
+  const counter = getByTestId("counter") as HTMLElement;
+  expect(counter).toHaveTextContent("1");
+});
+
 test("onChange non-native radio", () => {
   const Test = () => {
     const { state, setState, ...radio } = useRadioState();


### PR DESCRIPTION
Fixes https://github.com/reakit/reakit/issues/790

`change` event is fired for native radio inputs by the browser. Therefore we don't need to fire it when we click on a native radio.

**How to test?**

Regression test included

**Does this PR introduce breaking changes?**

No