### PR TITLE
make tsc work in typescript 4.4.2

### DIFF
--- a/packages/reakit/src/Form/__utils/types.ts
+++ b/packages/reakit/src/Form/__utils/types.ts
@@ -11,7 +11,7 @@ export type ArrayWithLength<N extends number> = { [K in N]: any };
  * @template T Object with keys { foo: { bar: [{ baz }] } }
  * @template P Path ["foo", "bar", 0, "baz"]
  */
-export interface DeepPathArray<T, P> extends ReadonlyArray<string | number> {
+export interface DeepPathArray<T, P> extends ReadonlyArray<any> {
   ["0"]?: keyof T;
   ["1"]?: P extends {
     ["0"]: infer K0;


### PR DESCRIPTION
Closes #900 

## What

`reakit` when included in a project with `typescript` 4.4.2 would fail `tsc`. This PR updates the troubled typings.

## Original

#903 