### PR TITLE
fix: Accept other option props together with the `state` prop

### DIFF
--- a/packages/reakit-utils/README.md
+++ b/packages/reakit-utils/README.md
@@ -685,7 +685,7 @@ omitted.
 #### Parameters
 
 -   `props` **T** 
--   `keys` **(ReadonlyArray&lt;K> | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;K>)?** 
+-   `keys` **(ReadonlyArray&lt;K> | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;K>)**  (optional, default `[]`)
 
 #### Examples
 

--- a/packages/reakit-utils/src/__tests__/splitProps-test.ts
+++ b/packages/reakit-utils/src/__tests__/splitProps-test.ts
@@ -10,7 +10,10 @@ test("splitProps backward compatibility", () => {
 test("splitProps options passed as state object", () => {
   expect(
     splitProps({ state: { a: "aa" }, a: "a", b: "b", c: "c" }, ["b"])
-  ).toEqual([{ a: "aa" }, { a: "a", b: "b", c: "c" }]);
+  ).toEqual([
+    { a: "aa", b: "b" },
+    { a: "a", c: "c" },
+  ]);
 });
 
 test("splitProps should fallback to the deprecated version if state is not a plain object", () => {

--- a/packages/reakit-utils/src/splitProps.ts
+++ b/packages/reakit-utils/src/splitProps.ts
@@ -56,7 +56,7 @@ function __deprecatedSplitProps<
 export function splitProps<T extends Record<string, any>, K extends keyof T>(
   props: T,
   keys: ReadonlyArray<K> | Array<K> = []
-): [{ [P in K]: T[P] }, Omit<T, K>] {
+): [{ [P in K]: T["state"][P] }, Omit<T, K>] {
   if (!isPlainObject(props.state)) {
     return __deprecatedSplitProps(props, keys);
   }

--- a/packages/reakit-utils/src/splitProps.ts
+++ b/packages/reakit-utils/src/splitProps.ts
@@ -55,15 +55,14 @@ function __deprecatedSplitProps<
  */
 export function splitProps<T extends Record<string, any>, K extends keyof T>(
   props: T,
-  keys?: ReadonlyArray<K> | Array<K>
-): [{ [P in K]: T["state"][P] }, Omit<T, K>] {
-  if (!isPlainObject(props.state) && keys) {
-    return __deprecatedSplitProps(props, keys);
+  keys: ReadonlyArray<K> | Array<K> = []
+): [{ [P in K]: T["state"][P] }, Omit<T, K | "state">] {
+  const [picked, omitted] = __deprecatedSplitProps(props, [...keys, "state"]);
+
+  if (isPlainObject(picked.state)) {
+    const { state, ...restPicked } = picked;
+    return [{ ...state, ...restPicked }, omitted];
   }
 
-  const { state, ...restProps } = props;
-  return [
-    props.state as { [P in K]: T["state"][P] },
-    (restProps as unknown) as Omit<T, K>,
-  ];
+  return [picked, omitted];
 }

--- a/packages/reakit-utils/src/splitProps.ts
+++ b/packages/reakit-utils/src/splitProps.ts
@@ -56,13 +56,12 @@ function __deprecatedSplitProps<
 export function splitProps<T extends Record<string, any>, K extends keyof T>(
   props: T,
   keys: ReadonlyArray<K> | Array<K> = []
-): [{ [P in K]: T["state"][P] }, Omit<T, K | "state">] {
+): [{ [P in K]: T[P] }, Omit<T, K>] {
+  if (!isPlainObject(props.state)) {
+    return __deprecatedSplitProps(props, keys);
+  }
   const [picked, omitted] = __deprecatedSplitProps(props, [...keys, "state"]);
 
-  if (isPlainObject(picked.state)) {
-    const { state, ...restPicked } = picked;
-    return [{ ...state, ...restPicked }, omitted];
-  }
-
-  return [picked, omitted];
+  const { state, ...restPicked } = picked;
+  return [{ ...state, ...restPicked }, omitted as Omit<T, K>];
 }

--- a/packages/reakit/src/Dialog/__examples__/ChatDialog/__tests__/index-test.tsx
+++ b/packages/reakit/src/Dialog/__examples__/ChatDialog/__tests__/index-test.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { click, screen, render, axe } from "reakit-test-utils";
+import ChatDialog from "..";
+
+test("open and close chat dialog", () => {
+  const { baseElement } = render(<ChatDialog />);
+  const dialog = screen.getByLabelText("Chat");
+  expect(dialog).not.toBeVisible();
+  click(screen.getByText("Open chat"));
+  expect(dialog).toBeVisible();
+  click(baseElement);
+  expect(dialog).toBeVisible();
+});
+
+test("a11y", async () => {
+  const { baseElement } = render(<ChatDialog />);
+  expect(await axe(baseElement)).toHaveNoViolations();
+});

--- a/packages/reakit/src/Dialog/__examples__/ChatDialog/index.tsx
+++ b/packages/reakit/src/Dialog/__examples__/ChatDialog/index.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { Button } from "reakit/Button";
+import { useDialogState, Dialog, DialogDisclosure } from "reakit/Dialog";
+
+export default function ChatDialog() {
+  const state = useDialogState();
+  return (
+    <>
+      <DialogDisclosure state={state}>Open chat</DialogDisclosure>
+      <Dialog state={state} hideOnClickOutside={false} aria-label="Chat">
+        <Button onClick={state.hide}>Close chat</Button>
+      </Dialog>
+    </>
+  );
+}

--- a/packages/reakit/src/Dialog/__examples__/index.story.ts
+++ b/packages/reakit/src/Dialog/__examples__/index.story.ts
@@ -1,5 +1,6 @@
 import { Dialog } from "../Dialog";
 
+export { default as ChatDialog } from "./ChatDialog";
 export { default as DialogWithCompositeWithTooltip } from "./DialogWithCompositeWithTooltip";
 export { default as DialogWithFocusLoss } from "./DialogWithFocusLoss";
 export { default as DialogWithForm } from "./DialogWithForm";


### PR DESCRIPTION
Closes #798

**How to test?**

See tests, [storybook](https://deploy-preview-799--reakit.netlify.app/storybook/?path=/story/dialog--chat-dialog) (try to close the chat dialog by clicking outside) and the generated [CodeSandbox](https://codesandbox.io/s/naughty-resonance-yb9l8).

**Does this PR introduce breaking changes?**

No

---

cc @david-szabo97 Could you please have a look here when you have time? 😊