### PR TITLE
Fix missing quote querySelector in useFocusOnHide

### DIFF
--- a/packages/reakit/src/Dialog/__utils/useFocusOnHide.ts
+++ b/packages/reakit/src/Dialog/__utils/useFocusOnHide.ts
@@ -45,7 +45,7 @@ export function useFocusOnHide(
       if (finalFocusEl.id) {
         const document = getDocument(finalFocusEl);
         const compositeElement = document.querySelector<HTMLElement>(
-          `[aria-activedescendant=${finalFocusEl.id}]`
+          `[aria-activedescendant='${finalFocusEl.id}']`
         );
         if (compositeElement) {
           ensureFocus(compositeElement);


### PR DESCRIPTION
To be error proof it could be better that the document.querySelector in useFocusOnHide have quote around the value in the selector.

For example with the current code, some id may go in error (number, special characters)
![image](https://user-images.githubusercontent.com/4653573/100343636-eae4ae80-2fdf-11eb-8e9a-ba109d08117c.png)

[MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector)

**How to test?**

Some query selector example
https://codesandbox.io/s/morning-tree-xbo5g?file=/src/App.js

**Does this PR introduce breaking changes?**

Nop

