### PR TITLE
Fix: layout shift when first render popper

### DIFF
--- a/packages/reakit/src/Button/__examples__/ButtonWithTooltip/__tests__/index-test.tsx
+++ b/packages/reakit/src/Button/__examples__/ButtonWithTooltip/__tests__/index-test.tsx
@@ -32,7 +32,7 @@ test("markup", () => {
           hidden=""
           id="id-1"
           role="tooltip"
-          style="display: none; pointer-events: none;"
+          style="display: none; position: fixed; left: 0px; top: 0px; pointer-events: none;"
         >
           Tooltip
         </div>

--- a/packages/reakit/src/Menu/__examples__/SimpleMenu/index.tsx
+++ b/packages/reakit/src/Menu/__examples__/SimpleMenu/index.tsx
@@ -1,16 +1,20 @@
 import * as React from "react";
 import { useMenuState, Menu, MenuButton, MenuItem } from "reakit/Menu";
+import { Portal } from "reakit/Portal";
 
 export default function SimpleMenu() {
   const menu = useMenuState();
   return (
     <>
       <MenuButton {...menu}>Preferences</MenuButton>
-      <Menu {...menu} aria-label="Preferences">
-        <MenuItem {...menu}>Settings</MenuItem>
-        <MenuItem {...menu}>Extensions</MenuItem>
-        <MenuItem {...menu}>Keyboard shortcuts</MenuItem>
-      </Menu>
+      <Portal>
+        <Menu {...menu} aria-label="Preferences">
+          <MenuItem {...menu}>Settings</MenuItem>
+          <MenuItem {...menu}>Extensions</MenuItem>
+          <MenuItem {...menu}>Keyboard shortcuts</MenuItem>
+        </Menu>
+      </Portal>
+      <div style={{ marginTop: "100vh" }}>Bottom</div>
     </>
   );
 }

--- a/packages/reakit/src/Menu/__examples__/SimpleMenu/index.tsx
+++ b/packages/reakit/src/Menu/__examples__/SimpleMenu/index.tsx
@@ -1,20 +1,16 @@
 import * as React from "react";
 import { useMenuState, Menu, MenuButton, MenuItem } from "reakit/Menu";
-import { Portal } from "reakit/Portal";
 
 export default function SimpleMenu() {
   const menu = useMenuState();
   return (
     <>
       <MenuButton {...menu}>Preferences</MenuButton>
-      <Portal>
-        <Menu {...menu} aria-label="Preferences">
-          <MenuItem {...menu}>Settings</MenuItem>
-          <MenuItem {...menu}>Extensions</MenuItem>
-          <MenuItem {...menu}>Keyboard shortcuts</MenuItem>
-        </Menu>
-      </Portal>
-      <div style={{ marginTop: "100vh" }}>Bottom</div>
+      <Menu {...menu} aria-label="Preferences">
+        <MenuItem {...menu}>Settings</MenuItem>
+        <MenuItem {...menu}>Extensions</MenuItem>
+        <MenuItem {...menu}>Keyboard shortcuts</MenuItem>
+      </Menu>
     </>
   );
 }

--- a/packages/reakit/src/Popover/PopoverState.ts
+++ b/packages/reakit/src/Popover/PopoverState.ts
@@ -142,7 +142,11 @@ export function usePopoverState(
   const [placement, setPlacement] = React.useState(sealedPlacement);
   const [offset] = React.useState(sealedOffset || [0, gutter]);
   const [popoverStyles, setPopoverStyles] = React.useState<React.CSSProperties>(
-    {}
+    {
+      position: "fixed",
+      left: "0",
+      top: "0",
+    }
   );
   const [arrowStyles, setArrowStyles] = React.useState<React.CSSProperties>({});
 


### PR DESCRIPTION
Closes #819
Closes #820

Related to #820 but i only cherry-pick the layout-shift fix.

**Screenshots**

![Screen Recording 2021-03-01 at 4 03 59 PM](https://user-images.githubusercontent.com/4253314/109475886-d3b6d080-7aa8-11eb-8da3-4e77cc6cc8ef.gif)

**How to test?**

Wrap Menu inside Portal then first render will make the scroll jump to bottom.

```jsx
import { useMenuState, Menu, MenuItem, MenuButton } from "reakit/Menu";
import { Portal } from 'reakit/Portal'

function Example() {
  const menu = useMenuState();
  return (
    <>
      <MenuButton {...menu}>Preferences</MenuButton>
      <Portal>
      	<Menu {...menu} tabIndex={0} aria-label="Preferences">
          <MenuItem {...menu}>Settings</MenuItem>
          <MenuItem {...menu}>Extensions</MenuItem>
          <MenuItem {...menu}>Keyboard shortcuts</MenuItem>
        </Menu>
      </Portal>
    </>
  );
}
```

**Does this PR introduce breaking changes?**

No
