### PR TITLE
fix: add default empty value for items prop

### DIFF
--- a/packages/reakit/src/Menu/__utils/useShortcuts.ts
+++ b/packages/reakit/src/Menu/__utils/useShortcuts.ts
@@ -4,7 +4,7 @@ import { MenuStateReturn } from "../MenuState";
 
 export function useShortcuts(
   menuRef: React.RefObject<HTMLElement>,
-  { items, move }: Pick<MenuStateReturn, "items" | "move">,
+  { items = [], move }: Pick<MenuStateReturn, "items" | "move">,
   timeout = 500
 ) {
   const [keys, setKeys] = React.useState("");


### PR DESCRIPTION
Had an issue when I use the Menu from `reakit/Menu` to open a modal (code base from my company).

When just after the click of an `MenuItem` (without any focus of elements on the opened modal) I press any key, the app crashes every time with this exception:

![image](https://user-images.githubusercontent.com/9880560/142388761-b773a648-792f-4c9d-9871-fcc007a8f1f1.png)

Breakpoints:
![image](https://user-images.githubusercontent.com/9880560/142388072-f99f6a8c-0bc2-439f-967a-d7d6a981b8d3.png)

The property `items` is always `undefined`. So, the `.find` will crash. I've just added a default value for it to avoid this issue. I don't really know how this issue occurs because I can't reproduce it on my own.. but my company has this issue and we're struggling to deal with.

Don't hesitate to tell me if I forgot something.

Thanks! ;-)