### PR TITLE
chore: Add `menu-item-checkbox` example 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "raw-loader": "4.0.2",
         "react": "18.0.0-rc.0",
         "react-dom": "18.0.0-rc.0",
+        "react-icons": "4.3.1",
         "react-router-dom": "6.1.1",
         "rehype-parse": "8.0.3",
         "rimraf": "3.0.2",
@@ -15529,6 +15530,15 @@
         "react": "^18.0.0-rc.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
+      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -30967,6 +30977,12 @@
         "object-assign": "^4.1.1",
         "scheduler": "^0.21.0-rc.0"
       }
+    },
+    "react-icons": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
+      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
+      "dev": true
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "raw-loader": "4.0.2",
     "react": "18.0.0-rc.0",
     "react-dom": "18.0.0-rc.0",
+    "react-icons": "4.3.1",
     "react-router-dom": "6.1.1",
     "rehype-parse": "8.0.3",
     "rimraf": "3.0.2",

--- a/packages/ariakit/src/menu/__examples__/menu-item-checkbox/index.tsx
+++ b/packages/ariakit/src/menu/__examples__/menu-item-checkbox/index.tsx
@@ -1,0 +1,103 @@
+import * as React from "react";
+import {
+  Menu,
+  MenuArrow,
+  MenuButton,
+  MenuButtonArrow,
+  MenuButtonProps,
+  MenuItemCheck,
+  MenuItemCheckbox,
+  useMenuState,
+} from "ariakit/menu";
+import { Toolbar, ToolbarItem, useToolbarState } from "ariakit/toolbar";
+import {
+  HiOutlineArchive,
+  HiOutlineEye,
+  HiOutlineHeart,
+  HiOutlineStar,
+} from "react-icons/hi";
+import "./style.css";
+
+const menuWatch = [
+  {
+    name: "participatingandmetions",
+    title: "Participating and @mentions",
+    sumary:
+      "Only receive notifications from this repository when participating or @mentioned.",
+  },
+  {
+    name: "all-activity",
+    title: "All Activity",
+    sumary: "Notified of all notifications on this repository.",
+  },
+  {
+    name: "ignore",
+    title: "Ignore",
+    sumary: "Never be notified.",
+  },
+];
+
+const MenuWatch = React.forwardRef<HTMLButtonElement, MenuButtonProps>(
+  (props, ref) => {
+    const menu = useMenuState({
+      defaultValues: {
+        participatingandmetions: true,
+        ignore: false,
+        name: false,
+      },
+    });
+
+    return (
+      <>
+        <MenuButton {...props} state={menu} ref={ref}>
+          {props.children}
+          <MenuButtonArrow />
+        </MenuButton>
+        <Menu state={menu} className="menu">
+          <MenuArrow />
+          {menuWatch.map((item) => (
+            <MenuItemCheckbox
+              key={item.name}
+              name={item.name}
+              className="menu-item-checkbox"
+            >
+              <div className="menu-item-check-wrapper">
+                <MenuItemCheck />
+              </div>
+              <div className="menu-item-check-content">
+                <p className="menu-item-check-title">{item.title}</p>
+                <p className="menu-item-check-summary">{item.sumary}</p>
+              </div>
+            </MenuItemCheckbox>
+          ))}
+        </Menu>
+      </>
+    );
+  }
+);
+
+export default function Example() {
+  const state = useToolbarState();
+  return (
+    <div className="container">
+      <Toolbar state={state} className="toolbar">
+        <ToolbarItem className="button">
+          <HiOutlineHeart />
+          <span>Sponsor</span>
+        </ToolbarItem>
+        <ToolbarItem className="button" as={MenuWatch}>
+          <HiOutlineEye />
+          <span>Unwatch</span>
+        </ToolbarItem>
+        <ToolbarItem className="button">
+          <HiOutlineArchive />
+          <span>Fork</span>
+        </ToolbarItem>
+        <ToolbarItem className="button">
+          <HiOutlineStar />
+          <span>Star</span>
+        </ToolbarItem>
+      </Toolbar>
+    </div>
+  );
+}

--- a/packages/ariakit/src/menu/__examples__/menu-item-checkbox/index.tsx
+++ b/packages/ariakit/src/menu/__examples__/menu-item-checkbox/index.tsx
@@ -1,103 +1,69 @@
-import * as React from "react";
 import {
   Menu,
   MenuArrow,
   MenuButton,
   MenuButtonArrow,
-  MenuButtonProps,
   MenuItemCheck,
   MenuItemCheckbox,
   useMenuState,
 } from "ariakit/menu";
-import { Toolbar, ToolbarItem, useToolbarState } from "ariakit/toolbar";
-import {
-  HiOutlineArchive,
-  HiOutlineEye,
-  HiOutlineHeart,
-  HiOutlineStar,
-} from "react-icons/hi";
+import { HiOutlineEye } from "react-icons/hi";
 import "./style.css";
 
-const menuWatch = [
-  {
-    name: "participatingandmetions",
-    title: "Participating and @mentions",
-    sumary:
-      "Only receive notifications from this repository when participating or @mentioned.",
-  },
-  {
-    name: "all-activity",
-    title: "All Activity",
-    sumary: "Notified of all notifications on this repository.",
-  },
-  {
-    name: "ignore",
-    title: "Ignore",
-    sumary: "Never be notified.",
-  },
-];
-
-const MenuWatch = React.forwardRef<HTMLButtonElement, MenuButtonProps>(
-  (props, ref) => {
-    const menu = useMenuState({
-      defaultValues: {
-        participatingandmetions: true,
-        ignore: false,
-        name: false,
-      },
-    });
-
-    return (
-      <>
-        <MenuButton {...props} state={menu} ref={ref}>
-          {props.children}
-          <MenuButtonArrow />
-        </MenuButton>
-        <Menu state={menu} className="menu">
-          <MenuArrow />
-          {menuWatch.map((item) => (
-            <MenuItemCheckbox
-              key={item.name}
-              name={item.name}
-              className="menu-item-checkbox"
-            >
-              <div className="menu-item-check-wrapper">
-                <MenuItemCheck />
-              </div>
-              <div className="menu-item-check-content">
-                <p className="menu-item-check-title">{item.title}</p>
-                <p className="menu-item-check-summary">{item.sumary}</p>
-              </div>
-            </MenuItemCheckbox>
-          ))}
-        </Menu>
-      </>
-    );
-  }
-);
-
 export default function Example() {
-  const state = useToolbarState();
+  const menu = useMenuState({
+    defaultValues: {
+      watching: ["issues"],
+    },
+  });
+  const watching = menu.values.watching as string[];
+
   return (
-    <div className="container">
-      <Toolbar state={state} className="toolbar">
-        <ToolbarItem className="button">
-          <HiOutlineHeart />
-          <span>Sponsor</span>
-        </ToolbarItem>
-        <ToolbarItem className="button" as={MenuWatch}>
-          <HiOutlineEye />
-          <span>Unwatch</span>
-        </ToolbarItem>
-        <ToolbarItem className="button">
-          <HiOutlineArchive />
-          <span>Fork</span>
-        </ToolbarItem>
-        <ToolbarItem className="button">
-          <HiOutlineStar />
-          <span>Star</span>
-        </ToolbarItem>
-      </Toolbar>
+    <div>
+      <MenuButton state={menu} className="button">
+        <HiOutlineEye />
+        {!!watching.length ? "Unwatch" : "Watch"}
+        <MenuButtonArrow />
+      </MenuButton>
+      <Menu state={menu} className="menu">
+        <MenuArrow className="menu-arrow" />
+        <MenuItemCheckbox name="watching" value="issues" className="menu-item">
+          <MenuItemCheck />
+          Issues
+        </MenuItemCheckbox>
+        <MenuItemCheckbox
+          name="watching"
+          value="pull-requests"
+          className="menu-item"
+        >
+          <MenuItemCheck />
+          Pull requests
+        </MenuItemCheckbox>
+        <MenuItemCheckbox
+          name="watching"
+          value="releases"
+          className="menu-item"
+        >
+          <MenuItemCheck />
+          Releases
+        </MenuItemCheckbox>
+        <MenuItemCheckbox
+          name="watching"
+          value="discussions"
+          className="menu-item"
+        >
+          <MenuItemCheck />
+          Discussions
+        </MenuItemCheckbox>
+        <MenuItemCheckbox
+          name="watching"
+          value="security-alerts"
+          className="menu-item"
+        >
+          <MenuItemCheck />
+          Security alerts
+        </MenuItemCheckbox>
+      </Menu>
     </div>
   );
 }

--- a/packages/ariakit/src/menu/__examples__/menu-item-checkbox/index.tsx
+++ b/packages/ariakit/src/menu/__examples__/menu-item-checkbox/index.tsx
@@ -17,9 +17,8 @@ export default function Example() {
     },
   });
   const watching = menu.values.watching as string[];
-
   return (
-    <div>
+    <>
       <MenuButton state={menu} className="button">
         <HiOutlineEye />
         {!!watching.length ? "Unwatch" : "Watch"}
@@ -64,6 +63,6 @@ export default function Example() {
           Security alerts
         </MenuItemCheckbox>
       </Menu>
-    </div>
+    </>
   );
 }

--- a/packages/ariakit/src/menu/__examples__/menu-item-checkbox/style.css
+++ b/packages/ariakit/src/menu/__examples__/menu-item-checkbox/style.css
@@ -1,0 +1,64 @@
+.container {
+  @apply w-full bg-canvas-2 h-screen p-3 flex items-center justify-center;
+}
+
+.toolbar {
+  @apply flex space-x-3;
+}
+
+.button {
+  @apply
+    flex
+    items-center
+    gap-2
+    py-2
+    px-3
+    bg-canvas-1
+    text-canvas-5
+    text-sm
+    font-semibold
+    rounded-md
+    shadow-sm
+    hover:bg-canvas-1
+    border
+    border-canvas-1
+  ;
+}
+
+.menu {
+  @apply
+    max-w-[300px]
+    outline-none
+    w-full
+    bg-white
+    py-1
+    rounded-md
+    shadow-sm
+    border
+    border-canvas-1
+  ;
+}
+
+.menu-item-checkbox {
+  @apply w-full cursor-default pl-3 py-2 text-left flex hover:bg-canvas-1 focus:bg-canvas-1;
+}
+
+.menu-item-check-wrapper {
+  @apply mr-3 w-4 h-4 relative;
+}
+
+.menu-item-check-wrapper span {
+  @apply absolute top-1;
+}
+
+.menu-item-check-content {
+  @apply flex flex-1 flex-col pr-2;
+}
+
+.menu-item-check-title {
+  @apply font-semibold text-sm text-canvas-1 mb-1;
+}
+
+.menu-item-check-summary {
+  @apply text-xs text-canvas-1;
+}

--- a/packages/ariakit/src/menu/__examples__/menu-item-checkbox/style.css
+++ b/packages/ariakit/src/menu/__examples__/menu-item-checkbox/style.css
@@ -51,28 +51,3 @@
     dark:bg-primary-2-dark
     dark:text-primary-2-dark;
 }
-
-/*
-.menu-item {
-  @apply flex w-full py-2 pl-3 text-left cursor-default hover:bg-canvas-1 focus:bg-canvas-1;
-}
-
-.menu-item-check-wrapper {
-  @apply relative w-4 h-4 mr-3;
-}
-
-.menu-item-check-wrapper span {
-  @apply absolute top-1;
-}
-
-.menu-item-check-content {
-  @apply flex flex-col flex-1 pr-2;
-}
-
-.menu-item-check-title {
-  @apply mb-1 text-sm font-semibold text-canvas-1;
-}
-
-.menu-item-check-summary {
-  @apply text-xs text-canvas-1;
-} */

--- a/packages/ariakit/src/menu/__examples__/menu-item-checkbox/style.css
+++ b/packages/ariakit/src/menu/__examples__/menu-item-checkbox/style.css
@@ -1,5 +1,5 @@
 .container {
-  @apply w-full bg-canvas-2 h-screen p-3 flex items-center justify-center;
+  @apply flex items-center justify-center w-full h-screen p-3 bg-canvas-2;
 }
 
 .toolbar {
@@ -11,16 +11,16 @@
     flex
     items-center
     gap-2
-    py-2
     px-3
-    bg-canvas-1
-    text-canvas-5
+    py-2
     text-sm
     font-semibold
+    border
     rounded-md
     shadow-sm
+    bg-canvas-1
+    text-canvas-5
     hover:bg-canvas-1
-    border
     border-canvas-1
   ;
 }
@@ -40,11 +40,11 @@
 }
 
 .menu-item-checkbox {
-  @apply w-full cursor-default pl-3 py-2 text-left flex hover:bg-canvas-1 focus:bg-canvas-1;
+  @apply flex w-full py-2 pl-3 text-left cursor-default hover:bg-canvas-1 focus:bg-canvas-1;
 }
 
 .menu-item-check-wrapper {
-  @apply mr-3 w-4 h-4 relative;
+  @apply relative w-4 h-4 mr-3;
 }
 
 .menu-item-check-wrapper span {
@@ -52,11 +52,11 @@
 }
 
 .menu-item-check-content {
-  @apply flex flex-1 flex-col pr-2;
+  @apply flex flex-col flex-1 pr-2;
 }
 
 .menu-item-check-title {
-  @apply font-semibold text-sm text-canvas-1 mb-1;
+  @apply mb-1 text-sm font-semibold text-canvas-1;
 }
 
 .menu-item-check-summary {

--- a/packages/ariakit/src/menu/__examples__/menu-item-checkbox/style.css
+++ b/packages/ariakit/src/menu/__examples__/menu-item-checkbox/style.css
@@ -1,45 +1,59 @@
-.container {
-  @apply flex items-center justify-center w-full h-screen p-3 bg-canvas-2;
-}
-
-.toolbar {
-  @apply flex space-x-3;
-}
-
-.button {
-  @apply
-    flex
-    items-center
-    gap-2
-    px-3
-    py-2
-    text-sm
-    font-semibold
-    border
-    rounded-md
-    shadow-sm
-    bg-canvas-1
-    text-canvas-5
-    hover:bg-canvas-1
-    border-canvas-1
-  ;
-}
+@import url("../../../button/__examples__/button/style.css");
 
 .menu {
   @apply
-    max-w-[300px]
-    outline-none
-    w-full
-    bg-white
-    py-1
-    rounded-md
-    shadow-sm
+    w-[250px]
+    relative
+    flex
+    flex-col
+    z-50
+    p-2
+    rounded-lg
+    drop-shadow
+    dark:drop-shadow-dark
     border
-    border-canvas-1
-  ;
+    border-solid
+    border-canvas-4
+    dark:border-canvas-4-dark
+    bg-canvas-4
+    dark:bg-canvas-4-dark
+    text-canvas-4
+    dark:text-canvas-4-dark
+    ariakit-focus-visible:ariakit-outline;
 }
 
-.menu-item-checkbox {
+.menu-arrow svg {
+  @apply
+    fill-canvas-4
+    dark:fill-canvas-4-dark
+    stroke-canvas-4
+    dark:stroke-canvas-4-dark;
+}
+
+.menu-item {
+  @apply
+    flex
+    gap-2
+    items-center
+    scroll-m-2
+    outline-none
+    cursor-default
+    rounded
+    p-2
+    hover:bg-primary-1-hover
+    dark:hover:bg-primary-1-dark-hover;
+}
+
+.menu-item:focus {
+  @apply
+    bg-primary-2
+    text-primary-2
+    dark:bg-primary-2-dark
+    dark:text-primary-2-dark;
+}
+
+/*
+.menu-item {
   @apply flex w-full py-2 pl-3 text-left cursor-default hover:bg-canvas-1 focus:bg-canvas-1;
 }
 
@@ -61,4 +75,4 @@
 
 .menu-item-check-summary {
   @apply text-xs text-canvas-1;
-}
+} */

--- a/packages/ariakit/src/menu/__examples__/menu-item-checkbox/style.css
+++ b/packages/ariakit/src/menu/__examples__/menu-item-checkbox/style.css
@@ -9,6 +9,7 @@
     z-50
     p-2
     rounded-lg
+    outline-none
     drop-shadow
     dark:drop-shadow-dark
     border
@@ -18,8 +19,7 @@
     bg-canvas-4
     dark:bg-canvas-4-dark
     text-canvas-4
-    dark:text-canvas-4-dark
-    ariakit-focus-visible:ariakit-outline;
+    dark:text-canvas-4-dark;
 }
 
 .menu-arrow svg {
@@ -41,13 +41,9 @@
     rounded
     p-2
     hover:bg-primary-1-hover
-    dark:hover:bg-primary-1-dark-hover;
-}
-
-.menu-item:focus {
-  @apply
-    bg-primary-2
-    text-primary-2
-    dark:bg-primary-2-dark
-    dark:text-primary-2-dark;
+    dark:hover:bg-primary-1-dark-hover
+    focus:bg-primary-2
+    focus:text-primary-2
+    dark:focus:bg-primary-2-dark
+    dark:focus:text-primary-2-dark;
 }

--- a/packages/ariakit/src/menu/__examples__/menu-item-checkbox/test.tsx
+++ b/packages/ariakit/src/menu/__examples__/menu-item-checkbox/test.tsx
@@ -1,0 +1,8 @@
+import { render } from "ariakit-test-utils";
+import { axe } from "jest-axe";
+import Example from ".";
+
+test("a11y", async () => {
+  const { container } = render(<Example />);
+  expect(await axe(container)).toHaveNoViolations();
+});

--- a/packages/ariakit/src/menu/__examples__/menu-item-checkbox/test.tsx
+++ b/packages/ariakit/src/menu/__examples__/menu-item-checkbox/test.tsx
@@ -21,6 +21,9 @@ test("update menu button label on menu item check", async () => {
 test("check/uncheck menu item on click", async () => {
   render(<Example />);
   await click(getMenuButton("Unwatch"));
+  expect(getMenuItem("Issues")).toHaveAttribute("aria-checked", "true");
+  await click(getMenuItem("Issues"));
+  expect(getMenuItem("Issues")).toHaveAttribute("aria-checked", "false");
   expect(getMenuItem("Releases")).toHaveAttribute("aria-checked", "false");
   await click(getMenuItem("Releases"));
   expect(getMenuItem("Releases")).toHaveAttribute("aria-checked", "true");

--- a/packages/ariakit/src/menu/__examples__/menu-item-checkbox/test.tsx
+++ b/packages/ariakit/src/menu/__examples__/menu-item-checkbox/test.tsx
@@ -1,8 +1,64 @@
-import { render } from "ariakit-test-utils";
+import { click, getByRole, press, render } from "ariakit-test-utils";
 import { axe } from "jest-axe";
 import Example from ".";
+
+const getMenuButton = (name: string) => getByRole("button", { name });
+const getMenuItem = (name: string) => getByRole("menuitemcheckbox", { name });
 
 test("a11y", async () => {
   const { container } = render(<Example />);
   expect(await axe(container)).toHaveNoViolations();
+});
+
+test("update menu button label on menu item check", async () => {
+  render(<Example />);
+  expect(getMenuButton("Unwatch")).toBeInTheDocument();
+  await click(getMenuButton("Unwatch"));
+  await click(getMenuItem("Issues"));
+  expect(getMenuButton("Watch")).toBeInTheDocument();
+});
+
+test("check/uncheck menu item on click", async () => {
+  render(<Example />);
+  await click(getMenuButton("Unwatch"));
+  expect(getMenuItem("Releases")).toHaveAttribute("aria-checked", "false");
+  await click(getMenuItem("Releases"));
+  expect(getMenuItem("Releases")).toHaveAttribute("aria-checked", "true");
+  await click(getMenuItem("Releases"));
+  expect(getMenuItem("Releases")).toHaveAttribute("aria-checked", "false");
+});
+
+test("check/uncheck menu item on enter", async () => {
+  render(<Example />);
+  await press.Tab();
+  await press.Enter();
+  await press.ArrowDown();
+  await press.ArrowDown();
+  await press.ArrowDown();
+  expect(getMenuItem("Discussions")).toHaveAttribute("aria-checked", "false");
+  await press.Enter();
+  expect(getMenuItem("Discussions")).toHaveAttribute("aria-checked", "true");
+  await press.Enter();
+  expect(getMenuItem("Discussions")).toHaveAttribute("aria-checked", "false");
+});
+
+test("check/uncheck menu item on space", async () => {
+  render(<Example />);
+  await press.Tab();
+  await press.Space();
+  await press.End();
+  expect(getMenuItem("Security alerts")).toHaveAttribute(
+    "aria-checked",
+    "false"
+  );
+  await press.Space();
+  expect(getMenuItem("Security alerts")).toHaveAttribute(
+    "aria-checked",
+    "true"
+  );
+  await press.Space();
+  expect(getMenuItem("Security alerts")).toHaveAttribute(
+    "aria-checked",
+    "false"
+  );
 });

--- a/packages/ariakit/src/menu/readme.md
+++ b/packages/ariakit/src/menu/readme.md
@@ -1,0 +1,3 @@
+# Menu
+
+<a href="./__examples__/menu-item-checkbox/index.tsx" data-playground>Example</a>

--- a/packages/website/pages/index.tsx
+++ b/packages/website/pages/index.tsx
@@ -32,6 +32,9 @@ export default function Home() {
         <li>
           <Link href="/examples/popover">Popover</Link>
         </li>
+        <li>
+          <Link href="/examples/menu-item-checkbox">Menu item checkbox</Link>
+        </li>
       </ul>
     </div>
   );


### PR DESCRIPTION
Adds a "Menu item checkbox" example https://github.com/reakit/reakit/issues/939.

## Screen
<img width="606" alt="Screen Shot 2021-12-21 at 23 47 13" src="https://user-images.githubusercontent.com/1995213/147027041-c23a2b19-bff8-44ba-a76a-1dcd31ff28ab.png">

