### PR TITLE
fix: Stop passing the `state` prop to custom `as` components

### DIFF
--- a/packages/reakit-system/src/__tests__/state-createComponent-test.tsx
+++ b/packages/reakit-system/src/__tests__/state-createComponent-test.tsx
@@ -51,23 +51,6 @@ test("as generic component", () => {
   `);
 });
 
-test("as other component created with createComponent", () => {
-  const useA = ({ a }: { a: string }, h: any) => ({ children: a, ...h });
-  const A = createComponent({ as: "div", useHook: useA });
-
-  const useB = ({ b }: { b: string }, h: any) => ({ id: b, ...h });
-  const B = createComponent({ as: "div", useHook: useB });
-
-  const { getByText } = render(<A as={B} state={{ a: "a", b: "b" }} />);
-  expect(getByText("a")).toMatchInlineSnapshot(`
-            <div
-              id="b"
-            >
-              a
-            </div>
-      `);
-});
-
 test("wrap", () => {
   const useA = (_: any, h: any) => ({
     wrapElement: (element: React.ReactNode) => (

--- a/packages/reakit-system/src/createComponent.ts
+++ b/packages/reakit-system/src/createComponent.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 import { As, PropsWithAs } from "reakit-utils/types";
 import { splitProps } from "reakit-utils/splitProps";
 import { shallowEqual } from "reakit-utils/shallowEqual";
-import { isPlainObject, normalizePropsAreEqual } from "reakit-utils";
+import { normalizePropsAreEqual } from "reakit-utils/normalizePropsAreEqual";
 import { forwardRef } from "./__utils/forwardRef";
 import { useCreateElement as defaultUseCreateElement } from "./useCreateElement";
 import { memo } from "./__utils/memo";
@@ -73,16 +73,9 @@ export function createComponent<T extends As, O>({
       // @ts-ignore
       const asKeys = as.render?.__keys || as.__keys;
       const asOptions = asKeys && splitProps(props, asKeys)[0];
-      const allProps =
-        // If `as` is a string, then that means it's an element not a component
-        // we don't need to pass the state in this case.
-        // If a component is passed, then the component can decide
-        // what should happen with the state prop.
-        isPlainObject(props.state) && typeof as !== "string"
-          ? { state: props.state, ...elementProps }
-          : asOptions
-          ? { ...elementProps, ...asOptions }
-          : elementProps;
+      const allProps = asOptions
+        ? { ...elementProps, ...asOptions }
+        : elementProps;
       const element = useCreateElement(as, allProps as typeof props);
       if (wrapElement) {
         return wrapElement(element);


### PR DESCRIPTION
Closes #797

**How to test?**

Check console on CodeSandbox: https://codesandbox.io/s/empty-resonance-43go3

**Does this PR introduce breaking changes?**

Technically, yes. The following code would stop working:
```jsx
<Grid as={Composite} state={state} />
```
But I've never really seen that being used like that. `Grid` uses `Composite` internally already, so that doesn't make much sense.

And, since `state={state}` isn't documented yet, I think it's safe to change it. The only problem is that it would behave differently from `{...state}`. But I've temporarily removed support for this on `{...state}` as well and, still, all the tests were passing. So I would argue that this behavior is not really useful, but let's keep it as is for `{...state}` so as to prevent breaking edge cases.

However we decide to proceed on v1, I don't think we should support this on v2's `state={state}`. 