### PR TITLE
fix: do not scroll to bottom of page when opening modal menus

### DIFF
--- a/packages/reakit/src/Button/__examples__/ButtonWithTooltip/__tests__/index-test.tsx
+++ b/packages/reakit/src/Button/__examples__/ButtonWithTooltip/__tests__/index-test.tsx
@@ -32,7 +32,7 @@ test("markup", () => {
           hidden=""
           id="id-1"
           role="tooltip"
-          style="display: none; pointer-events: none;"
+          style="display: none; position: fixed; left: 0px; top: 0px; pointer-events: none;"
         >
           Tooltip
         </div>

--- a/packages/reakit/src/Menu/MenuButton.ts
+++ b/packages/reakit/src/Menu/MenuButton.ts
@@ -184,7 +184,7 @@ export const useMenuButton = createHook<MenuButtonOptions, MenuButtonHTMLProps>(
               !parentIsMenuBar &&
               !options.visible
             ) {
-              options.move?.(null);
+              setTimeout(() => options.move?.(null), 0);
             }
           }
           hasPressedMouse.current = false;

--- a/packages/reakit/src/Menu/MenuButton.ts
+++ b/packages/reakit/src/Menu/MenuButton.ts
@@ -184,7 +184,7 @@ export const useMenuButton = createHook<MenuButtonOptions, MenuButtonHTMLProps>(
               !parentIsMenuBar &&
               !options.visible
             ) {
-              setTimeout(() => options.move?.(null), 0);
+              options.move?.(null);
             }
           }
           hasPressedMouse.current = false;


### PR DESCRIPTION
Closes https://github.com/reakit/reakit/issues/819

~This change adjusts the move behavior on MenuButton to wait a tick before triggering, thus ensuring React can render the menu on the screen and preventing a scroll jump.~ Trying a different approach that feels a bit better. The issue came down to popper briefly rendering the popover content on screen in the document flow (it quickly applies appropriate styles on second tick). What I did to resolve is to set the initial popper styles to fixed position so that it doesn't affect document flow.

I also do not think that `createPopper` needs to be called unless `dialog.visible` is `true`, which saves a bunch of unnecessary work.

It also has the nice benefit of enabling lazy menus along the lines of the below. This is particularly helpful for situations such as file system trees, where hundreds of menus are attached to items in the tree and do not need to be rendered until the user interacts with the item.

```tsx
import {
  useMenuState,
  Menu,
  MenuItem,
  MenuButton,
  MenuSeparator,
} from "reakit/Menu";

export function Example() {
  const menu = useMenuState();
  return (
    <>
      <MenuButton {...menu}>Preferences</MenuButton>

      <ExampleContents menu={menu}>    
        <MenuItem {...menu}>Settings</MenuItem>
        <MenuItem {...menu} disabled>
          Extensions
        </MenuItem>
        <MenuSeparator {...menu} />
        <MenuItem {...menu}>Keyboard shortcuts</MenuItem>
      </ExampleContents>
    </>
  );
}

function ExampleContents({ menu, children }) {
  let [shouldRender, setShouldRender] = React.useState(menu.visible);

  React.useEffect(() => {
    if (shouldRender !== menu.visible) setShouldRender(menu.visible);
  }, [menu.visible, shouldRender]);

  /**
   * Performance improvement by not rendering menus until they're opened.
   * Need the extra shoudlRender/useEffect tick for reakit to properly switch focus etc on submenus
   */
  if (!menu.visible && !shouldRender) return null;

  return (
    <Menu {...menu} aria-label="Preferences">
      {children}
    </Menu>
  )
}
```

**Does this PR introduce breaking changes?**

No
