### PR TITLE
fix: Fix `CompositeItem` with `tabindex=0` on the first render

### DIFF
--- a/packages/reakit/src/Composite/CompositeItem.ts
+++ b/packages/reakit/src/Composite/CompositeItem.ts
@@ -151,7 +151,7 @@ export const useCompositeItem = createHook<
         isCurrentItem) ||
       // We don't want to set tabIndex="-1" when using CompositeItem as a
       // standalone component, without state props.
-      !options.items?.length;
+      !options.items;
 
     React.useEffect(() => {
       if (!id) return undefined;

--- a/packages/reakit/src/Grid/__tests__/GridCell-test.tsx
+++ b/packages/reakit/src/Grid/__tests__/GridCell-test.tsx
@@ -26,7 +26,7 @@ test("render", () => {
       <span
         id="gridcell"
         role="gridcell"
-        tabindex="0"
+        tabindex="-1"
       />
     </div>
   `);

--- a/packages/reakit/src/Menu/__tests__/MenuItem-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/MenuItem-test.tsx
@@ -26,7 +26,7 @@ test("render", () => {
         <button
           id="item"
           role="menuitem"
-          tabindex="0"
+          tabindex="-1"
         >
           item
         </button>

--- a/packages/reakit/src/Menu/__tests__/MenuItemCheckbox-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/MenuItemCheckbox-test.tsx
@@ -31,7 +31,7 @@ test("render", () => {
           id="item"
           name="checkbox"
           role="menuitemcheckbox"
-          tabindex="0"
+          tabindex="-1"
         />
       </div>
     </body>

--- a/packages/reakit/src/Menu/__tests__/MenuItemRadio-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/MenuItemRadio-test.tsx
@@ -31,7 +31,7 @@ test("render", () => {
           aria-checked="false"
           id="item"
           role="menuitemradio"
-          tabindex="0"
+          tabindex="-1"
         />
       </div>
     </body>

--- a/packages/reakit/src/Radio/__tests__/Radio-test.tsx
+++ b/packages/reakit/src/Radio/__tests__/Radio-test.tsx
@@ -26,7 +26,7 @@ test("render", () => {
         <input
           aria-checked="false"
           id="radio"
-          tabindex="0"
+          tabindex="-1"
           type="radio"
           value="radio"
         />

--- a/packages/reakit/src/Tab/__tests__/Tab-test.tsx
+++ b/packages/reakit/src/Tab/__tests__/Tab-test.tsx
@@ -30,7 +30,7 @@ test("render", () => {
           aria-selected="false"
           id="tab"
           role="tab"
-          tabindex="0"
+          tabindex="-1"
         >
           tab
         </button>
@@ -93,7 +93,7 @@ test("render selected", () => {
           aria-selected="true"
           id="tab"
           role="tab"
-          tabindex="0"
+          tabindex="-1"
         >
           tab
         </button>

--- a/packages/reakit/src/Toolbar/__tests__/ToolbarItem-test.tsx
+++ b/packages/reakit/src/Toolbar/__tests__/ToolbarItem-test.tsx
@@ -24,7 +24,7 @@ test("render", () => {
       <div>
         <button
           id="item"
-          tabindex="0"
+          tabindex="-1"
         >
           button
         </button>


### PR DESCRIPTION
`CompositeItem` was checking for `props.items.length`, which is always `0` on the first render. This PR changes it so it checks for the existence of the items array instead in order to determine whether it should have tabindex -1 or not.

**Does this PR introduce breaking changes?**

No