### PR TITLE
fix: Fix `Menu` scroll jump

### DIFF
--- a/packages/reakit-playground/src/__deps/reakit-utils.ts
+++ b/packages/reakit-playground/src/__deps/reakit-utils.ts
@@ -8,6 +8,7 @@ export default {
   "reakit-utils/contains": require("reakit-utils/contains"),
   "reakit-utils/createEvent": require("reakit-utils/createEvent"),
   "reakit-utils/createOnKeyDown": require("reakit-utils/createOnKeyDown"),
+  "reakit-utils/dom": require("reakit-utils/dom"),
   "reakit-utils/ensureFocus": require("reakit-utils/ensureFocus"),
   "reakit-utils/fireBlurEvent": require("reakit-utils/fireBlurEvent"),
   "reakit-utils/fireEvent": require("reakit-utils/fireEvent"),

--- a/packages/reakit-utils/.gitignore
+++ b/packages/reakit-utils/.gitignore
@@ -6,6 +6,7 @@
 /createEvent
 /createOnKeyDown
 /dist
+/dom
 /ensureFocus
 /es
 /fireBlurEvent

--- a/packages/reakit-utils/README.md
+++ b/packages/reakit-utils/README.md
@@ -30,6 +30,7 @@ yarn add reakit-utils
 -   [contains](#contains)
 -   [createEvent](#createevent)
 -   [createOnKeyDown](#createonkeydown)
+-   [isUA](#isua)
 -   [ensureFocus](#ensurefocus)
 -   [fireBlurEvent](#fireblurevent)
 -   [fireEvent](#fireevent)
@@ -174,6 +175,14 @@ Returns an `onKeyDown` handler to be passed to a component.
     -   `options.preventDefault`   (optional, default `true`)
 
 Returns **React.KeyboardEventHandler** 
+
+### isUA
+
+Checks if a given string exists in the user agent string.
+
+#### Parameters
+
+-   `string` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 ### ensureFocus
 

--- a/packages/reakit-utils/src/dom.ts
+++ b/packages/reakit-utils/src/dom.ts
@@ -1,0 +1,9 @@
+import { canUseDOM } from "./canUseDOM";
+
+/**
+ * Checks if a given string exists in the user agent string.
+ */
+export function isUA(string: string) {
+  if (!canUseDOM) return false;
+  return window.navigator.userAgent.indexOf(string) !== -1;
+}

--- a/packages/reakit-utils/src/index.ts
+++ b/packages/reakit-utils/src/index.ts
@@ -4,6 +4,7 @@ export * from "./closest";
 export * from "./contains";
 export * from "./createEvent";
 export * from "./createOnKeyDown";
+export * from "./dom";
 export * from "./ensureFocus";
 export * from "./fireEvent";
 export * from "./fireBlurEvent";

--- a/packages/reakit/src/Popover/PopoverState.ts
+++ b/packages/reakit/src/Popover/PopoverState.ts
@@ -6,7 +6,7 @@ import {
 } from "reakit-utils/useSealedState";
 import { useIsomorphicEffect } from "reakit-utils/useIsomorphicEffect";
 import { shallowEqual } from "reakit-utils/shallowEqual";
-import { canUseDOM } from "reakit-utils/canUseDOM";
+import { isUA } from "reakit-utils/dom";
 import {
   DialogState,
   DialogActions,
@@ -14,11 +14,6 @@ import {
   useDialogState,
   DialogStateReturn,
 } from "../Dialog/DialogState";
-
-function isUA(string: string) {
-  if (!canUseDOM) return false;
-  return window.navigator.userAgent.indexOf(string) !== -1;
-}
 
 const isSafari = isUA("Mac") && !isUA("Chrome") && isUA("Safari");
 

--- a/packages/reakit/src/Popover/PopoverState.ts
+++ b/packages/reakit/src/Popover/PopoverState.ts
@@ -142,7 +142,6 @@ export function usePopoverState(
   const referenceRef = React.useRef<HTMLElement>(null);
   const popoverRef = React.useRef<HTMLElement>(null);
   const arrowRef = React.useRef<HTMLElement>(null);
-  const popperCreated = React.useRef(false);
 
   const [originalPlacement, place] = React.useState(sealedPlacement);
   const [placement, setPlacement] = React.useState(sealedPlacement);
@@ -228,7 +227,6 @@ export function usePopoverState(
           },
         ],
       });
-      popperCreated.current = true;
     }
     return () => {
       if (popper.current) {

--- a/packages/reakit/src/Popover/PopoverState.ts
+++ b/packages/reakit/src/Popover/PopoverState.ts
@@ -174,7 +174,9 @@ export function usePopoverState(
         // https://popper.js.org/docs/v2/constructors/#options
         placement: originalPlacement,
         strategy: fixed ? "fixed" : "absolute",
-        // Safari needs styles to be applied in the first render
+        // Safari needs styles to be applied in the first render, otherwise
+        // hovering over the popover when it gets visible for the first time
+        // will change its dimensions unexpectedly.
         onFirstUpdate: isSafari ? updateState : undefined,
         modifiers: [
           {

--- a/packages/reakit/src/Popover/PopoverState.ts
+++ b/packages/reakit/src/Popover/PopoverState.ts
@@ -199,7 +199,7 @@ export function usePopoverState(
           {
             // https://popper.js.org/docs/v2/modifiers/#custom-modifiers
             name: "updateState",
-            phase: "write",
+            phase: "main",
             requires: ["computeStyles"],
             enabled:
               // Safari needs styles to be applied in the first render

--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -9,7 +9,7 @@ import { hasFocusWithin } from "reakit-utils/hasFocusWithin";
 import { isButton } from "reakit-utils/isButton";
 import { isPortalEvent } from "reakit-utils/isPortalEvent";
 import { getActiveElement } from "reakit-utils/getActiveElement";
-import { canUseDOM } from "reakit-utils/canUseDOM";
+import { isUA } from "reakit-utils/dom";
 import { getClosestFocusable } from "reakit-utils/tabbable";
 import { RoleOptions, RoleHTMLProps, useRole } from "../Role/Role";
 import { TABBABLE_KEYS } from "./__keys";
@@ -32,11 +32,6 @@ export type TabbableHTMLProps = RoleHTMLProps & {
 };
 
 export type TabbableProps = TabbableOptions & TabbableHTMLProps;
-
-function isUA(string: string) {
-  if (!canUseDOM) return false;
-  return window.navigator.userAgent.indexOf(string) !== -1;
-}
 
 const isSafariOrFirefoxOnMac =
   isUA("Mac") && !isUA("Chrome") && (isUA("Safari") || isUA("Firefox"));


### PR DESCRIPTION
Closes #751

Updated the popover state to update the popper styles in the main phase so they're defined before the menu popover receives focus. I'm still not sure if this is the right solution nor the side effects it could have. I need to read Popper.js docs more carefully.

**How to test?**

Follow the reproduction steps on #751 on https://deploy-preview-801--reakit.netlify.app/

**Does this PR introduce breaking changes?**

No