### PR TITLE
chore: Add `checkbox-controlled` example

### DIFF
--- a/packages/ariakit/src/checkbox/__examples__/checkbox-controlled/index.tsx
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-controlled/index.tsx
@@ -1,0 +1,17 @@
+import { useState } from "react";
+import { Checkbox } from "ariakit/checkbox";
+import "./style.css";
+
+export default function Example() {
+  const [checked, setChecked] = useState(true);
+  return (
+    <label className="label">
+      <Checkbox
+        className="checkbox"
+        checked={checked}
+        onChange={(event) => setChecked(event.target.checked)}
+      />
+      I have read and agree to the terms and conditions
+    </label>
+  );
+}

--- a/packages/ariakit/src/checkbox/__examples__/checkbox-controlled/style.css
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-controlled/style.css
@@ -1,0 +1,1 @@
+@import url("../checkbox/style.css");

--- a/packages/ariakit/src/checkbox/__examples__/checkbox-controlled/test.tsx
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-controlled/test.tsx
@@ -1,0 +1,29 @@
+import { click, getByRole, render } from "ariakit-test-utils";
+import Example from ".";
+
+test("render checkbox", async () => {
+  const { container } = render(<Example />);
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <label
+        class="label"
+      >
+        <input
+          aria-checked="true"
+          checked=""
+          class="checkbox"
+          data-command=""
+          type="checkbox"
+        />
+        I have read and agree to the terms and conditions
+      </label>
+    </div>
+  `);
+});
+
+test("change controlled state", async () => {
+  render(<Example />);
+  expect(getByRole("checkbox")).toBeChecked();
+  await click(getByRole("checkbox"));
+  expect(getByRole("checkbox")).not.toBeChecked();
+});


### PR DESCRIPTION
Add `controlled checkbox` example #939

The default example is when the checkbox is uncontrolled. #949 