### PR TITLE
fix(Combobox): Fix badly positioned popover on click + minValueLength

### DIFF
--- a/packages/reakit/src/Combobox/Combobox.ts
+++ b/packages/reakit/src/Combobox/Combobox.ts
@@ -227,11 +227,19 @@ export const unstable_useCombobox = createHook<
       (event: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
         onClickRef.current?.(event);
         if (event.defaultPrevented) return;
-        options.show?.();
+        if (value.length >= options.minValueLength) {
+          options.show?.();
+        }
         options.setCurrentId?.(null);
         options.setInputValue(value);
       },
-      [options.show, options.setCurrentId, options.setInputValue, value]
+      [
+        options.show,
+        options.setCurrentId,
+        options.setInputValue,
+        options.minValueLength,
+        value,
+      ]
     );
 
     const onBlur = React.useCallback(
@@ -350,6 +358,7 @@ export type unstable_ComboboxOptions = CompositeOptions &
     | "show"
     | "hide"
     | "unstable_referenceRef"
+    | "minValueLength"
   > &
   Pick<
     unstable_ComboboxStateReturn,

--- a/packages/reakit/src/Combobox/Combobox.ts
+++ b/packages/reakit/src/Combobox/Combobox.ts
@@ -227,7 +227,8 @@ export const unstable_useCombobox = createHook<
       (event: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
         onClickRef.current?.(event);
         if (event.defaultPrevented) return;
-        if (value.length >= options.minValueLength) {
+        // https://github.com/reakit/reakit/issues/808
+        if (!options.minValueLength || value.length >= options.minValueLength) {
           options.show?.();
         }
         options.setCurrentId?.(null);

--- a/packages/reakit/src/Combobox/README.md
+++ b/packages/reakit/src/Combobox/README.md
@@ -760,7 +760,7 @@ similarly to `readOnly` on form elements. In this case, only
   When enabled, user can hide the combobox popover by pressing
 <kbd>Esc</kbd> while focusing on the combobox input.
 
-<details><summary>23 state props</summary>
+<details><summary>24 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
 
@@ -861,6 +861,12 @@ state will get focus.
   <code>boolean</code>
 
   Whether it's visible or not.
+
+- **`minValueLength`**
+  <code>number</code>
+
+  How many characters are needed for opening the combobox popover and
+populating `matches` with filtered values.
 
 - **`list`**
   <code>boolean</code>


### PR DESCRIPTION
Before this commit we were trying to show the Popover as soon as the user click
on the Combobox. This resulted in badly positioned Popover in some cases like
non-static Combobox containers.

Now we check if the Combobox value length is bigger than the minValueLength
before trying to show the Popover.

fixes #808