### PR TITLE
fix: Fix `PlaygroundEditor` preventing scroll when not focused

### DIFF
--- a/packages/ariakit-playground/src/playground-code.tsx
+++ b/packages/ariakit-playground/src/playground-code.tsx
@@ -18,7 +18,7 @@ import {
 import { cx } from "ariakit-utils/misc";
 import { createMemoComponent, useStore } from "ariakit-utils/store";
 import { createElement, createHook } from "ariakit-utils/system";
-import { As, Options, Props, SetState } from "ariakit-utils/types";
+import { As, Options, Props } from "ariakit-utils/types";
 import { Button, ButtonProps } from "ariakit/button";
 import { highlight, languages } from "prismjs";
 import { getExtension } from "./__utils/get-extension";
@@ -212,7 +212,7 @@ export type PlaygroundCodeOptions<T extends As = "div"> = Options<T> & {
   maxHeight?: number;
   disclosureProps?: ButtonProps<ElementType>;
   expanded?: boolean;
-  setExpanded?: SetState<boolean>;
+  setExpanded?: (expanded: boolean) => void;
   defaultExpanded?: boolean;
   theme?: SerializedStyles;
 };


### PR DESCRIPTION
Right now, we can't scroll the playground editor when it's expanded, but not focused (which in the code is translated into the `editable` local state).

This has been an annoying experience. So this PR fixes the behavior so the editor doesn't need to be focused anymore to be scrollable.

## How to test

1. Open https://ariakit.org/examples/combobox
2. Expand the editor
3. Focus on something else
4. Try to scroll on the editor

And then repeat the same with this PR preview site (https://ariakit-git-fix-playground-editor-scrolling-ariakit.vercel.app/examples/combobox)