### PR TITLE
add `{"endOfLine": "auto"}` rule for prettier, to neglect eslint error on windows

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,7 @@
     }
   },
   "rules": {
-    "prettier/prettier": "error",
+    "prettier/prettier": ["error", {"endOfLine": "auto"}],
     "react/no-children-prop": "off",
     "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43727167/145874430-2aabfdcd-9595-46fe-a19f-323597907145.png)


This is getting annoying on windows, so I added this rule so that it won't validate for LF on windows, what do u think @diegohaz ?