### PR TITLE
chore: Add `tooltip-with-timeout` example

### DIFF
--- a/packages/ariakit/src/tooltip/__examples__/tooltip-with-timeout/index.tsx
+++ b/packages/ariakit/src/tooltip/__examples__/tooltip-with-timeout/index.tsx
@@ -1,0 +1,17 @@
+import { Button } from "ariakit/button";
+import { Tooltip, TooltipAnchor, useTooltipState } from "ariakit/tooltip";
+import "./style.css";
+
+export default function Example() {
+  const tooltip = useTooltipState({ timeout: 2000 });
+  return (
+    <>
+      <TooltipAnchor state={tooltip} as={Button} className="button">
+        Hover or focus on me and wait for 2 seconds
+      </TooltipAnchor>
+      <Tooltip state={tooltip} className="tooltip">
+        Tooltip
+      </Tooltip>
+    </>
+  );
+}

--- a/packages/ariakit/src/tooltip/__examples__/tooltip-with-timeout/style.css
+++ b/packages/ariakit/src/tooltip/__examples__/tooltip-with-timeout/style.css
@@ -1,0 +1,1 @@
+@import url("../tooltip/style.css");

--- a/packages/ariakit/src/tooltip/__examples__/tooltip-with-timeout/test.tsx
+++ b/packages/ariakit/src/tooltip/__examples__/tooltip-with-timeout/test.tsx
@@ -1,0 +1,65 @@
+import {
+  blur,
+  getByRole,
+  hover,
+  press,
+  render,
+  waitFor,
+} from "ariakit-test-utils";
+import Example from ".";
+
+test("render tooltip", () => {
+  const { baseElement } = render(<Example />);
+  expect(baseElement).toMatchInlineSnapshot(`
+    <body>
+      <div>
+        <button
+          aria-labelledby="r:0"
+          class="button"
+          data-command=""
+          tabindex="0"
+          type="button"
+        >
+          Hover or focus on me and wait for 2 seconds
+        </button>
+      </div>
+      <div
+        id="r:0-portal"
+      >
+        <div>
+          <div
+            class="tooltip"
+            hidden=""
+            id="r:0"
+            role="tooltip"
+            style="display: none;"
+          >
+            Tooltip
+          </div>
+        </div>
+      </div>
+    </body>
+  `);
+});
+
+test("show tooltip on hover after timeout", async () => {
+  const { baseElement } = render(<Example />);
+  expect(getByRole("tooltip", { hidden: true })).not.toBeVisible();
+  await hover(getByRole("button"));
+  await waitFor(() => expect(getByRole("tooltip")).toBeVisible(), {
+    timeout: 2000,
+  });
+  await hover(baseElement);
+  expect(getByRole("tooltip", { hidden: true })).not.toBeVisible();
+});
+
+test("show tooltip on focus after timeout", async () => {
+  render(<Example />);
+  expect(getByRole("tooltip", { hidden: true })).not.toBeVisible();
+  await press.Tab();
+  await waitFor(() => expect(getByRole("tooltip")).toBeVisible(), {
+    timeout: 2000,
+  });
+  await blur();
+  expect(getByRole("tooltip", { hidden: true })).not.toBeVisible();
+});

--- a/packages/ariakit/src/tooltip/__examples__/tooltip-with-timeout/test.tsx
+++ b/packages/ariakit/src/tooltip/__examples__/tooltip-with-timeout/test.tsx
@@ -12,7 +12,7 @@ test("show tooltip on hover after timeout", async () => {
   const { baseElement } = render(<Example />);
   expect(getByRole("tooltip", { hidden: true })).not.toBeVisible();
   await hover(getByRole("button"));
-  await waitFor(expect(getByRole("tooltip")).toBeVisible, {
+  await waitFor(() => expect(getByRole("tooltip")).toBeVisible(), {
     timeout: 2000,
   });
   await hover(baseElement);
@@ -23,7 +23,7 @@ test("show tooltip on focus after timeout", async () => {
   render(<Example />);
   expect(getByRole("tooltip", { hidden: true })).not.toBeVisible();
   await press.Tab();
-  await waitFor(expect(getByRole("tooltip")).toBeVisible, {
+  await waitFor(() => expect(getByRole("tooltip")).toBeVisible(), {
     timeout: 2000,
   });
   await blur();

--- a/packages/ariakit/src/tooltip/__examples__/tooltip-with-timeout/test.tsx
+++ b/packages/ariakit/src/tooltip/__examples__/tooltip-with-timeout/test.tsx
@@ -12,7 +12,7 @@ test("show tooltip on hover after timeout", async () => {
   const { baseElement } = render(<Example />);
   expect(getByRole("tooltip", { hidden: true })).not.toBeVisible();
   await hover(getByRole("button"));
-  await waitFor(() => expect(getByRole("tooltip")).toBeVisible(), {
+  await waitFor(expect(getByRole("tooltip", { hidden: true })).toBeVisible, {
     timeout: 2000,
   });
   await hover(baseElement);
@@ -23,7 +23,7 @@ test("show tooltip on focus after timeout", async () => {
   render(<Example />);
   expect(getByRole("tooltip", { hidden: true })).not.toBeVisible();
   await press.Tab();
-  await waitFor(() => expect(getByRole("tooltip")).toBeVisible(), {
+  await waitFor(expect(getByRole("tooltip", { hidden: true })).toBeVisible, {
     timeout: 2000,
   });
   await blur();

--- a/packages/ariakit/src/tooltip/__examples__/tooltip-with-timeout/test.tsx
+++ b/packages/ariakit/src/tooltip/__examples__/tooltip-with-timeout/test.tsx
@@ -8,45 +8,11 @@ import {
 } from "ariakit-test-utils";
 import Example from ".";
 
-test("render tooltip", () => {
-  const { baseElement } = render(<Example />);
-  expect(baseElement).toMatchInlineSnapshot(`
-    <body>
-      <div>
-        <button
-          aria-labelledby="r:0"
-          class="button"
-          data-command=""
-          tabindex="0"
-          type="button"
-        >
-          Hover or focus on me and wait for 2 seconds
-        </button>
-      </div>
-      <div
-        id="r:0-portal"
-      >
-        <div>
-          <div
-            class="tooltip"
-            hidden=""
-            id="r:0"
-            role="tooltip"
-            style="display: none;"
-          >
-            Tooltip
-          </div>
-        </div>
-      </div>
-    </body>
-  `);
-});
-
 test("show tooltip on hover after timeout", async () => {
   const { baseElement } = render(<Example />);
   expect(getByRole("tooltip", { hidden: true })).not.toBeVisible();
   await hover(getByRole("button"));
-  await waitFor(() => expect(getByRole("tooltip")).toBeVisible(), {
+  await waitFor(expect(getByRole("tooltip")).toBeVisible, {
     timeout: 2000,
   });
   await hover(baseElement);
@@ -57,7 +23,7 @@ test("show tooltip on focus after timeout", async () => {
   render(<Example />);
   expect(getByRole("tooltip", { hidden: true })).not.toBeVisible();
   await press.Tab();
-  await waitFor(() => expect(getByRole("tooltip")).toBeVisible(), {
+  await waitFor(expect(getByRole("tooltip")).toBeVisible, {
     timeout: 2000,
   });
   await blur();


### PR DESCRIPTION
Adds tooltip with timeout example for #939 