### PR TITLE
Update Menu Abstracting example

### DIFF
--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -415,6 +415,8 @@ function Example() {
 
 You can build your own `Menu` component with a different API on top of Reakit.
 
+Be careful not to accidentally shadow props coming in from the menu state.
+
 ```jsx
 import React from "react";
 import {
@@ -422,35 +424,56 @@ import {
   Menu as BaseMenu,
   MenuItem,
   MenuButton,
+  MenuSeparator,
 } from "reakit/Menu";
 
-function Menu({ disclosure, menuItems, ...props }) {
-  const menu = useMenuState();
-  return (
-    <>
-      <MenuButton {...menu} ref={disclosure.ref} {...disclosure.props}>
-        {(disclosureProps) => React.cloneElement(disclosure, disclosureProps)}
-      </MenuButton>
-      <BaseMenu {...menu} {...props}>
-        {menuItems.map((item, i) => (
-          <MenuItem {...menu} {...item.props} key={i}>
-            {(itemProps) => React.cloneElement(item, itemProps)}
-          </MenuItem>
-        ))}
-      </BaseMenu>
-    </>
-  );
-}
+const Menu = React.forwardRef(
+  ({ disclosure, menuItems, menuProps, ...props }, ref) => {
+    const menu = useMenuState();
+    return (
+      <>
+        <MenuButton ref={ref} {...menu} {...props} {...disclosure.props}>
+          {(disclosureProps) => React.cloneElement(disclosure, disclosureProps)}
+        </MenuButton>
+        <BaseMenu {...menu} {...menuProps}>
+          {menuItems.map((item, i) => {
+            if (item.type === MenuSeparator) {
+              return React.cloneElement(item, {
+                ...menu,
+                key: item.key || i,
+                ...item.props,
+              });
+            }
+            return (
+              <MenuItem {...menu} {...item.props} key={item.key || i}>
+                {(itemProps) => React.cloneElement(item, itemProps)}
+              </MenuItem>
+            );
+          })}
+        </BaseMenu>
+      </>
+    );
+  }
+);
 
 function Example() {
   return (
     <Menu
-      aria-label="Custom menu"
+      menuProps={{ "aria-label": "Custom menu" }}
       disclosure={<button>Custom menu</button>}
       menuItems={[
         <button>Custom item 1</button>,
         <button>Custom item 2</button>,
         <button>Custom item 3</button>,
+        <MenuSeparator />,
+        <Menu
+          menuProps={{ "aria-label": "Sub Menu" }}
+          disclosure={<button>Sub Menu</button>}
+          menuItems={[
+            <button>Custom item 4</button>,
+            <button>Custom item 5</button>,
+          ]}
+        />,
       ]}
     />
   );

--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -424,7 +424,7 @@ import {
   MenuButton,
 } from "reakit/Menu";
 
-function Menu({ disclosure, items, ...props }) {
+function Menu({ disclosure, menuItems, ...props }) {
   const menu = useMenuState();
   return (
     <>
@@ -432,7 +432,7 @@ function Menu({ disclosure, items, ...props }) {
         {(disclosureProps) => React.cloneElement(disclosure, disclosureProps)}
       </MenuButton>
       <BaseMenu {...menu} {...props}>
-        {items.map((item, i) => (
+        {menuItems.map((item, i) => (
           <MenuItem {...menu} {...item.props} key={i}>
             {(itemProps) => React.cloneElement(item, itemProps)}
           </MenuItem>
@@ -447,7 +447,7 @@ function Example() {
     <Menu
       aria-label="Custom menu"
       disclosure={<button>Custom menu</button>}
-      items={[
+      menuItems={[
         <button>Custom item 1</button>,
         <button>Custom item 2</button>,
         <button>Custom item 3</button>,


### PR DESCRIPTION
In the docs, change use of `items` to `menuItems` as `items` can be conflicting with the menu state props

Closes #839

I can also set up this PR to extend the abstracting example towards what I have in #839 which allows for the `Menu` component to be used as a menuItem for sub menus or that could be set up as a separate PR if desired.

**Screenshots**


![image](https://user-images.githubusercontent.com/19843782/107418479-52d56c00-6adc-11eb-9277-30e2925eaaf3.png)

**Does this PR introduce breaking changes?**

No, just an update to the markdown for the Menu component
