### PR TITLE
876 - updated styled-components doc to include forwardedAs prop

### DIFF
--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -74,7 +74,7 @@ function Example() {
 
 Example with styled-components:
 
-> When using libraries like styled-components, you'll not be able to use the Reakit [`as` prop](https://reakit.io/docs/composition/#as-prop) since styled components have their own built-in `as` prop which is not passed down to the underlying component. You can use [render props](https://reakit.io/docs/composition/#render-props) instead to achieve the same functionality
+> When using styled-components, you will have to use [`forwardedAs` prop](https://styled-components.com/docs/api#forwardedas-prop) instead of Reakit [`as` prop](https://reakit.io/docs/composition/#as-prop) since styled-components have their own built-in `as` prop. Otherwise, you can use [render props](https://reakit.io/docs/composition/#render-props) to achieve the same functionality
 
 ```jsx static
 import { Button } from "reakit";


### PR DESCRIPTION
Closes #876 

<img width="1792" alt="Screen Shot 2021-06-10 at 8 16 18 AM" src="https://user-images.githubusercontent.com/64196382/121456812-4ac30580-c9c4-11eb-8fe8-016a4e6e1f0d.png">

