### PR TITLE
Try state in context

### DIFF
--- a/packages/reakit-system/src/StateContextHoc.tsx
+++ b/packages/reakit-system/src/StateContextHoc.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { unstable_useId as useId } from "reakit/Id";
+
+export const StateContextHoc = (Comp, ctx) => (props) => {
+  const context = React.useContext(ctx);
+
+  let subscribe;
+  let initialState;
+  if (context) {
+    const { subscribe: _subscribe, ..._initialState } = context;
+    subscribe = _subscribe;
+    initialState = _initialState;
+  }
+
+  const { id } = useId({ ...initialState, ...props });
+  const [state, setState] = React.useState(initialState);
+
+  React.useEffect(
+    () =>
+      subscribe
+        ? subscribe((nextState) => {
+            if (
+              state.currentId === null ||
+              id === state.currentId ||
+              id === nextState.currentId
+            ) {
+              setState(nextState);
+            }
+          })
+        : undefined,
+    [subscribe, state?.currentId, id, props.id]
+  );
+
+  return <Comp {...state} {...props} id={id} />;
+};

--- a/packages/reakit-system/src/StateContextHoc.tsx
+++ b/packages/reakit-system/src/StateContextHoc.tsx
@@ -8,13 +8,12 @@ export type StateContextValue<O> = {
 };
 export type StateContextListener<O> = (options: O) => void;
 export type StateContextSubscribe<O> = (callback: (options: O) => any) => any;
-export type HOCInner<T, O> = (props: O) => T;
 
 export function StateContextHoc<
   T extends React.ComponentType<any>,
   O extends React.HTMLAttributes<any>
->(Comp: T, ctx: StateContext<O>): HOCInner<T, O> {
-  const inner: HOCInner<T, O> = (props: O) => {
+>(Comp: T, ctx: StateContext<O>): T {
+  const inner = (props: O) => {
     const context = React.useContext(ctx);
 
     let subscribe: StateContextSubscribe<O> | null = null;
@@ -44,8 +43,8 @@ export function StateContextHoc<
       [subscribe, state?.currentId, id, props.id]
     );
 
-    return ((<Comp {...state} {...props} id={id} />) as unknown) as T;
+    return <Comp {...state} {...props} id={id} />;
   };
 
-  return inner;
+  return (inner as unknown) as T;
 }

--- a/packages/reakit-system/src/StateContextHoc.tsx
+++ b/packages/reakit-system/src/StateContextHoc.tsx
@@ -1,35 +1,50 @@
 import React from "react";
 import { unstable_useId as useId } from "reakit/Id";
 
-export const StateContextHoc = (Comp, ctx) => (props) => {
-  const context = React.useContext(ctx);
+export type StateContext<O> = React.Context<{
+  initialState: O;
+  subscribe: StateContextSubscribe<O>;
+}>;
+export type StateContextListener<O> = (options: O) => void;
+export type StateContextSubscribe<O> = (callback: (options: O) => any) => any;
+export type HOCInner<T, O> = (props: O) => T;
 
-  let subscribe;
-  let initialState;
-  if (context) {
-    const { subscribe: _subscribe, ..._initialState } = context;
-    subscribe = _subscribe;
-    initialState = _initialState;
-  }
+export function StateContextHoc<
+  T extends React.ComponentType<any>,
+  O extends React.HTMLAttributes<any>
+>(Comp: T, ctx: StateContext<O>): HOCInner<T, O> {
+  const inner: HOCInner<T, O> = (props: O) => {
+    const context = React.useContext(ctx);
 
-  const { id } = useId({ ...initialState, ...props });
-  const [state, setState] = React.useState(initialState);
+    let subscribe: StateContextSubscribe<O> | null = null;
+    let initialState: O = {} as O;
+    if (context) {
+      const { subscribe: _subscribe, initialState: _initialState } = context;
+      subscribe = _subscribe;
+      initialState = _initialState;
+    }
 
-  React.useEffect(
-    () =>
-      subscribe
-        ? subscribe((nextState) => {
-            if (
-              state.currentId === null ||
-              id === state.currentId ||
-              id === nextState.currentId
-            ) {
-              setState(nextState);
-            }
-          })
-        : undefined,
-    [subscribe, state?.currentId, id, props.id]
-  );
+    const { id } = useId({ ...initialState, ...props });
+    const [state, setState] = React.useState<any>(initialState);
 
-  return <Comp {...state} {...props} id={id} />;
-};
+    React.useEffect(
+      () =>
+        subscribe
+          ? subscribe((nextState: any) => {
+              if (
+                state.currentId === null ||
+                id === state.currentId ||
+                id === nextState.currentId
+              ) {
+                setState(nextState);
+              }
+            })
+          : undefined,
+      [subscribe, state?.currentId, id, props.id]
+    );
+
+    return ((<Comp {...state} {...props} id={id} />) as unknown) as T;
+  };
+
+  return inner;
+}

--- a/packages/reakit-system/src/StateContextHoc.tsx
+++ b/packages/reakit-system/src/StateContextHoc.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { unstable_useId as useId } from "reakit/Id";
 
-export type StateContext<O> = React.Context<{
+export type StateContext<O> = React.Context<StateContextValue<O>>;
+export type StateContextValue<O> = {
   initialState: O;
   subscribe: StateContextSubscribe<O>;
-}>;
+};
 export type StateContextListener<O> = (options: O) => void;
 export type StateContextSubscribe<O> = (callback: (options: O) => any) => any;
 export type HOCInner<T, O> = (props: O) => T;

--- a/packages/reakit-system/src/createComponent.ts
+++ b/packages/reakit-system/src/createComponent.ts
@@ -8,10 +8,10 @@ import { useCreateElement as defaultUseCreateElement } from "./useCreateElement"
 import { memo } from "./__utils/memo";
 import {
   StateContext,
-  StateContextHoc,
+  withStateContextSubscriber,
   StateContextListener,
   StateContextSubscribe,
-} from "./StateContextHoc";
+} from "./withStateContextSubscriber";
 
 type RoleHTMLProps = React.HTMLAttributes<any> &
   React.RefAttributes<any> & {
@@ -142,7 +142,7 @@ export function createComponent<T extends As, O>({
   Comp = forwardRef(Comp);
 
   if (context && !isContextProvider) {
-    Comp = StateContextHoc(Comp, context);
+    Comp = withStateContextSubscriber(Comp, context);
   }
 
   if (shouldMemo) {

--- a/packages/reakit-system/src/createStateContext.ts
+++ b/packages/reakit-system/src/createStateContext.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { StateContext } from "./StateContextHoc";
+import { StateContext } from "./withStateContextSubscriber";
 
 export function createStateContext<O>(): StateContext<O> {
   return (React.createContext({

--- a/packages/reakit-system/src/createStateContext.ts
+++ b/packages/reakit-system/src/createStateContext.ts
@@ -1,0 +1,9 @@
+import React from "react";
+import { StateContext } from "./StateContextHoc";
+
+export function createStateContext<O>(): StateContext<O> {
+  return (React.createContext({
+    initialState: {},
+    subscribe: () => {},
+  }) as unknown) as StateContext<O>;
+}

--- a/packages/reakit-system/src/index.ts
+++ b/packages/reakit-system/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./createComponent";
 export * from "./createHook";
+export * from "./createStateContext";
 export * from "./mergeSystem";
 export * from "./SystemContext";
 export * from "./SystemProvider";

--- a/packages/reakit-system/src/withStateContextSubscriber.tsx
+++ b/packages/reakit-system/src/withStateContextSubscriber.tsx
@@ -9,7 +9,7 @@ export type StateContextValue<O> = {
 export type StateContextListener<O> = (options: O) => void;
 export type StateContextSubscribe<O> = (callback: (options: O) => any) => any;
 
-export function StateContextHoc<
+export function withStateContextSubscriber<
   T extends React.ComponentType<any>,
   O extends React.HTMLAttributes<any>
 >(Comp: T, ctx: StateContext<O>): T {

--- a/packages/reakit/src/Combobox/ComboboxOption.ts
+++ b/packages/reakit/src/Combobox/ComboboxOption.ts
@@ -11,6 +11,7 @@ import {
   unstable_ComboboxItemHTMLProps as ComboboxItemHTMLProps,
   unstable_useComboboxItem as useComboboxItem,
 } from "./ComboboxItem";
+import { Context } from "./ComboboxPopover";
 
 export const unstable_useComboboxOption = createHook<
   unstable_ComboboxOptionOptions,
@@ -29,6 +30,7 @@ export const unstable_ComboboxOption = createComponent({
   as: "div",
   memo: true,
   useHook: unstable_useComboboxOption,
+  context: Context,
 });
 
 export type unstable_ComboboxOptionOptions = CompositeItemOptions &

--- a/packages/reakit/src/Combobox/ComboboxOption.ts
+++ b/packages/reakit/src/Combobox/ComboboxOption.ts
@@ -11,7 +11,7 @@ import {
   unstable_ComboboxItemHTMLProps as ComboboxItemHTMLProps,
   unstable_useComboboxItem as useComboboxItem,
 } from "./ComboboxItem";
-import { Context } from "./ComboboxPopover";
+import { StateContext } from "./ComboboxPopover";
 
 export const unstable_useComboboxOption = createHook<
   unstable_ComboboxOptionOptions,
@@ -30,7 +30,7 @@ export const unstable_ComboboxOption = createComponent({
   as: "div",
   memo: true,
   useHook: unstable_useComboboxOption,
-  context: Context,
+  context: StateContext,
 });
 
 export type unstable_ComboboxOptionOptions = CompositeItemOptions &

--- a/packages/reakit/src/Combobox/ComboboxPopover.ts
+++ b/packages/reakit/src/Combobox/ComboboxPopover.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { createComponent } from "reakit-system/createComponent";
 import { createHook } from "reakit-system/createHook";
 import { useWarning } from "reakit-warning";
@@ -42,9 +43,13 @@ export const unstable_useComboboxPopover = createHook<
   },
 });
 
+export const Context = React.createContext({});
+
 export const unstable_ComboboxPopover = createComponent({
   as: "div",
   useHook: unstable_useComboboxPopover,
+  context: Context,
+  isContextProvider: true,
   useCreateElement: (type, props, children) => {
     useWarning(
       !props["aria-label"] && !props["aria-labelledby"],

--- a/packages/reakit/src/Combobox/ComboboxPopover.ts
+++ b/packages/reakit/src/Combobox/ComboboxPopover.ts
@@ -1,8 +1,8 @@
-import React from "react";
 import { createComponent } from "reakit-system/createComponent";
 import { createHook } from "reakit-system/createHook";
 import { useWarning } from "reakit-warning";
 import { useCreateElement } from "reakit-system/useCreateElement";
+import { createStateContext } from "reakit-system/createStateContext";
 import {
   PopoverOptions,
   PopoverHTMLProps,
@@ -43,12 +43,12 @@ export const unstable_useComboboxPopover = createHook<
   },
 });
 
-export const Context = React.createContext({});
+export const StateContext = createStateContext();
 
 export const unstable_ComboboxPopover = createComponent({
   as: "div",
   useHook: unstable_useComboboxPopover,
-  context: Context,
+  context: StateContext,
   isContextProvider: true,
   useCreateElement: (type, props, children) => {
     useWarning(

--- a/packages/reakit/src/Combobox/__examples__/ComboboxNonContextVsContext/index.tsx
+++ b/packages/reakit/src/Combobox/__examples__/ComboboxNonContextVsContext/index.tsx
@@ -56,9 +56,9 @@ export default function ComboBoxNonContextVsContext() {
     <>
       <div>
         <p>
-          Original Combobox, clicking on it may take some time. Use arrows (hold
-          down your down-arrow key) to navigate between elements. You will
-          notice how slow it is.
+          <strong>Original Combobox</strong>, clicking on it may take some time.
+          Use arrows (hold down your down-arrow key) to navigate between
+          elements. You will notice how slow it is.
         </p>
 
         <ComboboxOriginal />
@@ -66,9 +66,9 @@ export default function ComboBoxNonContextVsContext() {
 
       <div>
         <p>
-          New Combobox using Context, clicking on it takes less time. Use arrows
-          (hold down your down-arrow key) to navigate between elements. You will
-          notice how fast it is compared to the original.
+          <strong>New Combobox using Context</strong>, clicking on it takes less
+          time. Use arrows (hold down your down-arrow key) to navigate between
+          elements. You will notice how fast it is compared to the original.
         </p>
 
         <ComboboxContext />

--- a/packages/reakit/src/Combobox/__examples__/ComboboxNonContextVsContext/index.tsx
+++ b/packages/reakit/src/Combobox/__examples__/ComboboxNonContextVsContext/index.tsx
@@ -1,0 +1,78 @@
+import {
+  unstable_Combobox as Combobox,
+  unstable_ComboboxOption as ComboboxOption,
+  unstable_useComboboxState as useComboboxState,
+  unstable_ComboboxPopover as ComboboxPopover,
+} from "reakit/Combobox";
+import "./style.css";
+import * as React from "react";
+
+function ComboboxOriginal() {
+  const items = Array.from({ length: 250 }).map((_, i) => `Item ${i}`);
+
+  const combobox = useComboboxState({
+    values: items,
+    gutter: 8,
+    limit: false,
+    autoSelect: true,
+  });
+
+  return (
+    <>
+      <Combobox {...combobox} aria-label="Color" placeholder="Type a color" />
+      <ComboboxPopover {...combobox} aria-label="Colors">
+        {items.map((value) => (
+          <ComboboxOption {...combobox} key={value} value={value} />
+        ))}
+      </ComboboxPopover>
+    </>
+  );
+}
+
+function ComboboxContext() {
+  const items = Array.from({ length: 250 }).map((_, i) => `Item ${i}`);
+
+  const combobox = useComboboxState({
+    values: items,
+    gutter: 8,
+    limit: false,
+    autoSelect: true,
+  });
+
+  return (
+    <>
+      <Combobox {...combobox} aria-label="Color" placeholder="Type a color" />
+      <ComboboxPopover {...combobox} aria-label="Colors">
+        {items.map((value) => (
+          <ComboboxOption key={value} value={value} />
+        ))}
+      </ComboboxPopover>
+    </>
+  );
+}
+
+export default function ComboBoxNonContextVsContext() {
+  return (
+    <>
+      <div>
+        <p>
+          Original Combobox, clicking on it may take some time. Use arrows (hold
+          down your down-arrow key) to navigate between elements. You will
+          notice how slow it is.
+        </p>
+
+        <ComboboxOriginal />
+      </div>
+
+      <div>
+        <p>
+          New Combobox using Context, clicking on it takes less time. Use arrows
+          (hold down your down-arrow key) to navigate between elements. You will
+          notice how fast it is compared to the original.
+        </p>
+
+        <ComboboxContext />
+      </div>
+    </>
+  );
+}

--- a/packages/reakit/src/Combobox/__examples__/ComboboxNonContextVsContext/style.css
+++ b/packages/reakit/src/Combobox/__examples__/ComboboxNonContextVsContext/style.css
@@ -1,0 +1,1 @@
+@import "../AccessibleCombobox/style.css";

--- a/packages/reakit/src/Combobox/__examples__/ComboboxNonContextVsContext/style.css
+++ b/packages/reakit/src/Combobox/__examples__/ComboboxNonContextVsContext/style.css
@@ -1,1 +1,10 @@
 @import "../AccessibleCombobox/style.css";
+
+#combobox--combobox-non-context-vs-context {
+  display: flex;
+}
+
+#combobox--combobox-non-context-vs-context > div {
+  flex: 1;
+  padding: 1rem;
+}

--- a/packages/reakit/src/Combobox/__examples__/index.story.ts
+++ b/packages/reakit/src/Combobox/__examples__/index.story.ts
@@ -11,6 +11,7 @@ export { default as ComboboxList } from "./ComboboxList";
 export { default as ComboboxListGridWithPopover } from "./ComboboxListGridWithPopover";
 export { default as ComboboxMinValueLength } from "./ComboboxMinValueLength";
 export { default as ComboboxVisible } from "./ComboboxVisible";
+export { default as ComboboxNonContextVsContext } from "./ComboboxNonContextVsContext";
 
 export default {
   title: "Combobox",


### PR DESCRIPTION
Resolves: https://github.com/reakit/reakit/issues/745

The code is experimental. There are many TS linter errors. More like a proof-of-concept = this is possible in the core!

## Benefits
* Less code, no need to spread those states everywhere
* Better performance, less rerenders

## Goals
* 100% backward compatibility. It should work with every existing component without any changes. This isn't proved yet but I'll include tests later on.
* Should be easy to enable this new feature for existing and upcoming components

## How this works in the userland?
See https://github.com/reakit/reakit/issues/745

## Is there anything we need to do to enable this feature for components?
**Yes**

* We need to add a `context` and `isContextProvider` prop to parent components. (Like `ComboboxPopover`)
* We need to add `context` prop to children components. (Like`ComboboxOption`)

## How it works under the hood?
Based on @diegohaz 's awesome work: https://twitter.com/diegohaz/status/1307299869200191490

Components can be registered to use a specific Context and/or be a context provider. This is possible with the `createComponent` function. Two new properties are `context` and `isContextProvider`. Context providers are providing context for components that are created with the same `context` property. See `ComboboxPopover` as a context provider example. And see `ComboboxOption` as a context consumer example.

There is an internal pub-sub system between providers are consumers on top of the context. To avoid many rerenders of changing the value of the context we use this pub-sub system.

Consumers are wrapped with `StateContextHoc` HOC. This takes care of the receiving of the state updates from the pub-sub system. Applies the new state if applicable.

## How to test?

- `npm run storybook`
- Open `Combobox -> Combobox Non Context Vs Context`

## Does this PR introduce breaking changes?

The goal is 100% backward compatibility. Not sure yet 😄 