### PR TITLE
fix: Revert `CompositeItem` tabIndex fix

### DIFF
--- a/packages/reakit/src/Composite/CompositeItem.ts
+++ b/packages/reakit/src/Composite/CompositeItem.ts
@@ -151,7 +151,7 @@ export const useCompositeItem = createHook<
         isCurrentItem) ||
       // We don't want to set tabIndex="-1" when using CompositeItem as a
       // standalone component, without state props.
-      !options.items;
+      !options.items?.length;
 
     React.useEffect(() => {
       if (!id) return undefined;

--- a/packages/reakit/src/Grid/__tests__/GridCell-test.tsx
+++ b/packages/reakit/src/Grid/__tests__/GridCell-test.tsx
@@ -26,7 +26,7 @@ test("render", () => {
       <span
         id="gridcell"
         role="gridcell"
-        tabindex="-1"
+        tabindex="0"
       />
     </div>
   `);

--- a/packages/reakit/src/Menu/__tests__/MenuItem-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/MenuItem-test.tsx
@@ -26,7 +26,7 @@ test("render", () => {
         <button
           id="item"
           role="menuitem"
-          tabindex="-1"
+          tabindex="0"
         >
           item
         </button>

--- a/packages/reakit/src/Menu/__tests__/MenuItemCheckbox-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/MenuItemCheckbox-test.tsx
@@ -31,7 +31,7 @@ test("render", () => {
           id="item"
           name="checkbox"
           role="menuitemcheckbox"
-          tabindex="-1"
+          tabindex="0"
         />
       </div>
     </body>

--- a/packages/reakit/src/Menu/__tests__/MenuItemRadio-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/MenuItemRadio-test.tsx
@@ -31,7 +31,7 @@ test("render", () => {
           aria-checked="false"
           id="item"
           role="menuitemradio"
-          tabindex="-1"
+          tabindex="0"
         />
       </div>
     </body>

--- a/packages/reakit/src/Radio/__tests__/Radio-test.tsx
+++ b/packages/reakit/src/Radio/__tests__/Radio-test.tsx
@@ -26,7 +26,7 @@ test("render", () => {
         <input
           aria-checked="false"
           id="radio"
-          tabindex="-1"
+          tabindex="0"
           type="radio"
           value="radio"
         />

--- a/packages/reakit/src/Tab/__tests__/Tab-test.tsx
+++ b/packages/reakit/src/Tab/__tests__/Tab-test.tsx
@@ -30,7 +30,7 @@ test("render", () => {
           aria-selected="false"
           id="tab"
           role="tab"
-          tabindex="-1"
+          tabindex="0"
         >
           tab
         </button>
@@ -93,7 +93,7 @@ test("render selected", () => {
           aria-selected="true"
           id="tab"
           role="tab"
-          tabindex="-1"
+          tabindex="0"
         >
           tab
         </button>

--- a/packages/reakit/src/Toolbar/__tests__/ToolbarItem-test.tsx
+++ b/packages/reakit/src/Toolbar/__tests__/ToolbarItem-test.tsx
@@ -24,7 +24,7 @@ test("render", () => {
       <div>
         <button
           id="item"
-          tabindex="-1"
+          tabindex="0"
         >
           button
         </button>


### PR DESCRIPTION
#817 ended up introducing some breaking changes. This PR reverts it.