### PR TITLE
feat: add example 'button as link'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,6 @@ jobs:
           git commit -am "chore: Add build files" || echo "No changes to commit"
           git push
 
-      # TODO: Add later
-      # - name: Type check
-      #   run: npm run type-check
-
       - name: Test
         run: npm test -- --coverage
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches: [master, next, v*]
-  pull_request:
+  pull_request_target:
 
 jobs:
   build:
@@ -12,12 +12,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-
-      - name: Checkout PR
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr checkout ${{ github.event.pull_request.number }}
 
       - name: Set up Node
         uses: actions/setup-node@v2

--- a/packages/ariakit/src/button/__examples__/button-as-link/index.tsx
+++ b/packages/ariakit/src/button/__examples__/button-as-link/index.tsx
@@ -1,0 +1,10 @@
+import { Button } from "ariakit/button";
+import "./style.css";
+
+export default function Example() {
+  return (
+    <Button as="a" className="button" href="#">
+      Button
+    </Button>
+  );
+}

--- a/packages/ariakit/src/button/__examples__/button-as-link/style.css
+++ b/packages/ariakit/src/button/__examples__/button-as-link/style.css
@@ -1,0 +1,15 @@
+.button {
+  @apply text-primary-1
+    dark:text-primary-1-dark
+    text-base
+    cursor-pointer
+    underline;
+}
+
+.button:hover {
+  @apply no-underline;
+}
+
+.button[data-focus-visible] {
+  @apply outline-primary dark:outline-primary-dark;
+}

--- a/packages/ariakit/src/button/__examples__/button-as-link/test.tsx
+++ b/packages/ariakit/src/button/__examples__/button-as-link/test.tsx
@@ -1,0 +1,21 @@
+import { getByRole, render } from "ariakit-test-utils";
+import { axe } from "jest-axe";
+import Example from ".";
+
+test("a11y", async () => {
+  render(<Example />);
+  expect(await axe(getByRole("link"))).toHaveNoViolations();
+});
+
+test("render button as link", () => {
+  render(<Example />);
+  expect(getByRole("link")).toMatchInlineSnapshot(`
+    <a
+      class="button"
+      data-command=""
+      href="#"
+    >
+      Button
+    </a>
+  `);
+});


### PR DESCRIPTION
Hello @diegohaz 
I want to contribute to Ariakit, so i made this simple example. 

Example button as a link #939 

**Screenshots**

![image](https://user-images.githubusercontent.com/3093946/144934284-3cd8fdc0-46f4-4f12-89b7-06df80d86129.png)

