### PR TITLE
fix: Fix button focus on mouse down on Safari and React 17

### DIFF
--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -178,7 +178,6 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
         // focusable ancestor element, which is ultimately the body element. So
         // we make sure to give focus to the tabbable element on mouse down so
         // it works consistently across browsers.
-        // istanbul ignore start
         if (!isSafariOrFirefoxOnMac) return;
         if (isPortalEvent(event)) return;
         if (!isButton(element)) return;
@@ -203,7 +202,6 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
           once: true,
           capture: true,
         });
-        // istanbul ignore end
       },
       []
     );

--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -8,9 +8,8 @@ import { warning } from "reakit-warning";
 import { hasFocusWithin } from "reakit-utils/hasFocusWithin";
 import { isButton } from "reakit-utils/isButton";
 import { isPortalEvent } from "reakit-utils/isPortalEvent";
-import { getActiveElement } from "reakit-utils/getActiveElement";
 import { isUA } from "reakit-utils/dom";
-import { getClosestFocusable } from "reakit-utils/tabbable";
+import { isFocusable } from "reakit-utils/tabbable";
 import { RoleOptions, RoleHTMLProps, useRole } from "../Role/Role";
 import { TABBABLE_KEYS } from "./__keys";
 
@@ -37,70 +36,9 @@ const isSafariOrFirefoxOnMac =
   isUA("Mac") && !isUA("Chrome") && (isUA("Safari") || isUA("Firefox"));
 
 function focusIfNeeded(element: HTMLElement) {
-  if (!hasFocusWithin(element)) {
+  if (!hasFocusWithin(element) && isFocusable(element)) {
     element.focus();
   }
-}
-
-// Safari and Firefox on MacOS don't focus on buttons on mouse down like other
-// browsers/platforms. Instead, they focus on the closest focusable ancestor
-// element, which is ultimately the body element. So we make sure to give focus
-// to the tabbable element on mouse down so it works consistently across
-// browsers.
-// istanbul ignore next
-function useFocusOnMouseDown() {
-  if (!isSafariOrFirefoxOnMac) return undefined;
-  const [tabbable, scheduleFocus] = React.useState<HTMLElement | null>(null);
-
-  React.useEffect(() => {
-    if (!tabbable) return;
-    focusIfNeeded(tabbable);
-    scheduleFocus(null);
-  }, [tabbable]);
-
-  const onMouseDown = React.useCallback(
-    (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
-      const element = event.currentTarget;
-      if (isPortalEvent(event)) return;
-      if (!isButton(element)) return;
-      const activeElement = getActiveElement(element);
-      if (!activeElement) return;
-      const activeElementIsBody = activeElement.tagName === "BODY";
-      const focusableAncestor = getClosestFocusable(element.parentElement);
-      if (
-        activeElement === focusableAncestor ||
-        (activeElementIsBody && !focusableAncestor)
-      ) {
-        // When the active element is the focusable ancestor, it'll not emit
-        // focus/blur events. After all, it's already focused. So we can't
-        // listen to those events to focus this tabbable element.
-        // When the active element is body and there's no focusable ancestor,
-        // we also don't have any other event to listen to since body never
-        // emits focus/blur events on itself.
-        // In both of these cases, we have to schedule focus on this tabbable
-        // element.
-        scheduleFocus(element);
-      } else if (focusableAncestor) {
-        // Clicking (mouse down) on the tabbable element on Safari and Firefox
-        // on MacOS will fire focus on the focusable ancestor element if
-        // there's any and if it's not the current active element. So we wait
-        // for this event to happen before moving focus to this element.
-        // Instead of moving focus right away, we have to schedule it,
-        // otherwise it's gonna prevent drag events from happening.
-        const onFocus = () => scheduleFocus(element);
-        focusableAncestor.addEventListener("focusin", onFocus, { once: true });
-      } else {
-        // Finally, if there's no focsuable ancestor and there's another
-        // element with focus, we wait for that element to get blurred before
-        // focusing this one.
-        const onBlur = () => focusIfNeeded(element);
-        activeElement.addEventListener("blur", onBlur, { once: true });
-      }
-    },
-    []
-  );
-
-  return onMouseDown;
 }
 
 function isNativeTabbable(element: Element) {
@@ -199,7 +137,6 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
     const style = options.disabled
       ? { pointerEvents: "none" as const, ...htmlStyle }
       : htmlStyle;
-    const focusOnMouseDown = useFocusOnMouseDown();
 
     useIsomorphicEffect(() => {
       const tabbable = ref.current;
@@ -234,10 +171,41 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
     const onMouseDown = React.useCallback(
       (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
         onMouseDownRef.current?.(event);
+        const element = event.currentTarget;
         if (event.defaultPrevented) return;
-        focusOnMouseDown?.(event);
+        // Safari and Firefox on MacOS don't focus on buttons on mouse down
+        // like other browsers/platforms. Instead, they focus on the closest
+        // focusable ancestor element, which is ultimately the body element. So
+        // we make sure to give focus to the tabbable element on mouse down so
+        // it works consistently across browsers.
+        // istanbul ignore start
+        if (!isSafariOrFirefoxOnMac) return;
+        if (isPortalEvent(event)) return;
+        if (!isButton(element)) return;
+        // We can't focus right away after on mouse down, otherwise it would
+        // prevent drag events from happening. So we schedule the focus to the
+        // next animation frame.
+        const raf = requestAnimationFrame(() => {
+          element.removeEventListener("mouseup", focusImmediately, true);
+          focusIfNeeded(element);
+        });
+        // If mouseUp happens before the next animation frame (which is common
+        // on touch screens or by just tapping the trackpad on MacBook's), we
+        // cancel the animation frame and immediately focus on the element.
+        const focusImmediately = () => {
+          cancelAnimationFrame(raf);
+          focusIfNeeded(element);
+        };
+        // By listening to the event in the capture phase, we make sure the
+        // focus event is fired before the onMouseUp and onMouseUpCapture React
+        // events, which is aligned with the default browser behavior.
+        element.addEventListener("mouseup", focusImmediately, {
+          once: true,
+          capture: true,
+        });
+        // istanbul ignore end
       },
-      [options.disabled, focusOnMouseDown]
+      [options.disabled]
     );
 
     return {

--- a/packages/reakit/src/Tabbable/Tabbable.ts
+++ b/packages/reakit/src/Tabbable/Tabbable.ts
@@ -205,7 +205,7 @@ export const useTabbable = createHook<TabbableOptions, TabbableHTMLProps>({
         });
         // istanbul ignore end
       },
-      [options.disabled]
+      []
     );
 
     return {


### PR DESCRIPTION
In React 17, React effects triggered by native focus/blur events run before the `onFocus`/`onBlur` events on React.

Here's the difference (click on "Test" and see the logs):

- [React 16](https://codesandbox.io/s/difference-between-dom-focus-and-react-focus-16-3blvl?file=/src/App.js)
- [React 17](https://codesandbox.io/s/difference-between-dom-focus-and-react-focus-17-r4z3l?file=/src/App.js)

Currently on master we are scheduling a React effect in response to a native `focusin` event:

https://github.com/reakit/reakit/blob/caa81b385c0e95689a13a729635374c60956b154/packages/reakit/src/Tabbable/Tabbable.ts#L84-L91

With the change on React 17, this may break some code that's relying on the `onFocus` React event on the `focusableAncestor` element, since the effect will now run before the React event. This is happening on the WordPress Popover component, more especifically the `useFocusOutside` hook that's expecting `onFocus` to be fired in the correct order (https://github.com/WordPress/gutenberg/pull/26847#issuecomment-824718736).

This PR updates this logic so we move the focus on the next animation frame instead of in a React effect. To make sure this will happen before any mouse up or click action, we're also listening to the `mouseup` event and moving the focus right away. See the code comments for more details.

**How to test?**

Checkout the code on https://github.com/WordPress/gutenberg/pull/26847 and install the Reakit version created for this PR by CodeSandbox (some comment below). Follow the instructions there to test the block inserter on Safari/Firefox (macOS).

**Does this PR introduce breaking changes?**

No.