### PR TITLE
feat: Add `onFocusVisible` prop to Tabbable

### DIFF
--- a/packages/reakit/package.json
+++ b/packages/reakit/package.json
@@ -40,6 +40,7 @@
   ],
   "dependencies": {
     "@popperjs/core": "^2.5.4",
+    "@react-aria/interactions": "^3.3.3",
     "body-scroll-lock": "^3.1.5",
     "reakit-system": "^0.15.1",
     "reakit-utils": "^0.15.1",

--- a/packages/reakit/src/Button/README.md
+++ b/packages/reakit/src/Button/README.md
@@ -158,3 +158,8 @@ Learn more in [Composition](/docs/composition/#props-hooks).
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.

--- a/packages/reakit/src/Checkbox/README.md
+++ b/packages/reakit/src/Checkbox/README.md
@@ -261,6 +261,11 @@ going to be an array.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 - **`value`**
   <code>string | number | undefined</code>
 

--- a/packages/reakit/src/Clickable/README.md
+++ b/packages/reakit/src/Clickable/README.md
@@ -71,3 +71,8 @@ Learn more in [Composition](/docs/composition/#props-hooks).
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.

--- a/packages/reakit/src/Combobox/README.md
+++ b/packages/reakit/src/Combobox/README.md
@@ -764,6 +764,11 @@ the combobox popover opens, but the input value remains the same.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 - **`hideOnEsc`**
   <code>boolean | undefined</code>
 
@@ -961,6 +966,11 @@ the `matches` property.
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
 
 - **`id`**
   <code>string | undefined</code>
@@ -1170,6 +1180,11 @@ and `groupId` if any. This state is automatically updated when
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 - **`id`**
   <code>string | undefined</code>
 
@@ -1343,6 +1358,11 @@ the `matches` property.
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
 
 - **`id`**
   <code>string | undefined</code>

--- a/packages/reakit/src/Composite/README.md
+++ b/packages/reakit/src/Composite/README.md
@@ -313,6 +313,11 @@ to the item right before it.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 <details><summary>12 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
@@ -477,6 +482,11 @@ and `groupId` if any. This state is automatically updated when
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
 
 - **`id`**
   <code>string | undefined</code>

--- a/packages/reakit/src/Dialog/README.md
+++ b/packages/reakit/src/Dialog/README.md
@@ -545,6 +545,11 @@ by default.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 <details><summary>3 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.

--- a/packages/reakit/src/Disclosure/README.md
+++ b/packages/reakit/src/Disclosure/README.md
@@ -297,6 +297,11 @@ after the same number of milliseconds have passed.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 <details><summary>3 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.

--- a/packages/reakit/src/Form/README.md
+++ b/packages/reakit/src/Form/README.md
@@ -550,6 +550,11 @@ only occur on submit.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 - **`checked`**
   <code>boolean | undefined</code>
 
@@ -650,6 +655,11 @@ This stores the error messages throwed by `onValidate` and `onSubmit`.
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
 
 - **`name`**
   <code>P</code>
@@ -774,6 +784,11 @@ This stores the messages returned by `onValidate` and `onSubmit`.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 - **`name`**
   <code>P</code>
 
@@ -883,6 +898,11 @@ This stores the error messages throwed by `onValidate` and `onSubmit`.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 - **`name`**
   <code>P</code>
 
@@ -927,6 +947,11 @@ similarly to `readOnly` on form elements. In this case, only
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
 
 <details><summary>3 state props</summary>
 

--- a/packages/reakit/src/Grid/README.md
+++ b/packages/reakit/src/Grid/README.md
@@ -185,6 +185,11 @@ to the item right before it.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 <details><summary>12 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
@@ -297,6 +302,11 @@ state will get focus.
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
 
 - **`id`**
   <code>string | undefined</code>

--- a/packages/reakit/src/Input/README.md
+++ b/packages/reakit/src/Input/README.md
@@ -84,3 +84,8 @@ Learn more in [Composition](/docs/composition/#props-hooks).
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.

--- a/packages/reakit/src/Menu/README.md
+++ b/packages/reakit/src/Menu/README.md
@@ -834,6 +834,11 @@ It will be set to `false` if `modal` is `false`.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 <details><summary>21 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
@@ -1017,6 +1022,11 @@ state will get focus.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 <details><summary>14 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
@@ -1140,6 +1150,11 @@ state will get focus.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 <details><summary>12 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
@@ -1226,6 +1241,11 @@ arrow keys.
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
 
 <details><summary>12 state props</summary>
 
@@ -1317,6 +1337,11 @@ No props to show
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
 
 - **`id`**
   <code>string | undefined</code>
@@ -1460,6 +1485,11 @@ state will get focus.
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
 
 - **`value`**
   <code>string | number | undefined</code>
@@ -1642,6 +1672,11 @@ state will get focus.
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
 
 - **`id`**
   <code>string | undefined</code>

--- a/packages/reakit/src/Menu/__tests__/index-test.tsx
+++ b/packages/reakit/src/Menu/__tests__/index-test.tsx
@@ -22,6 +22,8 @@ import {
 
 [true, false].forEach((virtual) => {
   describe(virtual ? "aria-activedescendant" : "roving-tabindex", () => {
+    beforeEach(() => jest.resetAllMocks());
+
     test("menu bar is always visible", () => {
       const Test = () => {
         const menu = useMenuState({ unstable_virtual: virtual });

--- a/packages/reakit/src/Popover/README.md
+++ b/packages/reakit/src/Popover/README.md
@@ -489,6 +489,11 @@ by default.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 <details><summary>4 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.

--- a/packages/reakit/src/Radio/README.md
+++ b/packages/reakit/src/Radio/README.md
@@ -193,6 +193,11 @@ to the item right before it.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 - **`id`**
   <code>string | undefined</code>
 
@@ -335,6 +340,11 @@ state will get focus.
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
 
 <details><summary>12 state props</summary>
 

--- a/packages/reakit/src/Rover/README.md
+++ b/packages/reakit/src/Rover/README.md
@@ -136,6 +136,11 @@ Learn more in [Composition](/docs/composition/#props-hooks).
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 - **`id`**
   <code>string | undefined</code>
 

--- a/packages/reakit/src/Tab/README.md
+++ b/packages/reakit/src/Tab/README.md
@@ -402,6 +402,11 @@ to the item right before it.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 - **`id`**
   <code>string | undefined</code>
 
@@ -544,6 +549,11 @@ state will get focus.
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
 
 <details><summary>12 state props</summary>
 

--- a/packages/reakit/src/Tabbable/README.md
+++ b/packages/reakit/src/Tabbable/README.md
@@ -68,3 +68,8 @@ Learn more in [Composition](/docs/composition/#props-hooks).
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.

--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -197,6 +197,8 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
   ) {
     const ref = React.useRef<HTMLElement>(null);
     const onClickCaptureRef = useLiveRef(htmlOnClickCapture);
+    const onFocusRef = useLiveRef(htmlOnFocus);
+    const onFocusVisibleRef = useLiveRef(options.onFocusVisible);
     const onMouseDownCaptureRef = useLiveRef(htmlOnMouseDownCapture);
     const onMouseDownRef = useLiveRef(htmlOnMouseDown);
     const onKeyPressCaptureRef = useLiveRef(htmlOnKeyPressCapture);
@@ -233,13 +235,15 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
 
     const onClickCapture = useDisableEvent(onClickCaptureRef, options.disabled);
 
-    const onFocus = (event: React.FocusEvent) => {
-      htmlOnFocus?.(event);
-
-      if (isFocusVisible) {
-        options.onFocusVisible?.(event);
-      }
-    };
+    const onFocus = React.useCallback(
+      (event: React.FocusEvent) => {
+        onFocusRef.current?.(event);
+        if (isFocusVisible) {
+          onFocusVisibleRef.current?.(event);
+        }
+      },
+      [isFocusVisible]
+    );
 
     const onMouseDownCapture = useDisableEvent(
       onMouseDownCaptureRef,

--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -29,7 +29,7 @@ export type TabbableOptions = RoleOptions & {
   /**
    * Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
    */
-  onFocusVisible?: () => void;
+  onFocusVisible?: (event: React.FocusEvent) => void;
 };
 
 export type TabbableHTMLProps = RoleHTMLProps & {
@@ -232,7 +232,7 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
       htmlOnFocus?.(event);
 
       if (isFocusVisible) {
-        options.onFocusVisible?.();
+        options.onFocusVisible?.(event);
       }
     };
 

--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useFocusVisible } from "@react-aria/interactions";
 import { createComponent } from "reakit-system/createComponent";
 import { createHook } from "reakit-system/createHook";
 import { useForkRef } from "reakit-utils/useForkRef";
@@ -25,6 +26,10 @@ export type TabbableOptions = RoleOptions & {
    * `aria-disabled` will be set.
    */
   focusable?: boolean;
+  /**
+   * Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+   */
+  onFocusVisible?: () => void;
 };
 
 export type TabbableHTMLProps = RoleHTMLProps & {
@@ -181,6 +186,7 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
       ref: htmlRef,
       tabIndex: htmlTabIndex,
       onClickCapture: htmlOnClickCapture,
+      onFocus: htmlOnFocus,
       onMouseDownCapture: htmlOnMouseDownCapture,
       onMouseDown: htmlOnMouseDown,
       onKeyPressCapture: htmlOnKeyPressCapture,
@@ -200,6 +206,7 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
       ? { pointerEvents: "none" as const, ...htmlStyle }
       : htmlStyle;
     const focusOnMouseDown = useFocusOnMouseDown();
+    const { isFocusVisible } = useFocusVisible({ isTextInput: true });
 
     useIsomorphicEffect(() => {
       const tabbable = ref.current;
@@ -220,6 +227,14 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
     }, []);
 
     const onClickCapture = useDisableEvent(onClickCaptureRef, options.disabled);
+
+    const onFocus = (event: React.FocusEvent) => {
+      htmlOnFocus?.(event);
+
+      if (isFocusVisible) {
+        options.onFocusVisible?.();
+      }
+    };
 
     const onMouseDownCapture = useDisableEvent(
       onMouseDownCaptureRef,
@@ -252,6 +267,7 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
       disabled: trulyDisabled && supportsDisabled ? true : undefined,
       "aria-disabled": options.disabled ? true : undefined,
       onClickCapture,
+      onFocus,
       onMouseDownCapture,
       onMouseDown,
       onKeyPressCapture,

--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -9,6 +9,7 @@ import { warning } from "reakit-warning";
 import { hasFocusWithin } from "reakit-utils/hasFocusWithin";
 import { isButton } from "reakit-utils/isButton";
 import { isPortalEvent } from "reakit-utils/isPortalEvent";
+import { isTextField } from "reakit-utils/isTextField";
 import { getActiveElement } from "reakit-utils/getActiveElement";
 import { isUA } from "reakit-utils/dom";
 import { getClosestFocusable } from "reakit-utils/tabbable";
@@ -202,11 +203,12 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
     const trulyDisabled = !!options.disabled && !options.focusable;
     const [nativeTabbable, setNativeTabbable] = React.useState(true);
     const [supportsDisabled, setSupportsDisabled] = React.useState(true);
+    const [isTextInput, setIsTextInput] = React.useState(false);
     const style = options.disabled
       ? { pointerEvents: "none" as const, ...htmlStyle }
       : htmlStyle;
     const focusOnMouseDown = useFocusOnMouseDown();
-    const { isFocusVisible } = useFocusVisible({ isTextInput: true });
+    const { isFocusVisible } = useFocusVisible({ isTextInput });
 
     useIsomorphicEffect(() => {
       const tabbable = ref.current;
@@ -223,6 +225,9 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
       }
       if (!supportsDisabledAttribute(tabbable)) {
         setSupportsDisabled(false);
+      }
+      if (isTextField(tabbable)) {
+        setIsTextInput(true);
       }
     }, []);
 

--- a/packages/reakit/src/Tabbable/__examples__/TabbableElements/__tests__/index-test.tsx
+++ b/packages/reakit/src/Tabbable/__examples__/TabbableElements/__tests__/index-test.tsx
@@ -49,40 +49,6 @@ test("click", () => {
   expect(window.alert).not.toHaveBeenCalledWith("Disabled focusable custom");
 });
 
-test("focus visible", () => {
-  render(<TabbableElements />);
-
-  click(screen.getByText("Button with focus visible handler"));
-  expect(screen.queryByText("I am focused")).toBeInTheDocument();
-  expect(screen.queryByText("I am focus visible")).not.toBeInTheDocument();
-  press.ShiftTab();
-  press.Tab();
-  expect(screen.queryByText("I am focused")).toBeInTheDocument();
-  expect(screen.queryByText("I am focus visible")).toBeInTheDocument();
-
-  const input = screen.getByLabelText("Input with focus visible handler:");
-  click(input);
-  expect(screen.queryByText("I am focused")).toBeInTheDocument();
-  expect(screen.queryByText("I am focus visible")).not.toBeInTheDocument();
-  type("abc", input);
-  expect(screen.queryByText("I am focused")).toBeInTheDocument();
-  expect(screen.queryByText("I am focus visible")).not.toBeInTheDocument();
-  press.ShiftTab();
-  press.Tab();
-  expect(input).toHaveValue("abc");
-  expect(screen.queryByText("I am focus visible")).toBeInTheDocument();
-
-  click(
-    screen.getByText("Disabled focusable button with focus visible handler")
-  );
-  expect(screen.queryByText("I am focused")).not.toBeInTheDocument();
-  expect(screen.queryByText("I am focus visible")).not.toBeInTheDocument();
-  click(input);
-  press.Tab();
-  expect(screen.queryByText("I am focused")).toBeInTheDocument();
-  expect(screen.queryByText("I am focus visible")).toBeInTheDocument();
-});
-
 test("type on input", () => {
   render(<TabbableElements />);
   const defaultInput = screen.getByLabelText("Default input");
@@ -200,23 +166,6 @@ test("markup", () => {
         >
           Disabled focusable custom
         </div>
-        <h2>
-          Focus visible
-        </h2>
-        <button>
-          Button with focus visible handler
-        </button>
-        <label>
-          Input with focus visible handler:
-          <br />
-          <input />
-        </label>
-        <button
-          aria-disabled="true"
-          style="pointer-events: none;"
-        >
-          Disabled focusable button with focus visible handler
-        </button>
       </div>
     </div>
   `);

--- a/packages/reakit/src/Tabbable/__examples__/TabbableElements/__tests__/index-test.tsx
+++ b/packages/reakit/src/Tabbable/__examples__/TabbableElements/__tests__/index-test.tsx
@@ -166,6 +166,23 @@ test("markup", () => {
         >
           Disabled focusable custom
         </div>
+        <h2>
+          Focus visible
+        </h2>
+        <button>
+          Button with focus visible handler
+        </button>
+        <label>
+          Input with focus visible handler:
+          <br />
+          <input />
+        </label>
+        <button
+          aria-disabled="true"
+          style="pointer-events: none;"
+        >
+          Disabled focusable button with focus visible handler
+        </button>
       </div>
     </div>
   `);

--- a/packages/reakit/src/Tabbable/__examples__/TabbableElements/__tests__/index-test.tsx
+++ b/packages/reakit/src/Tabbable/__examples__/TabbableElements/__tests__/index-test.tsx
@@ -49,6 +49,40 @@ test("click", () => {
   expect(window.alert).not.toHaveBeenCalledWith("Disabled focusable custom");
 });
 
+test("focus visible", () => {
+  render(<TabbableElements />);
+
+  click(screen.getByText("Button with focus visible handler"));
+  expect(screen.queryByText("I am focused")).toBeInTheDocument();
+  expect(screen.queryByText("I am focus visible")).not.toBeInTheDocument();
+  press.ShiftTab();
+  press.Tab();
+  expect(screen.queryByText("I am focused")).toBeInTheDocument();
+  expect(screen.queryByText("I am focus visible")).toBeInTheDocument();
+
+  const input = screen.getByLabelText("Input with focus visible handler:");
+  click(input);
+  expect(screen.queryByText("I am focused")).toBeInTheDocument();
+  expect(screen.queryByText("I am focus visible")).not.toBeInTheDocument();
+  type("abc", input);
+  expect(screen.queryByText("I am focused")).toBeInTheDocument();
+  expect(screen.queryByText("I am focus visible")).not.toBeInTheDocument();
+  press.ShiftTab();
+  press.Tab();
+  expect(input).toHaveValue("abc");
+  expect(screen.queryByText("I am focus visible")).toBeInTheDocument();
+
+  click(
+    screen.getByText("Disabled focusable button with focus visible handler")
+  );
+  expect(screen.queryByText("I am focused")).not.toBeInTheDocument();
+  expect(screen.queryByText("I am focus visible")).not.toBeInTheDocument();
+  click(input);
+  press.Tab();
+  expect(screen.queryByText("I am focused")).toBeInTheDocument();
+  expect(screen.queryByText("I am focus visible")).toBeInTheDocument();
+});
+
 test("type on input", () => {
   render(<TabbableElements />);
   const defaultInput = screen.getByLabelText("Default input");

--- a/packages/reakit/src/Tabbable/__examples__/TabbableElements/index.tsx
+++ b/packages/reakit/src/Tabbable/__examples__/TabbableElements/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Tabbable, TabbableProps } from "reakit/Tabbable";
+import { Tabbable } from "reakit/Tabbable";
 
 function onClick(event: React.MouseEvent) {
   const element = event.target as HTMLElement;

--- a/packages/reakit/src/Tabbable/__examples__/TabbableElements/index.tsx
+++ b/packages/reakit/src/Tabbable/__examples__/TabbableElements/index.tsx
@@ -29,8 +29,8 @@ const FocusVisibleTappable = (props: any) => {
         }}
         {...props}
       />
-      {isFocused && <div>focused</div>}
-      {isFocusVisible && <div>focus visible</div>}
+      {isFocused && <div>I am focused</div>}
+      {isFocusVisible && <div>I am focus visible</div>}
     </>
   );
 };

--- a/packages/reakit/src/Tabbable/__examples__/TabbableElements/index.tsx
+++ b/packages/reakit/src/Tabbable/__examples__/TabbableElements/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Tabbable } from "reakit/Tabbable";
+import { Tabbable, TabbableProps } from "reakit/Tabbable";
 
 function onClick(event: React.MouseEvent) {
   const element = event.target as HTMLElement;
@@ -13,6 +13,27 @@ const CustomComponent = React.forwardRef<
   React.HTMLAttributes<HTMLDivElement>
   // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
 >((props, ref) => <div ref={ref} {...props} onClick={onClick} />);
+
+const FocusVisibleTappable = (props: any) => {
+  const [isFocusVisible, setIsFocusVisible] = React.useState(false);
+  const [isFocused, setIsFocused] = React.useState(false);
+
+  return (
+    <>
+      <Tabbable
+        onFocus={() => setIsFocused(true)}
+        onFocusVisible={() => setIsFocusVisible(true)}
+        onBlur={() => {
+          setIsFocused(false);
+          setIsFocusVisible(false);
+        }}
+        {...props}
+      />
+      {isFocused && <div>focused</div>}
+      {isFocusVisible && <div>focus visible</div>}
+    </>
+  );
+};
 
 export default function TabbableElements() {
   return (
@@ -75,6 +96,18 @@ export default function TabbableElements() {
       <Tabbable as={CustomComponent} disabled focusable>
         Disabled focusable custom
       </Tabbable>
+
+      <h2>Focus visible</h2>
+
+      <FocusVisibleTappable as="button">
+        Button with focus visible handler
+      </FocusVisibleTappable>
+
+      <label>
+        Input with focus visible handler:
+        <br />
+        <FocusVisibleTappable as="input" />
+      </label>
     </div>
   );
 }

--- a/packages/reakit/src/Tabbable/__examples__/TabbableElements/index.tsx
+++ b/packages/reakit/src/Tabbable/__examples__/TabbableElements/index.tsx
@@ -108,6 +108,10 @@ export default function TabbableElements() {
         <br />
         <FocusVisibleTappable as="input" />
       </label>
+
+      <FocusVisibleTappable as="button" disabled focusable>
+        Disabled focusable button with focus visible handler
+      </FocusVisibleTappable>
     </div>
   );
 }

--- a/packages/reakit/src/Tabbable/__examples__/TabbableElements/index.tsx
+++ b/packages/reakit/src/Tabbable/__examples__/TabbableElements/index.tsx
@@ -14,27 +14,6 @@ const CustomComponent = React.forwardRef<
   // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
 >((props, ref) => <div ref={ref} {...props} onClick={onClick} />);
 
-const FocusVisibleTappable = (props: any) => {
-  const [isFocusVisible, setIsFocusVisible] = React.useState(false);
-  const [isFocused, setIsFocused] = React.useState(false);
-
-  return (
-    <>
-      <Tabbable
-        onFocus={() => setIsFocused(true)}
-        onFocusVisible={() => setIsFocusVisible(true)}
-        onBlur={() => {
-          setIsFocused(false);
-          setIsFocusVisible(false);
-        }}
-        {...props}
-      />
-      {isFocused && <div>I am focused</div>}
-      {isFocusVisible && <div>I am focus visible</div>}
-    </>
-  );
-};
-
 export default function TabbableElements() {
   return (
     <div style={{ display: "inline-flex", flexDirection: "column" }}>
@@ -96,22 +75,6 @@ export default function TabbableElements() {
       <Tabbable as={CustomComponent} disabled focusable>
         Disabled focusable custom
       </Tabbable>
-
-      <h2>Focus visible</h2>
-
-      <FocusVisibleTappable as="button">
-        Button with focus visible handler
-      </FocusVisibleTappable>
-
-      <label>
-        Input with focus visible handler:
-        <br />
-        <FocusVisibleTappable as="input" />
-      </label>
-
-      <FocusVisibleTappable as="button" disabled focusable>
-        Disabled focusable button with focus visible handler
-      </FocusVisibleTappable>
     </div>
   );
 }

--- a/packages/reakit/src/Tabbable/__examples__/TabbableWithFocusVisible/__tests__/index-test.tsx
+++ b/packages/reakit/src/Tabbable/__examples__/TabbableWithFocusVisible/__tests__/index-test.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+import { render, press, click, type, axe, screen } from "reakit-test-utils";
+import TabbableWithFocusVisible from "..";
+
+test("focus visible", () => {
+  render(<TabbableWithFocusVisible />);
+
+  click(screen.getByText("Button with focus visible handler"));
+  expect(screen.queryByText("I am focused")).toBeInTheDocument();
+  expect(screen.queryByText("I am focus visible")).not.toBeInTheDocument();
+  press.ShiftTab();
+  press.Tab();
+  expect(screen.queryByText("I am focused")).toBeInTheDocument();
+  expect(screen.queryByText("I am focus visible")).toBeInTheDocument();
+
+  const input = screen.getByLabelText("Input with focus visible handler:");
+  click(input);
+  expect(screen.queryByText("I am focused")).toBeInTheDocument();
+  expect(screen.queryByText("I am focus visible")).not.toBeInTheDocument();
+  type("abc", input);
+  expect(screen.queryByText("I am focused")).toBeInTheDocument();
+  expect(screen.queryByText("I am focus visible")).not.toBeInTheDocument();
+  press.ShiftTab();
+  press.Tab();
+  expect(input).toHaveValue("abc");
+  expect(screen.queryByText("I am focus visible")).toBeInTheDocument();
+
+  click(
+    screen.getByText("Disabled focusable button with focus visible handler")
+  );
+  expect(screen.queryByText("I am focused")).not.toBeInTheDocument();
+  expect(screen.queryByText("I am focus visible")).not.toBeInTheDocument();
+  click(input);
+  press.Tab();
+  expect(screen.queryByText("I am focused")).toBeInTheDocument();
+  expect(screen.queryByText("I am focus visible")).toBeInTheDocument();
+});
+
+test("markup", () => {
+  const { container } = render(<TabbableWithFocusVisible />);
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <div
+        style="display: inline-flex; flex-direction: column;"
+      >
+        <button>
+          Button with focus visible handler
+        </button>
+        <label>
+          Input with focus visible handler:
+          <br />
+          <input />
+        </label>
+        <button
+          aria-disabled="true"
+          style="pointer-events: none;"
+        >
+          Disabled focusable button with focus visible handler
+        </button>
+      </div>
+    </div>
+  `);
+});
+
+test("a11y", async () => {
+  const { baseElement } = render(<TabbableWithFocusVisible />);
+  expect(await axe(baseElement)).toHaveNoViolations();
+});

--- a/packages/reakit/src/Tabbable/__examples__/TabbableWithFocusVisible/index.tsx
+++ b/packages/reakit/src/Tabbable/__examples__/TabbableWithFocusVisible/index.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { Tabbable } from "reakit/Tabbable";
+
+const FocusVisibleTappable = (props: any) => {
+  const [isFocusVisible, setIsFocusVisible] = React.useState(false);
+  const [isFocused, setIsFocused] = React.useState(false);
+
+  return (
+    <>
+      <Tabbable
+        onFocus={() => setIsFocused(true)}
+        onFocusVisible={() => setIsFocusVisible(true)}
+        onBlur={() => {
+          setIsFocused(false);
+          setIsFocusVisible(false);
+        }}
+        {...props}
+      />
+      {isFocused && <div>I am focused</div>}
+      {isFocusVisible && <div>I am focus visible</div>}
+    </>
+  );
+};
+
+export default function TabbableWithFocusVisible() {
+  return (
+    <div style={{ display: "inline-flex", flexDirection: "column" }}>
+      <FocusVisibleTappable as="button">
+        Button with focus visible handler
+      </FocusVisibleTappable>
+
+      <label>
+        Input with focus visible handler:
+        <br />
+        <FocusVisibleTappable as="input" />
+      </label>
+
+      <FocusVisibleTappable as="button" disabled focusable>
+        Disabled focusable button with focus visible handler
+      </FocusVisibleTappable>
+    </div>
+  );
+}

--- a/packages/reakit/src/Tabbable/__examples__/index.story.ts
+++ b/packages/reakit/src/Tabbable/__examples__/index.story.ts
@@ -1,6 +1,7 @@
 import { Tabbable } from "../Tabbable";
 
 export { default as TabbableElements } from "./TabbableElements";
+export { default as TabbableWithFocusVisible } from "./TabbableWithFocusVisible";
 
 export default {
   title: "Tabbable",

--- a/packages/reakit/src/Tabbable/__keys.ts
+++ b/packages/reakit/src/Tabbable/__keys.ts
@@ -1,2 +1,6 @@
 // Automatically generated
-export const TABBABLE_KEYS = ["disabled", "focusable"] as const;
+export const TABBABLE_KEYS = [
+  "disabled",
+  "focusable",
+  "onFocusVisible",
+] as const;

--- a/packages/reakit/src/Toolbar/README.md
+++ b/packages/reakit/src/Toolbar/README.md
@@ -215,6 +215,11 @@ to the item right before it.
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
 
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
+
 <details><summary>12 state props</summary>
 
 > These props are returned by the state hook. You can spread them into this component (`{...state}`) or pass them separately. You can also provide these props from your own state logic.
@@ -327,6 +332,11 @@ state will get focus.
   When an element is `disabled`, it may still be `focusable`. It works
 similarly to `readOnly` on form elements. In this case, only
 `aria-disabled` will be set.
+
+- **`onFocusVisible`**
+  <code>((event: FocusEvent&#60;Element&#62;) =&#62; void) | undefined</code>
+
+  Do something only when focused via keyboard, similar to the :focus-visible pseudo class.
 
 - **`id`**
   <code>string | undefined</code>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2124,6 +2124,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.6.2":
+  version "7.13.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.4.tgz#a2f5b5304d6f98a94053e6737321501347325617"
+  integrity sha512-pZLFG10nRL1hPF9J0/WdxjVuLEanSge8W3Ct+Kls9fNhD4vOi9bhuAU8DdNARvBE9GTg6UhQFcEIF1XhIZd9ZA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/standalone@^7.12.6":
   version "7.12.9"
   resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.12.9.tgz#2da8a223b44498a1e7ca5b83d4e9d010088b0036"
@@ -4092,6 +4099,45 @@
     invariant "^2.2.3"
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
+
+"@react-aria/interactions@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.3.3.tgz#02852a11530f73d1ae4525cdef7c2595acde2fdc"
+  integrity sha512-wq6YwVFMzT7jdpVGqGoqXPCANHl6BvOOL1Lrg3vb+df5pvoCFNWBytqv/yQVpT4PKOSUbxSBdOTubvtZlu0l+g==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/utils" "^3.6.0"
+    "@react-types/shared" "^3.4.0"
+
+"@react-aria/ssr@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.0.1.tgz#5f7c111f9ecd184b8f6140139703c1ee552dca30"
+  integrity sha512-rweMNcSkUO4YkcmgFIoZFvgPyHN2P9DOjq3VOHnZ8SG3Y4TTvSY6Iv90KgzeEfmWCUqqt65FYH4JgrpGNToEMw==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+
+"@react-aria/utils@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.6.0.tgz#b7446f202469015713af8bf2812b748e694eca12"
+  integrity sha512-DO5F00T5NQ7j3GGWvruV8HrEd3YcN7KfbbvKvNZ3JWHETHNJxIc2xBz4Af6FSQzAjHkOrapd++SNoNLutRSz9Q==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/ssr" "^3.0.1"
+    "@react-stately/utils" "^3.2.0"
+    "@react-types/shared" "^3.4.0"
+    clsx "^1.1.1"
+
+"@react-stately/utils@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.2.0.tgz#0b90a70fee3236025ad8bed1f0e3555d5fc10296"
+  integrity sha512-vVBJvHVLnQySgqZ7OfP3ngDdwfGscJDsSD3WcN5ntHiT3JlZ5bksQReDkJEs20SFu2ST4w/0K7O4m97SbuMl2Q==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+
+"@react-types/shared@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.4.0.tgz#a7cbf8c676b4b3b7b687bcdc8e44828c34d115f4"
+  integrity sha512-qYuL9JdIVC5JQmUgmurtm4JZQrg6IUy8wrMbaqNbt1e85Zg7A6ff1ffFrZ5IIgc1LDxYC7BB9KtL/bCgnjqrng==
 
 "@rollup/plugin-babel@5.2.2":
   version "5.2.2"
@@ -8035,6 +8081,11 @@ cloneable-readable@^1.0.0:
     inherits "^2.0.1"
     process-nextick-args "^2.0.0"
     readable-stream "^2.3.5"
+
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
 
 co@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
Closes #737

As suggested by @Weffe in the issue, this uses the [`useFocusVisible`](https://react-spectrum.adobe.com/react-aria/useFocusVisible.html) hook from react-aria.

**How to test?**

1. Go to the Storybook for Tabbable at `?path=/story/tabbable--tabbable-elements`.
2. In the "Focus visible" section, the text "I am focus visible" should only appear when the Tabbable is focused via keyboard.

**Does this PR introduce breaking changes?**

No.