### PR TITLE
Feat/popper modifiers

### DIFF
--- a/packages/reakit/src/Combobox/README.md
+++ b/packages/reakit/src/Combobox/README.md
@@ -124,6 +124,11 @@ element.
 
   Offset between the reference and the popover: [main axis, alt axis]. Should not be combined with `gutter`.
 
+- **`unstable_popperModifiers`** <span title="Experimental">⚠️</span>
+  <code>[Object] | undefined</code>
+
+  Modifiers for Popper.js. Any attributes added here will override other configurations set in props.
+
 - **`gutter`**
   <code>number | undefined</code>
 
@@ -599,6 +604,11 @@ element.
   <code>[string | number, string | number] | undefined</code>
 
   Offset between the reference and the popover: [main axis, alt axis]. Should not be combined with `gutter`.
+
+- **`unstable_popperModifiers`** <span title="Experimental">⚠️</span>
+  <code>[Object] | undefined</code>
+
+  Modifiers for Popper.js. Any attributes added here will override other configurations set in props.
 
 - **`gutter`**
   <code>number | undefined</code>

--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -774,6 +774,11 @@ element.
 
   Offset between the reference and the popover: [main axis, alt axis]. Should not be combined with `gutter`.
 
+- **`unstable_popperModifiers`** <span title="Experimental">⚠️</span>
+  <code>[Object] | undefined</code>
+
+  Modifiers for Popper.js. Any attributes added here will override other configurations set in props.
+
 - **`gutter`**
   <code>number | undefined</code>
 

--- a/packages/reakit/src/Popover/PopoverState.ts
+++ b/packages/reakit/src/Popover/PopoverState.ts
@@ -97,6 +97,10 @@ export type PopoverInitialState = DialogInitialState &
      */
     unstable_offset?: [number | string, number | string];
     /**
+     * Modifiers for Popper.js. Any attributes added here will override other configurations set in props.
+     */
+    unstable_popperModifiers?: [Object] | undefined;
+    /**
      * Offset between the reference and the popover on the main axis. Should not be combined with `unstable_offset`.
      */
     gutter?: number;
@@ -127,6 +131,7 @@ export function usePopoverState(
     placement: sealedPlacement = "bottom",
     unstable_flip: flip = true,
     unstable_offset: sealedOffset,
+    unstable_popperModifiers,
     unstable_preventOverflow: preventOverflow = true,
     unstable_fixed: fixed = false,
     modal = false,
@@ -222,6 +227,9 @@ export function usePopoverState(
             enabled: dialog.visible && process.env.NODE_ENV !== "test",
             fn: ({ state }) => updateState(state),
           },
+          // Spread any Popper.js modifier objects into our modifier array.
+          // This can potentially override any of the above modifier objects.
+          ...(unstable_popperModifiers || []),
         ],
       });
     }

--- a/packages/reakit/src/Popover/README.md
+++ b/packages/reakit/src/Popover/README.md
@@ -311,6 +311,11 @@ element.
 
   Offset between the reference and the popover: [main axis, alt axis]. Should not be combined with `gutter`.
 
+- **`unstable_popperModifiers`** <span title="Experimental">⚠️</span>
+  <code>[Object] | undefined</code>
+
+  Modifiers for Popper.js. Any attributes added here will override other configurations set in props.
+
 - **`gutter`**
   <code>number | undefined</code>
 

--- a/packages/reakit/src/Popover/__examples__/PopoverModifiers/index.tsx
+++ b/packages/reakit/src/Popover/__examples__/PopoverModifiers/index.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { usePopoverState, Popover, PopoverDisclosure } from "reakit/Popover";
+
+export default function PopoverModifiers() {
+  const sameWidth = {
+    name: "sameWidth",
+    enabled: true,
+    phase: "beforeWrite",
+    requires: ["computeStyles"],
+    // @ts-ignore: No implicit any on state
+    fn: ({ state }) => {
+      state.styles.popper.width = `${state.rects.reference.width}px`;
+    },
+    // @ts-ignore: No implicit any on state
+    effect: ({ state }) => {
+      state.elements.popper.style.width = `${state.elements.reference.offsetWidth}px`;
+    },
+  };
+
+  const popover = usePopoverState();
+  const modifiedPopover = usePopoverState({
+    unstable_popperModifiers: [sameWidth],
+  });
+
+  const sectionStyle = {
+    width: "50%",
+    display: "inline-block",
+  };
+
+  return (
+    <>
+      <section style={sectionStyle}>
+        <h2>Popover</h2>
+        <PopoverDisclosure {...popover}>
+          This Is A Wide Disclosure
+        </PopoverDisclosure>
+        <Popover {...popover} aria-label="Greeting">
+          Hello
+        </Popover>
+      </section>
+
+      <section style={sectionStyle}>
+        <h2>Matched Width Popover</h2>
+        <PopoverDisclosure {...modifiedPopover}>
+          This Is A Wide Disclosure
+        </PopoverDisclosure>
+        <Popover {...modifiedPopover} aria-label="Greeting">
+          Hello
+        </Popover>
+      </section>
+    </>
+  );
+}

--- a/packages/reakit/src/Popover/__examples__/index.story.ts
+++ b/packages/reakit/src/Popover/__examples__/index.story.ts
@@ -1,0 +1,8 @@
+import { Popover } from "../Popover";
+
+export { default as PopoverModifiers } from "./PopoverModifiers";
+
+export default {
+  title: "Popover",
+  component: Popover,
+};

--- a/packages/reakit/src/Popover/__keys.ts
+++ b/packages/reakit/src/Popover/__keys.ts
@@ -19,6 +19,7 @@ const POPOVER_STATE_KEYS = [
   "unstable_popoverRef",
   "unstable_arrowRef",
   "unstable_popoverStyles",
+  "unstable_popperModifiers",
   "unstable_arrowStyles",
   "unstable_originalPlacement",
   "unstable_update",

--- a/packages/reakit/src/Popover/__keys.ts
+++ b/packages/reakit/src/Popover/__keys.ts
@@ -19,7 +19,6 @@ const POPOVER_STATE_KEYS = [
   "unstable_popoverRef",
   "unstable_arrowRef",
   "unstable_popoverStyles",
-  "unstable_popperModifiers",
   "unstable_arrowStyles",
   "unstable_originalPlacement",
   "unstable_update",

--- a/packages/reakit/src/Tooltip/README.md
+++ b/packages/reakit/src/Tooltip/README.md
@@ -229,6 +229,11 @@ element.
 
   Offset between the reference and the popover: [main axis, alt axis]. Should not be combined with `gutter`.
 
+- **`unstable_popperModifiers`** <span title="Experimental">⚠️</span>
+  <code>[Object] | undefined</code>
+
+  Modifiers for Popper.js. Any attributes added here will override other configurations set in props.
+
 - **`gutter`**
   <code>number | undefined</code>
 


### PR DESCRIPTION
Closes #606 

**Screenshots**
![image](https://user-images.githubusercontent.com/1161781/103822682-73199300-5025-11eb-8dac-3cc5248b27a0.png)

**How to test?**

There is now a Storybook story that can be used to test passing a Popper.js modifier on `usePopoverState` using `unstable_popperModifiers`. There is a side by side comparison with a default example without the initial state modifier.

**Does this PR introduce breaking changes?**

This should not introduce any breaking changes in existing code. However, if anyone uses this new `unstable_` state prop, they will need to be aware that it might override any of the other Popper.js modifiers that are already used by Reakit.
