### PR TITLE
fix: Add missing `useRadioGroup` export

### DIFF
--- a/packages/reakit/src/Radio/RadioGroup.tsx
+++ b/packages/reakit/src/Radio/RadioGroup.tsx
@@ -17,7 +17,7 @@ export type RadioGroupHTMLProps = CompositeHTMLProps &
 
 export type RadioGroupProps = RadioGroupOptions & RadioGroupHTMLProps;
 
-const useRadioGroup = createHook<RadioGroupOptions, RadioGroupHTMLProps>({
+export const useRadioGroup = createHook<RadioGroupOptions, RadioGroupHTMLProps>({
   name: "RadioGroup",
   compose: useComposite,
   keys: RADIO_GROUP_KEYS,

--- a/packages/reakit/src/Radio/RadioGroup.tsx
+++ b/packages/reakit/src/Radio/RadioGroup.tsx
@@ -17,15 +17,17 @@ export type RadioGroupHTMLProps = CompositeHTMLProps &
 
 export type RadioGroupProps = RadioGroupOptions & RadioGroupHTMLProps;
 
-export const useRadioGroup = createHook<RadioGroupOptions, RadioGroupHTMLProps>({
-  name: "RadioGroup",
-  compose: useComposite,
-  keys: RADIO_GROUP_KEYS,
+export const useRadioGroup = createHook<RadioGroupOptions, RadioGroupHTMLProps>(
+  {
+    name: "RadioGroup",
+    compose: useComposite,
+    keys: RADIO_GROUP_KEYS,
 
-  useProps(_, htmlProps) {
-    return { role: "radiogroup", ...htmlProps };
-  },
-});
+    useProps(_, htmlProps) {
+      return { role: "radiogroup", ...htmlProps };
+    },
+  }
+);
 
 export const RadioGroup = createComponent({
   as: "div",


### PR DESCRIPTION
Just a small refactor allowing Reakit to export `useRadioGroup` hook, so that it can be consumed for composing.